### PR TITLE
fix: resolve default values for optional flow inputs at runtime

### DIFF
--- a/src/lib/flow-runner.ts
+++ b/src/lib/flow-runner.ts
@@ -44,12 +44,20 @@ export class FlowRunner {
     this.statePath = path.join(RUNS_DIR, `${flow.key}-${this.runId}.state.json`);
     this.logPath = path.join(LOGS_DIR, `${flow.key}-${this.runId}.log`);
 
+    // Resolve default values for optional inputs not provided
+    const resolvedInputs: Record<string, unknown> = { ...inputs };
+    for (const [name, decl] of Object.entries(flow.inputs)) {
+      if (resolvedInputs[name] === undefined && decl.default !== undefined) {
+        resolvedInputs[name] = decl.default;
+      }
+    }
+
     this.state = {
       runId: this.runId,
       flowKey: flow.key,
       status: 'running',
       startedAt: new Date().toISOString(),
-      inputs,
+      inputs: resolvedInputs,
       completedSteps: [],
       context: {
         input: inputs,


### PR DESCRIPTION
## Summary
- `FlowRunner` was passing raw user inputs to the execution context without applying declared `default` values from input definitions
- When `executeFlow` received a `resumeState` (which `FlowRunner.execute()` always provides), it skipped its own default resolution at lines 816-824
- Fix: resolve defaults in the `FlowRunner` constructor so `this.state.inputs` has defaults applied before context creation

## Test plan
- [ ] Create a flow with optional inputs that have `default` values
- [ ] Execute without providing those inputs — verify defaults are used (not `undefined`)
- [ ] Execute providing those inputs — verify provided values take precedence over defaults
- [ ] Resume a paused flow with default inputs — verify defaults persist

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)