### PR TITLE
fix: support array values in --query-params for repeated parameters

### DIFF
--- a/skills/one-actions/SKILL.md
+++ b/skills/one-actions/SKILL.md
@@ -124,6 +124,11 @@ one --agent actions execute hub-spot <actionId> <connectionKey> \
 one --agent actions execute shopify <actionId> <connectionKey> \
   --path-vars '{"order_id": "12345"}' \
   --query-params '{"limit": "10"}'
+
+# With repeated query params (array values expand to repeated keys)
+one --agent actions execute gmail <actionId> <connectionKey> \
+  --path-vars '{"userId": "me", "id": "msg123"}' \
+  --query-params '{"format": "metadata", "metadataHeaders": ["From", "Subject", "Date"]}'
 ```
 
 Output format:
@@ -147,5 +152,6 @@ Parse the output as JSON. If the `error` key is present, the command failed — 
 - Always use the **exact action ID** from search results — don't guess or construct them
 - Always read the knowledge output carefully — it tells you which parameters are required vs optional, what format they need to be in, and any caveats specific to that API
 - JSON values passed to `-d`, `--path-vars`, `--query-params`, and `--headers` must be valid JSON strings (use single quotes around the JSON to avoid shell escaping issues)
+- **Array query params**: Use JSON arrays for repeated query parameters — `{"metadataHeaders": ["From", "Subject"]}` expands to `metadataHeaders=From&metadataHeaders=Subject`
 - If search returns no results, try broader queries (e.g., `"list"` instead of `"list active premium customers"`)
 - The execute command respects access control settings configured via `one config` — if execution is blocked, the user may need to adjust their permissions

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -200,9 +200,17 @@ export class OneApi {
 
     let queryString = '';
     if (args.queryParams && Object.keys(args.queryParams).length > 0) {
-      const params = new URLSearchParams(
-        Object.entries(args.queryParams).map(([k, v]) => [k, String(v)])
-      );
+      const entries: [string, string][] = [];
+      for (const [k, v] of Object.entries(args.queryParams)) {
+        if (Array.isArray(v)) {
+          for (const item of v) {
+            entries.push([k, String(item)]);
+          }
+        } else {
+          entries.push([k, String(v)]);
+        }
+      }
+      const params = new URLSearchParams(entries);
       queryString = `?${params.toString()}`;
     }
 


### PR DESCRIPTION
## Summary
- Array values in `--query-params` now expand to repeated query parameters (e.g., `{"metadataHeaders": ["From", "Subject"]}` becomes `metadataHeaders=From&metadataHeaders=Subject`)
- Previously, arrays were silently stringified via `String()` producing `"From,Subject"` — causing silent data loss
- Documents array syntax in the one-actions skill with an example

## Test plan
- [ ] Execute a Gmail get-message with `--query-params '{"format": "metadata", "metadataHeaders": ["From", "Subject", "Date"]}'` — verify all headers return
- [ ] Verify non-array query params still work as before
- [ ] Use `--dry-run` to inspect the generated URL and confirm repeated params

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)