### PR TITLE
fix: replace generic API structure with CLI flag mapping in knowledge output

### DIFF
--- a/skills/one-actions/SKILL.md
+++ b/skills/one-actions/SKILL.md
@@ -78,7 +78,7 @@ one --agent actions knowledge <platform> <actionId>
 
 Get comprehensive documentation for an action including parameters, requirements, validation rules, request/response structure, and examples. Returns JSON with the full API knowledge and HTTP method.
 
-Always call this before executing — it tells you exactly what parameters are required and how to structure the request.
+Always call this before executing — it tells you exactly what parameters are required, how to structure the request, and which CLI flags to use for path variables, query parameters, and body data. Do NOT pass path or query parameters in the `-d` body flag.
 
 Example:
 ```bash

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -392,30 +392,24 @@ export function buildActionKnowledgeWithGuidance(
   platform: string,
   actionId: string
 ): string {
-  const baseUrl = 'https://api.withone.ai';
-
   return `${knowledge}
 
-API REQUEST STRUCTURE
+CLI PARAMETER MAPPING
 ======================
-URL: ${baseUrl}/v1/passthrough/{{PATH}}
+Use the One CLI to execute this action. Map parameters from the documentation above to CLI flags:
 
-IMPORTANT: When constructing the URL, only include the API endpoint path after the base URL.
-Do NOT include the full third-party API URL.
+- **Path variables** (URL placeholders like {userId}, {id}) → \`--path-vars '{"userId": "me", "id": "123"}'\`
+- **Query parameters** (filtering, pagination, format options) → \`--query-params '{"key": "value"}'\`
+  - For repeated params, use arrays: \`--query-params '{"metadataHeaders": ["From", "Subject"]}'\`
+- **Request body** (POST/PUT/PATCH data) → \`-d '{"field": "value"}'\`
 
-Examples:
-  Correct: ${baseUrl}/v1/passthrough/crm/v3/objects/contacts/search
-  Incorrect: ${baseUrl}/v1/passthrough/https://api.hubapi.com/crm/v3/objects/contacts/search
+Do NOT pass path variables or query parameters in the -d body flag — they will be ignored.
 
-METHOD: ${method}
+EXAMPLE COMMAND:
+one --agent actions execute ${platform} ${actionId} <connectionKey> \\
+  --path-vars '{ ... }' \\
+  --query-params '{ ... }' \\
+  -d '{ ... }'
 
-HEADERS:
-- x-one-secret: {{process.env.ONE_SECRET}}
-- x-one-connection-key: {{process.env.ONE_${platform.toUpperCase()}_CONNECTION_KEY}}
-- x-one-action-id: ${actionId}
-- ... (other headers)
-
-BODY: {{BODY}}
-
-QUERY PARAMS: {{QUERY_PARAMS}}`;
+Replace the JSON objects above with the actual parameters from the documentation. Omit any flag that has no parameters for this action (e.g., omit --path-vars if the URL has no placeholders, omit -d for GET requests).`;
 }


### PR DESCRIPTION
## Summary
- Replaces the generic `{{PATH}}`, `{{BODY}}`, `{{QUERY_PARAMS}}` placeholders in knowledge output with an explicit **CLI PARAMETER MAPPING** section
- Shows agents exactly which flags to use: `--path-vars` for URL placeholders, `--query-params` for query parameters, `-d` for request body
- Includes a ready-to-use example command template with the actual platform and actionId
- Warns agents not to pass path/query params in the `-d` body flag

## Test plan
- [ ] Run `one --agent actions knowledge gmail <actionId>` and verify the output includes the CLI PARAMETER MAPPING section
- [ ] Verify the example command includes the correct platform and actionId
- [ ] Test that an agent can follow the knowledge output to correctly execute an action with path vars and query params on first attempt

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)