### PR TITLE
feat: webhook relay CLI commands + skill + guide rewrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+## One CLI — Development Guide
+
+### Publishing a new version
+
+Do NOT run `npm publish` directly. The release is automated via GitHub.
+
+1. Create a branch (e.g., `release/1.13.10`)
+2. Update the version in `package.json`
+3. Run `npm install` so `package-lock.json` updates
+4. Commit both files, push, and create a PR to `main`
+5. Once merged to `main`, create a **release tag** in GitHub for that version
+6. The GitHub release triggers the automated deploy to npm
+
+### Branch workflow
+
+Always create a branch and PR for changes — do not commit directly to `main`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one-relay/SKILL.md
+++ b/skills/one-relay/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: one-relay
+description: |
+  Set up webhook relay endpoints to receive events from third-party platforms and forward them to other platforms using passthrough actions with Handlebars templates — no middleware, no flows, no code.
+
+  TRIGGER when the user wants to:
+  - Receive webhooks from a platform and forward/relay them somewhere
+  - Set up event-driven automation between platforms (e.g., "when a Stripe customer is created, send a Slack message")
+  - Create webhook endpoints for a connected platform
+  - Map webhook event data from one platform to another platform's API
+  - List, manage, or debug webhook relay endpoints, events, or deliveries
+
+  DO NOT TRIGGER for:
+  - Single action execution without webhooks (use one-actions skill)
+  - Multi-step workflows not triggered by webhooks (use one-flow skill)
+  - Setting up One or installing MCP (that's `one init`)
+  - Adding new connections (that's `one connection add`)
+---
+
+# One Webhook Relay
+
+Webhook relay lets you receive webhooks from third-party platforms (Stripe, Shopify, GitHub, etc.) and forward the event data to other platforms using passthrough actions. The passthrough action type maps fields from the incoming webhook payload directly to another platform's API using Handlebars templates — no middleware, no flows, no code needed.
+
+## Supported Platforms
+
+Webhook relay is currently supported for these platforms:
+
+- **Airtable**
+- **Attio**
+- **GitHub**
+- **Google Calendar**
+- **Stripe**
+
+Only these platforms can be used as webhook sources. Any connected platform can be a destination via passthrough actions.
+
+## The Workflow
+
+**You MUST follow this process to build a correct relay:**
+
+### Step 1: Discover connections
+
+```bash
+one --agent connection list
+```
+
+Identify the **source** platform (sends webhooks) and **destination** platform (receives forwarded data). Note both connection keys.
+
+### Step 2: Get event types for the source platform
+
+```bash
+one --agent relay event-types <source-platform>
+```
+
+See what webhook events the source platform supports. Pick the relevant event type(s).
+
+### Step 3: Get source knowledge — understand the incoming webhook payload
+
+Search for the webhook event to understand what data the source platform sends:
+
+```bash
+one --agent actions search <source-platform> "<event description>" -t knowledge
+one --agent actions knowledge <source-platform> <actionId>
+```
+
+Read the knowledge to understand the webhook payload structure. These fields become `{{payload.*}}` paths in your Handlebars templates.
+
+### Step 4: Get destination knowledge — understand the outgoing API shape
+
+Search for the destination action to understand what data it expects:
+
+```bash
+one --agent actions search <dest-platform> "<what you want to do>" -t execute
+one --agent actions knowledge <dest-platform> <actionId>
+```
+
+Read the knowledge to understand required fields, data types, and request body structure. These become the keys in your passthrough action's `body`.
+
+### Step 5: Create the relay endpoint
+
+```bash
+one --agent relay create \
+  --connection-key <source-connection-key> \
+  --description "Forward <event> from <source> to <dest>" \
+  --event-filters '["event.type"]' \
+  --create-webhook
+```
+
+The `--create-webhook` flag automatically registers the webhook URL with the source platform. The response includes the relay endpoint `id` you need for activation.
+
+### Step 6: Activate with a passthrough action
+
+```bash
+one --agent relay activate <relay-id> --actions '[{
+  "type": "passthrough",
+  "actionId": "<destination-action-id>",
+  "connectionKey": "<destination-connection-key>",
+  "body": {
+    "field": "{{payload.path.to.value}}"
+  },
+  "eventFilters": ["event.type"]
+}]'
+```
+
+Map source fields to destination fields using Handlebars templates in the `body`. The template paths come from the source knowledge (Step 3), and the body keys come from the destination knowledge (Step 4).
+
+## Template Context Reference
+
+When a webhook event is received, the following variables are available in Handlebars templates:
+
+| Variable | Type | Description |
+|---|---|---|
+| `{{relayEventId}}` | UUID | Unique relay event ID |
+| `{{platform}}` | String | Source platform (e.g., `stripe`) |
+| `{{eventType}}` | String | Webhook event type (e.g., `customer.created`) |
+| `{{payload}}` | Object | The full incoming webhook body |
+| `{{timestamp}}` | DateTime | When the event was received |
+| `{{connectionId}}` | UUID | Source connection UUID |
+
+Access nested fields with dot notation: `{{payload.data.object.email}}`
+
+Use the `{{json payload}}` helper to embed a full object as a JSON string.
+
+## Action Types
+
+Each relay endpoint can have multiple actions. Three types are supported:
+
+### `passthrough` — Forward to another platform's API (primary)
+
+Maps webhook data to another platform's API using Handlebars templates. This is the most powerful action type.
+
+```json
+{
+  "type": "passthrough",
+  "actionId": "<action-id-from-search>",
+  "connectionKey": "<destination-connection-key>",
+  "body": {
+    "channel": "#alerts",
+    "text": "New customer: {{payload.data.object.name}} ({{payload.data.object.email}})"
+  },
+  "eventFilters": ["customer.created"]
+}
+```
+
+The `body`, `headers`, and `query` fields all support Handlebars templates.
+
+### `url` — Forward raw event to a URL
+
+```json
+{
+  "type": "url",
+  "url": "https://your-app.com/webhooks/handler",
+  "secret": "optional-signing-secret",
+  "eventFilters": ["customer.created"]
+}
+```
+
+### `agent` — Send to an agent
+
+```json
+{
+  "type": "agent",
+  "agentId": "<agent-uuid>",
+  "eventFilters": ["customer.created"]
+}
+```
+
+## Complete Example — Stripe customer.created → Slack message
+
+### 1. Get connections
+
+```bash
+one --agent connection list
+# stripe: live::stripe::default::abc123
+# slack:  live::slack::default::xyz789
+```
+
+### 2. Get Stripe event types
+
+```bash
+one --agent relay event-types stripe
+# Returns: ["customer.created", "customer.updated", "payment_intent.succeeded", ...]
+```
+
+### 3. Get Slack send message action
+
+```bash
+one --agent actions search slack "send message" -t execute
+# Returns: actionId "conn_mod_def::GJ7H84zBlaI::BCfuA16aTaGVIax5magsLA"
+
+one --agent actions knowledge slack conn_mod_def::GJ7H84zBlaI::BCfuA16aTaGVIax5magsLA
+# Required body: { "channel": "string", "text": "string" }
+# Optional: "blocks" for rich formatting
+```
+
+### 4. Create the relay
+
+```bash
+one --agent relay create \
+  --connection-key "live::stripe::default::abc123" \
+  --description "Notify Slack on new Stripe customers" \
+  --event-filters '["customer.created"]' \
+  --create-webhook
+# Returns: { "id": "c531d7b8-...", "url": "https://api.withone.ai/v1/webhooks/relay/incoming/stripe/..." }
+```
+
+### 5. Activate with Slack passthrough action
+
+```bash
+one --agent relay activate c531d7b8-... --actions '[{
+  "type": "passthrough",
+  "actionId": "conn_mod_def::GJ7H84zBlaI::BCfuA16aTaGVIax5magsLA",
+  "connectionKey": "live::slack::default::xyz789",
+  "body": {
+    "channel": "#alerts",
+    "text": "New Stripe customer: {{payload.data.object.name}} ({{payload.data.object.email}})",
+    "blocks": [
+      {
+        "type": "header",
+        "text": { "type": "plain_text", "text": ":tada: New Stripe Customer", "emoji": true }
+      },
+      {
+        "type": "section",
+        "fields": [
+          { "type": "mrkdwn", "text": "*Name:*\n{{payload.data.object.name}}" },
+          { "type": "mrkdwn", "text": "*Email:*\n{{payload.data.object.email}}" }
+        ]
+      },
+      {
+        "type": "section",
+        "fields": [
+          { "type": "mrkdwn", "text": "*Customer ID:*\n`{{payload.data.object.id}}`" },
+          { "type": "mrkdwn", "text": "*Created:*\n<!date^{{payload.data.object.created}}^{date_short} at {time}|{{payload.data.object.created}}>" }
+        ]
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "context",
+        "elements": [
+          { "type": "mrkdwn", "text": "Via One Webhook Relay · {{platform}}" }
+        ]
+      }
+    ]
+  },
+  "eventFilters": ["customer.created"]
+}]'
+```
+
+## Commands Reference
+
+```bash
+# Create a relay endpoint
+one --agent relay create --connection-key <key> [--description <desc>] [--event-filters <json>] [--create-webhook]
+
+# List all relay endpoints
+one --agent relay list [--limit <n>] [--page <n>]
+
+# Get relay endpoint details
+one --agent relay get <id>
+
+# Update a relay endpoint (including actions)
+one --agent relay update <id> [--actions <json>] [--description <desc>] [--event-filters <json>] [--active] [--no-active]
+
+# Delete a relay endpoint
+one --agent relay delete <id>
+
+# Activate a relay endpoint with actions
+one --agent relay activate <id> --actions <json> [--webhook-secret <secret>]
+
+# List supported event types for a platform
+one --agent relay event-types <platform>
+
+# List received webhook events
+one --agent relay events [--platform <p>] [--event-type <t>] [--limit <n>] [--after <iso>] [--before <iso>]
+
+# Get a specific event (includes full payload)
+one --agent relay event <id>
+
+# List delivery attempts
+one --agent relay deliveries --endpoint-id <id>
+one --agent relay deliveries --event-id <id>
+```
+
+## Debugging
+
+If a relay isn't working:
+
+1. **Check the endpoint is active:** `one --agent relay get <id>` — verify `active: true` and actions are configured
+2. **Check events are arriving:** `one --agent relay events --platform <p> --limit 5` — if no events, the webhook isn't registered with the source platform (use `--create-webhook` on create)
+3. **Check delivery status:** `one --agent relay deliveries --event-id <id>` — shows status, status code, and error for each delivery attempt
+4. **Inspect the event payload:** `one --agent relay event <id>` — see the full payload to verify your template paths are correct
+
+## Important Notes
+
+- **Always use `--agent` flag** for structured JSON output
+- **Always use `--create-webhook`** when creating relay endpoints — it automatically registers the webhook URL with the source platform
+- **Always check `actions knowledge`** for both source and destination platforms before building templates — the source knowledge tells you the `{{payload.*}}` paths, the destination knowledge tells you the required body fields
+- Platform names are **kebab-case** (e.g., `hub-spot`, not `HubSpot`)
+- Connection keys are passed as values, not hardcoded — use the exact keys from `one connection list`
+- Event filters on both the endpoint and individual actions must match — if the endpoint filters to `["customer.created"]`, the action's eventFilters should include `"customer.created"`
+- Multiple actions can be attached to a single relay endpoint — each can forward to a different platform
+- Missing template variables resolve to empty strings — verify your `{{payload.*}}` paths against the actual webhook payload structure

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -173,6 +173,8 @@ export async function connectionListCommand(options?: { search?: string; limit?:
           platform: conn.platform,
           state: conn.state,
           key: conn.key,
+          ...(conn.name && { name: conn.name }),
+          ...(conn.tags?.length && { tags: conn.tags }),
         })),
         ...(limited.length < filtered.length && {
           hint: `Showing ${limited.length} of ${filtered.length} connections. Use --search <query> to filter by platform or --limit <n> to see more.`,

--- a/src/commands/guide.ts
+++ b/src/commands/guide.ts
@@ -2,7 +2,7 @@ import pc from 'picocolors';
 import * as output from '../lib/output.js';
 import { getGuideContent, getAvailableTopics } from '../lib/guide-content.js';
 
-const VALID_TOPICS = ['overview', 'actions', 'flows', 'all'] as const;
+const VALID_TOPICS = ['overview', 'actions', 'flows', 'relay', 'all'] as const;
 type GuideTopic = (typeof VALID_TOPICS)[number];
 
 export async function guideCommand(topic: string = 'all'): Promise<void> {

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -108,18 +108,30 @@ The \`--agent\` flag gives structured JSON output. Always include it right
 after \`one\`:
   one --agent <command>
 
+### IMPORTANT: Learn before you use
+Before using any feature (actions, flows, relay), you MUST read the
+corresponding skill documentation first. The skills are bundled with
+the CLI and teach you the correct workflow, required steps, and
+common mistakes to avoid. Never guess — read the skill, then act.
+
 ### Quick reference:
 - \`one --agent list\` — See connected platforms and connection keys
 - \`one --agent actions search <platform> "<query>"\` — Find actions
 - \`one --agent actions knowledge <platform> <actionId>\` — Read docs (REQUIRED before execute)
 - \`one --agent actions execute <platform> <actionId> <connectionKey>\` — Execute action
 - \`one --agent flow create\` — Build multi-step workflows
+- \`one --agent relay create\` — Set up webhook relay (receive events, forward to other platforms)
 - \`one --agent guide\` — Full documentation
 - \`one add <platform>\` — Connect a new platform (interactive, no --agent)
 
 ### Workflow: search -> knowledge -> execute
 Always read the knowledge before executing. It tells you required parameters,
 validation rules, and platform-specific details.
+
+### Webhook Relay
+Use \`one relay\` to receive webhooks from platforms (Stripe, GitHub, etc.)
+and forward event data to other platforms using passthrough actions with
+Handlebars templates. No middleware needed.
 \`\`\``);
 
   sections.push(buildCurrentState(connections));
@@ -146,6 +158,17 @@ The \`--agent\` flag goes right after \`one\`, before the subcommand.
 ### Multi-Step Workflows:
 Use \`one flow create\` to build JSON workflows that chain actions across
 platforms with conditions, loops, parallel execution, and transforms.
+
+### Webhook Relay:
+Use \`one relay create\` to receive webhooks from platforms (Stripe, GitHub,
+Airtable, Attio, Google Calendar) and forward event data to any connected
+platform using passthrough actions with Handlebars templates.
+
+### IMPORTANT: Learn before you use
+Before using flows or relay, you MUST read the corresponding skill
+documentation first. The skills teach you the correct workflow, template
+syntax, required steps, and common mistakes. Never guess — read the
+skill, then act.
 
 Run \`one --agent guide\` for the complete reference documentation with examples.`);
 

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -1,0 +1,432 @@
+import pc from 'picocolors';
+import { getApiKey, getAccessControlFromAllSources } from '../lib/config.js';
+import { OneApi } from '../lib/api.js';
+import { printTable } from '../lib/table.js';
+import * as output from '../lib/output.js';
+
+function getConfig() {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    output.error('Not configured. Run `one init` first.');
+  }
+
+  const ac = getAccessControlFromAllSources();
+  const connectionKeys: string[] = ac.connectionKeys || ['*'];
+  return { apiKey, connectionKeys };
+}
+
+function parseJsonArg(value: string, argName: string): any {
+  try {
+    return JSON.parse(value);
+  } catch {
+    output.error(`Invalid JSON for ${argName}: ${value}`);
+  }
+}
+
+// ── Commands ──
+
+export async function relayCreateCommand(options: {
+  connectionKey: string;
+  description?: string;
+  eventFilters?: string;
+  tags?: string;
+  createWebhook?: boolean;
+}): Promise<void> {
+  const { apiKey, connectionKeys } = getConfig();
+
+  if (!connectionKeys.includes('*') && !connectionKeys.includes(options.connectionKey)) {
+    output.error(`Connection key "${options.connectionKey}" is not allowed.`);
+  }
+
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Creating relay endpoint...');
+
+  try {
+    const body: Record<string, unknown> = {
+      connectionKey: options.connectionKey,
+    };
+    if (options.description) body.description = options.description;
+    if (options.eventFilters) body.eventFilters = parseJsonArg(options.eventFilters, '--event-filters');
+    if (options.tags) body.tags = parseJsonArg(options.tags, '--tags');
+    if (options.createWebhook) body.createWebhook = true;
+
+    const result = await api.createRelayEndpoint(body as any);
+
+    if (output.isAgentMode()) {
+      output.json(result);
+      return;
+    }
+
+    spinner.stop('Relay endpoint created');
+    console.log();
+    console.log(`  ${pc.dim('ID:')}          ${result.id}`);
+    console.log(`  ${pc.dim('URL:')}         ${result.url}`);
+    console.log(`  ${pc.dim('Active:')}      ${result.active}`);
+    if (result.description) console.log(`  ${pc.dim('Description:')} ${result.description}`);
+    if (result.eventFilters?.length) console.log(`  ${pc.dim('Events:')}      ${result.eventFilters.join(', ')}`);
+    if (result.webhookPayload?.id) console.log(`  ${pc.dim('Webhook ID:')}  ${result.webhookPayload.id}`);
+    console.log();
+  } catch (error) {
+    spinner.stop('Failed to create relay endpoint');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayListCommand(options: {
+  limit?: string;
+  page?: string;
+}): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Loading relay endpoints...');
+
+  try {
+    const query: Record<string, string> = {};
+    if (options.limit) query.limit = options.limit;
+    if (options.page) query.page = options.page;
+
+    const result = await api.listRelayEndpoints(query);
+    const endpoints = result.rows || [];
+
+    if (output.isAgentMode()) {
+      output.json({
+        total: result.total,
+        showing: endpoints.length,
+        endpoints: endpoints.map((e: any) => ({
+          id: e.id,
+          active: e.active,
+          description: e.description,
+          eventFilters: e.eventFilters,
+          actionsCount: e.actions?.length || 0,
+          url: e.url,
+          createdAt: e.createdAt,
+        })),
+      });
+      return;
+    }
+
+    spinner.stop(`${endpoints.length} relay endpoint${endpoints.length === 1 ? '' : 's'} found`);
+
+    if (endpoints.length === 0) {
+      console.log('\n  No relay endpoints yet.\n');
+      return;
+    }
+
+    printTable(
+      ['Status', 'Description', 'Events', 'Actions', 'ID'],
+      endpoints.map((e: any) => [
+        e.active ? pc.green('●') : pc.dim('○'),
+        e.description || pc.dim('(none)'),
+        e.eventFilters?.join(', ') || pc.dim('all'),
+        String(e.actions?.length || 0),
+        pc.dim(e.id.slice(0, 8)),
+      ])
+    );
+  } catch (error) {
+    spinner.stop('Failed to list relay endpoints');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayGetCommand(id: string): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Loading relay endpoint...');
+
+  try {
+    const result = await api.getRelayEndpoint(id);
+
+    if (output.isAgentMode()) {
+      output.json(result);
+      return;
+    }
+
+    spinner.stop('Relay endpoint loaded');
+    console.log();
+    console.log(`  ${pc.dim('ID:')}          ${result.id}`);
+    console.log(`  ${pc.dim('URL:')}         ${result.url}`);
+    console.log(`  ${pc.dim('Active:')}      ${result.active}`);
+    if (result.description) console.log(`  ${pc.dim('Description:')} ${result.description}`);
+    if (result.eventFilters?.length) console.log(`  ${pc.dim('Events:')}      ${result.eventFilters.join(', ')}`);
+    console.log(`  ${pc.dim('Actions:')}     ${result.actions?.length || 0}`);
+    if (result.actions?.length) {
+      for (const [i, action] of result.actions.entries()) {
+        console.log(`    ${pc.dim(`[${i}]`)} type=${action.type}${action.actionId ? ` actionId=${action.actionId}` : ''}${action.url ? ` url=${action.url}` : ''}`);
+      }
+    }
+    console.log(`  ${pc.dim('Created:')}     ${result.createdAt}`);
+    console.log();
+  } catch (error) {
+    spinner.stop('Failed to load relay endpoint');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayUpdateCommand(
+  id: string,
+  options: {
+    description?: string;
+    active?: boolean;
+    eventFilters?: string;
+    tags?: string;
+    actions?: string;
+  }
+): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Updating relay endpoint...');
+
+  try {
+    const body: Record<string, unknown> = {};
+    if (options.description !== undefined) body.description = options.description;
+    if (options.active !== undefined) body.active = options.active;
+    if (options.eventFilters) body.eventFilters = parseJsonArg(options.eventFilters, '--event-filters');
+    if (options.tags) body.tags = parseJsonArg(options.tags, '--tags');
+    if (options.actions) body.actions = parseJsonArg(options.actions, '--actions');
+
+    const result = await api.updateRelayEndpoint(id, body);
+
+    if (output.isAgentMode()) {
+      output.json(result);
+      return;
+    }
+
+    spinner.stop('Relay endpoint updated');
+    console.log(`  ${pc.dim('ID:')} ${result.id}`);
+    console.log(`  ${pc.dim('Active:')} ${result.active}`);
+    console.log(`  ${pc.dim('Actions:')} ${result.actions?.length || 0}`);
+    console.log();
+  } catch (error) {
+    spinner.stop('Failed to update relay endpoint');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayDeleteCommand(id: string): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Deleting relay endpoint...');
+
+  try {
+    const result = await api.deleteRelayEndpoint(id);
+
+    if (output.isAgentMode()) {
+      output.json({ deleted: true, id: result.id });
+      return;
+    }
+
+    spinner.stop('Relay endpoint deleted');
+    console.log(`  Deleted: ${result.id}`);
+    console.log();
+  } catch (error) {
+    spinner.stop('Failed to delete relay endpoint');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayActivateCommand(
+  id: string,
+  options: { actions: string; webhookSecret?: string }
+): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Activating relay endpoint...');
+
+  try {
+    const actions = parseJsonArg(options.actions, '--actions');
+    const body: Record<string, unknown> = { actions };
+    if (options.webhookSecret) body.webhookSecret = options.webhookSecret;
+
+    const result = await api.activateRelayEndpoint(id, body as any);
+
+    if (output.isAgentMode()) {
+      output.json(result);
+      return;
+    }
+
+    spinner.stop('Relay endpoint activated');
+    console.log(`  ${pc.dim('ID:')} ${result.id}`);
+    console.log(`  ${pc.dim('Active:')} ${result.active}`);
+    console.log(`  ${pc.dim('Actions:')} ${result.actions?.length || 0}`);
+    console.log();
+  } catch (error) {
+    spinner.stop('Failed to activate relay endpoint');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayEventsCommand(options: {
+  limit?: string;
+  page?: string;
+  platform?: string;
+  eventType?: string;
+  after?: string;
+  before?: string;
+}): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Loading relay events...');
+
+  try {
+    const query: Record<string, string> = {};
+    if (options.limit) query.limit = options.limit;
+    if (options.page) query.page = options.page;
+    if (options.platform) query.platform = options.platform;
+    if (options.eventType) query.eventType = options.eventType;
+    if (options.after) query.after = options.after;
+    if (options.before) query.before = options.before;
+
+    const result = await api.listRelayEvents(query);
+    const events = result.rows || [];
+
+    if (output.isAgentMode()) {
+      output.json({
+        total: result.total,
+        showing: events.length,
+        events: events.map((e: any) => ({
+          id: e.id,
+          platform: e.platform,
+          eventType: e.eventType,
+          timestamp: e.timestamp || e.createdAt,
+        })),
+      });
+      return;
+    }
+
+    spinner.stop(`${events.length} event${events.length === 1 ? '' : 's'} found`);
+
+    if (events.length === 0) {
+      console.log('\n  No events found.\n');
+      return;
+    }
+
+    printTable(
+      ['Platform', 'Event Type', 'Timestamp', 'ID'],
+      events.map((e: any) => [
+        e.platform,
+        e.eventType || pc.dim('unknown'),
+        e.timestamp || e.createdAt,
+        pc.dim(e.id.slice(0, 8)),
+      ])
+    );
+  } catch (error) {
+    spinner.stop('Failed to list relay events');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayEventGetCommand(id: string): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Loading relay event...');
+
+  try {
+    const result = await api.getRelayEvent(id);
+
+    if (output.isAgentMode()) {
+      output.json(result);
+      return;
+    }
+
+    spinner.stop('Relay event loaded');
+    console.log();
+    console.log(`  ${pc.dim('ID:')}        ${result.id}`);
+    console.log(`  ${pc.dim('Platform:')}  ${result.platform}`);
+    console.log(`  ${pc.dim('Event:')}     ${result.eventType}`);
+    console.log(`  ${pc.dim('Timestamp:')} ${result.timestamp || result.createdAt}`);
+    console.log(`  ${pc.dim('Payload:')}`);
+    console.log(JSON.stringify(result.payload, null, 2));
+    console.log();
+  } catch (error) {
+    spinner.stop('Failed to load relay event');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayDeliveriesCommand(options: {
+  endpointId?: string;
+  eventId?: string;
+}): Promise<void> {
+  if (!options.endpointId && !options.eventId) {
+    output.error('Provide either --endpoint-id or --event-id');
+  }
+
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start('Loading deliveries...');
+
+  try {
+    const deliveries = options.endpointId
+      ? await api.listRelayEndpointDeliveries(options.endpointId)
+      : await api.listRelayEventDeliveries(options.eventId!);
+
+    const items = Array.isArray(deliveries) ? deliveries : deliveries.rows || [];
+
+    if (output.isAgentMode()) {
+      output.json({ deliveries: items });
+      return;
+    }
+
+    spinner.stop(`${items.length} deliver${items.length === 1 ? 'y' : 'ies'} found`);
+
+    if (items.length === 0) {
+      console.log('\n  No deliveries found.\n');
+      return;
+    }
+
+    printTable(
+      ['Status', 'Code', 'Attempt', 'Delivered At', 'Error'],
+      items.map((d: any) => [
+        d.status === 'success' ? pc.green(d.status) : pc.red(d.status),
+        d.statusCode != null ? String(d.statusCode) : pc.dim('-'),
+        String(d.attempt),
+        d.deliveredAt || pc.dim('-'),
+        d.error ? pc.red(d.error.slice(0, 50)) : pc.dim('-'),
+      ])
+    );
+  } catch (error) {
+    spinner.stop('Failed to load deliveries');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export async function relayEventTypesCommand(platform: string): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey);
+  const spinner = output.createSpinner();
+  spinner.start(`Loading event types for ${pc.cyan(platform)}...`);
+
+  try {
+    const eventTypes = await api.listRelayEventTypes(platform);
+
+    if (output.isAgentMode()) {
+      output.json({ platform, eventTypes });
+      return;
+    }
+
+    spinner.stop(`${eventTypes.length} event type${eventTypes.length === 1 ? '' : 's'} found`);
+
+    if (eventTypes.length === 0) {
+      console.log(`\n  No event types found for ${platform}.\n`);
+      return;
+    }
+
+    console.log();
+    for (const type of eventTypes) {
+      console.log(`  ${type}`);
+    }
+    console.log();
+  } catch (error) {
+    spinner.stop('Failed to load event types');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,18 @@ import {
   flowRunsCommand,
   collect,
 } from './commands/flow.js';
+import {
+  relayCreateCommand,
+  relayListCommand,
+  relayGetCommand,
+  relayUpdateCommand,
+  relayDeleteCommand,
+  relayActivateCommand,
+  relayEventsCommand,
+  relayEventGetCommand,
+  relayDeliveriesCommand,
+  relayEventTypesCommand,
+} from './commands/relay.js';
 import { guideCommand } from './commands/guide.js';
 import { onboardCommand } from './commands/onboard.js';
 import { updateCommand, checkLatestVersionCached, getCurrentVersion } from './commands/update.js';
@@ -50,6 +62,14 @@ program
     one flow create [key]                 Create a workflow from JSON
     one flow execute <key>                Execute a workflow
     one flow validate <key>               Validate a flow
+
+  Webhook Relay:
+    one relay create                      Create a relay endpoint for a connection
+    one relay list                        List relay endpoints
+    one relay activate <id>               Activate with passthrough actions
+    one relay event-types <platform>      List supported event types
+    one relay events                      List received webhook events
+    one relay deliveries                  List delivery attempts
 
   Example — send an email through Gmail:
     $ one list
@@ -247,9 +267,110 @@ flow
     await flowRunsCommand(flowKey);
   });
 
+// ── Relay Commands ──
+
+const relay = program
+  .command('relay')
+  .alias('r')
+  .description('Receive webhooks from platforms and relay them via passthrough actions');
+
+relay
+  .command('create')
+  .description('Create a new relay endpoint for a connection')
+  .requiredOption('--connection-key <key>', 'Connection key for the source platform')
+  .option('--description <desc>', 'Description of the relay endpoint')
+  .option('--event-filters <json>', 'JSON array of event types to filter (e.g. \'["customer.created"]\')')
+  .option('--tags <json>', 'JSON array of tags')
+  .option('--create-webhook', 'Automatically register the webhook with the source platform')
+  .action(async (options: { connectionKey: string; description?: string; eventFilters?: string; tags?: string; createWebhook?: boolean }) => {
+    await relayCreateCommand(options);
+  });
+
+relay
+  .command('list')
+  .alias('ls')
+  .description('List all relay endpoints')
+  .option('--limit <n>', 'Max results per page')
+  .option('--page <n>', 'Page number')
+  .action(async (options: { limit?: string; page?: string }) => {
+    await relayListCommand(options);
+  });
+
+relay
+  .command('get <id>')
+  .description('Get details of a relay endpoint')
+  .action(async (id: string) => {
+    await relayGetCommand(id);
+  });
+
+relay
+  .command('update <id>')
+  .description('Update a relay endpoint')
+  .option('--description <desc>', 'Update description')
+  .option('--active', 'Set active')
+  .option('--no-active', 'Set inactive')
+  .option('--event-filters <json>', 'JSON array of event types')
+  .option('--tags <json>', 'JSON array of tags')
+  .option('--actions <json>', 'JSON array of actions (url, passthrough, or agent)')
+  .action(async (id: string, options: { description?: string; active?: boolean; eventFilters?: string; tags?: string; actions?: string }) => {
+    await relayUpdateCommand(id, options);
+  });
+
+relay
+  .command('delete <id>')
+  .description('Delete a relay endpoint')
+  .action(async (id: string) => {
+    await relayDeleteCommand(id);
+  });
+
+relay
+  .command('activate <id>')
+  .description('Activate a relay endpoint with forwarding actions')
+  .requiredOption('--actions <json>', 'JSON array of actions (url, passthrough, or agent)')
+  .option('--webhook-secret <secret>', 'Webhook signing secret for signature verification')
+  .action(async (id: string, options: { actions: string; webhookSecret?: string }) => {
+    await relayActivateCommand(id, options);
+  });
+
+relay
+  .command('events')
+  .description('List received webhook events')
+  .option('--limit <n>', 'Max results per page')
+  .option('--page <n>', 'Page number')
+  .option('--platform <platform>', 'Filter by platform')
+  .option('--event-type <type>', 'Filter by event type')
+  .option('--after <iso>', 'Events after this timestamp')
+  .option('--before <iso>', 'Events before this timestamp')
+  .action(async (options: { limit?: string; page?: string; platform?: string; eventType?: string; after?: string; before?: string }) => {
+    await relayEventsCommand(options);
+  });
+
+relay
+  .command('event <id>')
+  .description('Get details of a specific webhook event')
+  .action(async (id: string) => {
+    await relayEventGetCommand(id);
+  });
+
+relay
+  .command('deliveries')
+  .description('List delivery attempts for an endpoint or event')
+  .option('--endpoint-id <id>', 'Relay endpoint ID')
+  .option('--event-id <id>', 'Relay event ID')
+  .action(async (options: { endpointId?: string; eventId?: string }) => {
+    await relayDeliveriesCommand(options);
+  });
+
+relay
+  .command('event-types <platform>')
+  .description('List supported webhook event types for a platform')
+  .action(async (platform: string) => {
+    await relayEventTypesCommand(platform);
+  });
+
 program
   .command('guide [topic]')
-  .description('Full CLI usage guide for agents (topics: overview, actions, flows, all)')
+  .description('Full CLI usage guide for agents (topics: overview, actions, flows, relay, all)')
   .action(async (topic?: string) => {
     await guideCommand(topic);
   });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -291,6 +291,59 @@ export class OneApi {
     };
   }
 
+  // Webhook Relay methods
+
+  async createRelayEndpoint(body: {
+    connectionKey: string;
+    createWebhook?: boolean;
+    description?: string;
+    eventFilters?: string[];
+    tags?: string[];
+    metadata?: Record<string, unknown>;
+  }): Promise<any> {
+    return this.requestFull({ path: '/webhooks/relay', method: 'POST', body });
+  }
+
+  async listRelayEndpoints(query?: Record<string, string>): Promise<any> {
+    return this.requestFull({ path: '/webhooks/relay', queryParams: query });
+  }
+
+  async getRelayEndpoint(id: string): Promise<any> {
+    return this.requestFull({ path: `/webhooks/relay/${id}` });
+  }
+
+  async updateRelayEndpoint(id: string, body: Record<string, unknown>): Promise<any> {
+    return this.requestFull({ path: `/webhooks/relay/${id}`, method: 'PATCH', body });
+  }
+
+  async deleteRelayEndpoint(id: string): Promise<any> {
+    return this.requestFull({ path: `/webhooks/relay/${id}`, method: 'DELETE' });
+  }
+
+  async activateRelayEndpoint(id: string, body: { actions: any[]; webhookSecret?: string }): Promise<any> {
+    return this.requestFull({ path: `/webhooks/relay/${id}/activate`, method: 'POST', body });
+  }
+
+  async listRelayEvents(query?: Record<string, string>): Promise<any> {
+    return this.requestFull({ path: '/webhooks/relay/events', queryParams: query });
+  }
+
+  async getRelayEvent(id: string): Promise<any> {
+    return this.requestFull({ path: `/webhooks/relay/events/${id}` });
+  }
+
+  async listRelayEndpointDeliveries(endpointId: string): Promise<any> {
+    return this.requestFull({ path: `/webhooks/relay/${endpointId}/deliveries` });
+  }
+
+  async listRelayEventDeliveries(eventId: string): Promise<any> {
+    return this.requestFull({ path: `/webhooks/relay/events/${eventId}/deliveries` });
+  }
+
+  async listRelayEventTypes(platform: string): Promise<any> {
+    return this.requestFull({ path: '/webhooks/relay/event-types', queryParams: { platform } });
+  }
+
   async waitForConnection(
     platform: string,
     timeoutMs = 5 * 60 * 1000,

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -1,7 +1,4 @@
-// Guide content bundled as string constants.
-// Source files (sync manually if updated):
-//   - skills/one-actions/SKILL.md (lines 19+)
-//   - skills/one-flow/SKILL.md (lines 19+)
+// Guide content — concise overview that routes agents to skill docs for details.
 
 export const GUIDE_OVERVIEW = `# One CLI — Agent Guide
 
@@ -21,47 +18,92 @@ one --agent <command>
 
 All commands return JSON. If an \`error\` key is present, the command failed.
 
+## IMPORTANT: Learn before you use
+
+Before using any feature, you MUST read the corresponding skill documentation first. The skills are bundled with the CLI and teach you the correct workflow, required steps, template syntax, and common mistakes. Never guess — read the skill, then act.
+
+## Features
+
+### 1. Actions — Execute API calls on 200+ platforms
+Search for actions, read their docs, and execute them. This is the core workflow.
+
+**Quick start:**
+\`\`\`bash
+one --agent connection list                                    # See connected platforms
+one --agent actions search <platform> "<query>" -t execute     # Find an action
+one --agent actions knowledge <platform> <actionId>            # Read docs (REQUIRED)
+one --agent actions execute <platform> <actionId> <key> -d '{}'  # Execute it
+\`\`\`
+
+**Parameter flags:**
+- \`-d <json>\` — Request body (POST/PUT/PATCH)
+- \`--path-vars <json>\` — URL path variables (e.g., \`{"userId": "me"}\`)
+- \`--query-params <json>\` — Query parameters (arrays expand to repeated params)
+- \`--form-url-encoded\` — Send as form data instead of JSON
+- \`--dry-run\` — Preview request without executing
+
+Do NOT pass path or query parameters in \`-d\` — use the correct flags.
+
+### 2. Flows — Multi-step API workflows
+Chain actions across platforms as JSON workflow files with conditions, loops, parallel execution, transforms, and AI analysis via bash steps.
+
+**Quick start:**
+\`\`\`bash
+one --agent flow create <key> --definition '<json>'   # Create a workflow
+one --agent flow validate <key>                       # Validate it
+one --agent flow execute <key> -i param=value         # Execute it
+one --agent flow list                                 # List all workflows
+\`\`\`
+
+**Key concepts:**
+- Workflows are JSON files at \`.one/flows/<key>.flow.json\`
+- 12 step types: action, transform, code, condition, loop, parallel, file-read, file-write, while, flow, paginate, bash
+- Data wiring via selectors: \`$.input.param\`, \`$.steps.stepId.response\`, \`$.loop.item\`
+- AI analysis via bash steps: \`claude --print\` with \`parseJson: true\`
+- Use \`--allow-bash\` to enable bash steps, \`--mock\` for dry-run with mock responses
+
+### 3. Relay — Webhook event forwarding between platforms
+Receive webhooks from platforms (Stripe, GitHub, Airtable, Attio, Google Calendar) and forward event data to any connected platform using passthrough actions with Handlebars templates. No middleware, no code.
+
+**Quick start:**
+\`\`\`bash
+one --agent relay event-types <platform>                        # See available events
+one --agent relay create --connection-key <key> --create-webhook --event-filters '["event.type"]'
+one --agent relay activate <id> --actions '[{"type":"passthrough","actionId":"...","connectionKey":"...","body":{...}}]'
+one --agent relay list                                          # List endpoints
+one --agent relay events --platform <p>                         # List received events
+one --agent relay deliveries --endpoint-id <id>                 # Check delivery status
+\`\`\`
+
+**Key concepts:**
+- \`passthrough\` actions map webhook fields to another platform's API using Handlebars: \`{{payload.data.object.email}}\`
+- Template context: \`{{relayEventId}}\`, \`{{platform}}\`, \`{{eventType}}\`, \`{{payload}}\`, \`{{timestamp}}\`, \`{{connectionId}}\`
+- \`--create-webhook\` auto-registers the webhook URL with the source platform
+- Use \`actions knowledge\` to learn both the incoming payload shape AND the destination API shape before building templates
+
 ## Topics
 
-This guide has three sections you can request individually:
+Request specific sections:
+- \`one guide overview\` — This section
+- \`one guide actions\` — Actions reference (search, knowledge, execute)
+- \`one guide flows\` — Workflow engine reference (step types, selectors, examples)
+- \`one guide relay\` — Webhook relay reference (templates, passthrough actions)
+- \`one guide all\` — Everything
 
-- **overview** — This section. Setup, flag usage, and discovery workflow.
-- **actions** — Full workflow for searching, reading docs, and executing platform actions.
-- **workflows** — Building and executing multi-step API workflows (JSON-based).
+## Important Notes
 
-## Discovery Workflow
-
-1. \`one --agent connection list\` — See connected platforms and connection keys
-2. \`one --agent actions search <platform> <query>\` — Find actions
-3. \`one --agent actions knowledge <platform> <actionId>\` — Read full docs (REQUIRED before execute)
-4. \`one --agent actions execute <platform> <actionId> <connectionKey>\` — Execute the action
-
-For multi-step workflows:
-1. Discover actions with the workflow above
-2. Build a workflow JSON definition
-3. \`one --agent flow create <key> --definition '<json>'\`
-4. \`one --agent flow execute <key> -i param=value\`
-
-Platform names are always kebab-case (e.g., \`hub-spot\`, \`google-calendar\`).
-Run \`one platforms\` to browse all 200+ available platforms.
+- **Always use \`--agent\` flag** for structured JSON output
+- Platform names are always **kebab-case** (e.g., \`hub-spot\`, \`google-calendar\`)
+- Always use the **exact action ID** from search results — don't guess
+- Always read **knowledge** before executing any action
+- Connection keys come from \`one connection list\` — don't hardcode them
 `;
 
-export const GUIDE_ACTIONS = `# One Actions CLI Workflow
+export const GUIDE_ACTIONS = `# One Actions — Reference
 
-You have access to the One CLI which lets you interact with 200+ third-party platforms through their APIs. The CLI handles authentication, request building, and execution through One's passthrough proxy.
+## Workflow: search → knowledge → execute
 
-## The Workflow
-
-Always follow this sequence — each step builds on the previous one:
-
-1. **List connections** to see what platforms the user has connected
-2. **Search actions** to find the right API action for what the user wants to do
-3. **Get knowledge** to understand the action's parameters, requirements, and structure
-4. **Execute** the action with the correct parameters
-
-Never skip the knowledge step before executing — it contains critical information about required parameters, validation rules, and request structure that you need to build a correct request.
-
-## Commands
+Always follow this sequence. Never skip the knowledge step.
 
 ### 1. List Connections
 
@@ -69,843 +111,229 @@ Never skip the knowledge step before executing — it contains critical informat
 one --agent connection list
 \`\`\`
 
-Returns JSON with all connected platforms, their status, and connection keys. You need the **connection key** for executing actions, and the **platform name** (kebab-case) for searching actions.
-
-Output format:
-\`\`\`json
-{"connections": [{"platform": "gmail", "state": "active", "key": "conn_abc123"}, ...]}
-\`\`\`
+Returns platforms, status, connection keys, and tags.
 
 ### 2. Search Actions
 
 \`\`\`bash
-one --agent actions search <platform> <query>
+one --agent actions search <platform> "<query>" -t execute
 \`\`\`
 
-Search for actions on a specific platform using natural language. Returns JSON with up to 5 matching actions including their action IDs, HTTP methods, and paths.
+- Use \`-t execute\` when the user wants to perform an action
+- Use \`-t knowledge\` (default) for documentation/code generation
+- Returns up to 5 matching actions with IDs, methods, and paths
 
-- \`<platform>\` — Platform name in kebab-case exactly as shown in the connections list (e.g., \`gmail\`, \`shopify\`, \`hub-spot\`)
-- \`<query>\` — Natural language description of what you want to do (e.g., \`"send email"\`, \`"list contacts"\`, \`"create order"\`)
-
-Options:
-- \`-t, --type <execute|knowledge>\` — Use \`execute\` when the user wants to perform an action, \`knowledge\` when they want documentation or want to write code. Defaults to \`knowledge\`.
-
-Example:
-\`\`\`bash
-one --agent actions search gmail "send email" -t execute
-\`\`\`
-
-Output format:
-\`\`\`json
-{"actions": [{"_id": "abc123", "title": "Send Email", "tags": [...], "method": "POST", "path": "/messages/send"}, ...]}
-\`\`\`
-
-### 3. Get Action Knowledge
+### 3. Get Knowledge
 
 \`\`\`bash
 one --agent actions knowledge <platform> <actionId>
 \`\`\`
 
-Get comprehensive documentation for an action including parameters, requirements, validation rules, request/response structure, and examples. Returns JSON with the full API knowledge and HTTP method.
+Returns full API docs: required fields, validation rules, request structure. **REQUIRED before execute.** The output includes a CLI PARAMETER MAPPING section showing which flags to use.
 
-Always call this before executing — it tells you exactly what parameters are required and how to structure the request.
-
-Example:
-\`\`\`bash
-one --agent actions knowledge gmail 67890abcdef
-\`\`\`
-
-Output format:
-\`\`\`json
-{"knowledge": "...full API documentation and guidance...", "method": "POST"}
-\`\`\`
-
-### 4. Execute Action
+### 4. Execute
 
 \`\`\`bash
 one --agent actions execute <platform> <actionId> <connectionKey> [options]
 \`\`\`
 
-Execute an action on a connected platform. Returns JSON with the request details and response data. You must have retrieved the knowledge for this action first.
+**Flags:**
+- \`-d, --data <json>\` — Request body (POST/PUT/PATCH)
+- \`--path-vars <json>\` — Path variables: \`{"userId": "me"}\`
+- \`--query-params <json>\` — Query params: \`{"limit": "10"}\`
+  - Arrays expand to repeated params: \`{"metadataHeaders": ["From", "Subject"]}\`
+- \`--headers <json>\` — Additional headers
+- \`--form-data\` / \`--form-url-encoded\` — Alternative content types
+- \`--dry-run\` — Preview without executing
 
-- \`<platform>\` — Platform name in kebab-case
-- \`<actionId>\` — Action ID from the search results
-- \`<connectionKey>\` — Connection key from \`one connection list\`
-
-Options:
-- \`-d, --data <json>\` — Request body as JSON string (for POST, PUT, PATCH)
-- \`--path-vars <json>\` — Path variables as JSON (for URLs with \`{id}\` placeholders)
-- \`--query-params <json>\` — Query parameters as JSON
-- \`--headers <json>\` — Additional headers as JSON
-- \`--form-data\` — Send as multipart/form-data instead of JSON
-- \`--form-url-encoded\` — Send as application/x-www-form-urlencoded
-- \`--dry-run\` — Show the request that would be sent without executing it
-
-Examples:
-\`\`\`bash
-# Simple GET request
-one --agent actions execute shopify <actionId> <connectionKey>
-
-# POST with data
-one --agent actions execute hub-spot <actionId> <connectionKey> \\
-  -d '{"properties": {"email": "jane@example.com", "firstname": "Jane"}}'
-
-# With path variables and query params
-one --agent actions execute shopify <actionId> <connectionKey> \\
-  --path-vars '{"order_id": "12345"}' \\
-  --query-params '{"limit": "10"}'
-\`\`\`
-
-Output format:
-\`\`\`json
-{"request": {"method": "POST", "url": "https://..."}, "response": {...}}
-\`\`\`
+**Do NOT** pass path or query parameters in \`-d\`. Use the correct flags.
 
 ## Error Handling
 
-All errors return JSON in agent mode:
-\`\`\`json
-{"error": "Error message here"}
-\`\`\`
+All errors return JSON: \`{"error": "message"}\`. Check the \`error\` key.
 
-Parse the output as JSON. If the \`error\` key is present, the command failed — report the error message to the user.
+## Notes
 
-## Important Notes
-
-- **Always use \`--agent\` flag** — it produces structured JSON output without spinners, colors, or interactive prompts
-- Platform names are always **kebab-case** (e.g., \`hub-spot\` not \`HubSpot\`, \`ship-station\` not \`ShipStation\`)
-- Always use the **exact action ID** from search results — don't guess or construct them
-- Always read the knowledge output carefully — it tells you which parameters are required vs optional, what format they need to be in, and any caveats specific to that API
-- JSON values passed to \`-d\`, \`--path-vars\`, \`--query-params\`, and \`--headers\` must be valid JSON strings (use single quotes around the JSON to avoid shell escaping issues)
-- If search returns no results, try broader queries (e.g., \`"list"\` instead of \`"list active premium customers"\`)
-- The execute command respects access control settings configured via \`one config\` — if execution is blocked, the user may need to adjust their permissions
+- Platform names are **kebab-case** (e.g., \`hub-spot\`)
+- JSON flags use single quotes around the JSON to avoid shell escaping
+- If search returns no results, try broader queries
+- Access control settings from \`one config\` may restrict execution
 `;
 
-export const GUIDE_FLOWS = `# One Workflows — Multi-Step API Workflows
+export const GUIDE_FLOWS = `# One Flows — Reference
 
-You have access to the One CLI's workflow engine, which lets you create and execute multi-step API workflows as JSON files. Workflows chain actions across platforms — e.g., look up a Stripe customer, then send them a welcome email via Gmail.
+## Overview
 
-## 1. Overview
+Workflows are JSON files at \`.one/flows/<key>.flow.json\` that chain actions across platforms.
 
-- Workflows are JSON files stored at \`.one/flows/<key>.flow.json\`
-- All dynamic values (including connection keys) are declared as **inputs**
-- Each workflow has a unique **key** used to reference and execute it
-- Executed via \`one --agent flow execute <key> -i name=value\`
-
-## 2. Building a Workflow — Step-by-Step Process
-
-**You MUST follow this process to build a correct workflow:**
-
-### Step 1: Discover connections
+## Commands
 
 \`\`\`bash
-one --agent connection list
+one --agent flow create <key> --definition '<json>'   # Create
+one --agent flow list                                  # List
+one --agent flow validate <key>                        # Validate
+one --agent flow execute <key> -i name=value           # Execute
+one --agent flow execute <key> --dry-run --mock        # Test with mock data
+one --agent flow execute <key> --allow-bash            # Enable bash steps
+one --agent flow runs [flowKey]                        # List past runs
+one --agent flow resume <runId>                        # Resume failed run
 \`\`\`
 
-Find out which platforms are connected and get their connection keys.
+## Building a Workflow
 
-### Step 2: For EACH API action needed, get the knowledge
+1. **Design first** — clarify the end goal, map the full value chain, identify where AI analysis is needed
+2. **Discover connections** — \`one --agent connection list\`
+3. **Get knowledge** for every action — \`one --agent actions knowledge <platform> <actionId>\`
+4. **Construct JSON** — declare inputs, wire steps with selectors
+5. **Validate** — \`one --agent flow validate <key>\`
+6. **Execute** — \`one --agent flow execute <key> -i param=value\`
 
-\`\`\`bash
-# Find the action ID
-one --agent actions search <platform> "<query>" -t execute
+## Step Types
 
-# Read the full docs — REQUIRED before adding to a workflow
-one --agent actions knowledge <platform> <actionId>
-\`\`\`
+| Type | Purpose |
+|------|---------|
+| \`action\` | Execute a platform API action |
+| \`transform\` | Single JS expression (implicit return) |
+| \`code\` | Multi-line async JS (explicit return) |
+| \`condition\` | If/then/else branching |
+| \`loop\` | Iterate over array with optional concurrency |
+| \`parallel\` | Run steps concurrently |
+| \`file-read\` | Read file (optional JSON parse) |
+| \`file-write\` | Write/append to file |
+| \`while\` | Do-while loop with condition |
+| \`flow\` | Execute a sub-flow |
+| \`paginate\` | Auto-paginate API results |
+| \`bash\` | Shell command (requires \`--allow-bash\`) |
 
-**CRITICAL:** You MUST call \`one actions knowledge\` for every action you include in the workflow. The knowledge output tells you the exact request body structure, required fields, path variables, and query parameters. Without this, your workflow JSON will have incorrect data shapes.
-
-### Step 3: Construct the workflow JSON
-
-Using the knowledge gathered, build the workflow JSON with:
-- All inputs declared (connection keys + user parameters)
-- Each step with the correct actionId, platform, and data structure (from knowledge)
-- Data wired between steps using \`$.input.*\` and \`$.steps.*\` selectors
-
-### Step 4: Write the workflow file
-
-\`\`\`bash
-one --agent flow create <key> --definition '<json>'
-\`\`\`
-
-Or write directly to \`.one/flows/<key>.flow.json\`.
-
-### Step 5: Validate
-
-\`\`\`bash
-one --agent flow validate <key>
-\`\`\`
-
-### Step 6: Execute
-
-\`\`\`bash
-one --agent flow execute <key> -i connectionKey=xxx -i param=value
-\`\`\`
-
-## 3. Workflow JSON Schema Reference
-
-\`\`\`json
-{
-  "key": "welcome-customer",
-  "name": "Welcome New Customer",
-  "description": "Look up a Stripe customer and send them a welcome email via Gmail",
-  "version": "1",
-  "inputs": {
-    "stripeConnectionKey": {
-      "type": "string",
-      "required": true,
-      "description": "Stripe connection key from one connection list",
-      "connection": { "platform": "stripe" }
-    },
-    "gmailConnectionKey": {
-      "type": "string",
-      "required": true,
-      "description": "Gmail connection key from one connection list",
-      "connection": { "platform": "gmail" }
-    },
-    "customerEmail": {
-      "type": "string",
-      "required": true,
-      "description": "Customer email to look up"
-    }
-  },
-  "steps": [
-    {
-      "id": "stepId",
-      "name": "Human-readable label",
-      "type": "action",
-      "action": {
-        "platform": "stripe",
-        "actionId": "the-action-id-from-search",
-        "connectionKey": "$.input.stripeConnectionKey",
-        "data": {},
-        "pathVars": {},
-        "queryParams": {},
-        "headers": {}
-      }
-    }
-  ]
-}
-\`\`\`
-
-### Input declarations
-
-| Field | Type | Description |
-|---|---|---|
-| \`type\` | string | \`string\`, \`number\`, \`boolean\`, \`object\`, \`array\` |
-| \`required\` | boolean | Whether this input must be provided (default: true) |
-| \`default\` | any | Default value if not provided |
-| \`description\` | string | Human-readable description |
-| \`connection\` | object | Connection metadata: \`{ "platform": "gmail" }\` — enables auto-resolution |
-
-**Connection inputs** have a \`connection\` field. If the user has exactly one connection for that platform, the workflow engine auto-resolves it.
-
-## 4. Selector Syntax Reference
+## Selectors
 
 | Pattern | Resolves To |
-|---|---|
-| \`$.input.gmailConnectionKey\` | Input value (including connection keys) |
-| \`$.input.customerEmail\` | Any input parameter |
-| \`$.steps.stepId.response\` | Full API response from a step |
-| \`$.steps.stepId.response.data[0].email\` | Nested field with array index |
-| \`$.steps.stepId.response.data[*].id\` | Wildcard — maps array to field |
+|---------|-------------|
+| \`$.input.paramName\` | Input value |
+| \`$.steps.stepId.response\` | Full API response |
+| \`$.steps.stepId.response.data[0].email\` | Nested field |
+| \`$.steps.stepId.response.data[*].id\` | Wildcard array map |
 | \`$.env.MY_VAR\` | Environment variable |
-| \`$.loop.item\` | Current loop item |
-| \`$.loop.i\` | Current loop index |
-| \`"Hello {{$.steps.getUser.response.data.name}}"\` | String interpolation |
+| \`$.loop.item\` / \`$.loop.i\` | Loop iteration |
+| \`"Hello {{$.steps.getUser.response.name}}"\` | String interpolation |
 
-**Rules:**
-- A value that is purely \`$.xxx\` resolves to the raw type (object, array, number)
-- A string containing \`{{$.xxx}}\` does string interpolation (stringifies objects)
-- Selectors inside objects/arrays are resolved recursively
-
-## 5. Step Types Reference
-
-### \`action\` — Execute a One API action
+## Error Handling
 
 \`\`\`json
-{
-  "id": "findCustomer",
-  "name": "Search Stripe customers",
-  "type": "action",
-  "action": {
-    "platform": "stripe",
-    "actionId": "conn_mod_def::xxx::yyy",
-    "connectionKey": "$.input.stripeConnectionKey",
-    "data": {
-      "query": "email:'{{$.input.customerEmail}}'"
-    }
-  }
-}
+{"onError": {"strategy": "retry", "retries": 3, "retryDelayMs": 1000}}
 \`\`\`
 
-### \`transform\` — Transform data with a JS expression
+Strategies: \`fail\` (default), \`continue\`, \`retry\`, \`fallback\`
 
-\`\`\`json
-{
-  "id": "extractNames",
-  "name": "Extract customer names",
-  "type": "transform",
-  "transform": {
-    "expression": "$.steps.findCustomer.response.data.map(c => c.name)"
-  }
-}
-\`\`\`
+Conditional execution: \`"if": "$.steps.prev.response.data.length > 0"\`
 
-The expression is evaluated with the full flow context as \`$\`.
+## AI-Augmented Pattern
 
-### \`code\` — Run multi-line JavaScript
+For workflows that need analysis/summarization, use the file-write → bash → code pattern:
 
-Unlike \`transform\` (single expression, implicit return), \`code\` runs a full function body with explicit \`return\`. Use it when you need variables, loops, try/catch, or \`await\`.
+1. \`file-write\` — save data to temp file
+2. \`bash\` — \`claude --print\` analyzes it (\`parseJson: true\`, \`timeout: 180000\`)
+3. \`code\` — parse and structure the output
 
-\`\`\`json
-{
-  "id": "processData",
-  "name": "Process and enrich data",
-  "type": "code",
-  "code": {
-    "source": "const customers = $.steps.listCustomers.response.data;\\nconst enriched = customers.map(c => ({\\n  ...c,\\n  tier: c.spend > 1000 ? 'gold' : 'silver'\\n}));\\nreturn enriched;"
-  }
-}
-\`\`\`
+Set timeout to at least 180000ms (3 min). Run Claude-heavy flows sequentially, not in parallel.
 
-The \`source\` field contains a JS function body. The flow context is available as \`$\`. The function is async, so you can use \`await\`. The return value is stored as the step result.
+## Notes
 
-### \`condition\` — If/then/else branching
-
-\`\`\`json
-{
-  "id": "checkFound",
-  "name": "Check if customer was found",
-  "type": "condition",
-  "condition": {
-    "expression": "$.steps.findCustomer.response.data.length > 0",
-    "then": [
-      { "id": "sendEmail", "name": "Send welcome email", "type": "action", "action": { "..." : "..." } }
-    ],
-    "else": [
-      { "id": "logNotFound", "name": "Log not found", "type": "transform", "transform": { "expression": "'Customer not found'" } }
-    ]
-  }
-}
-\`\`\`
-
-### \`loop\` — Iterate over an array
-
-\`\`\`json
-{
-  "id": "processOrders",
-  "name": "Process each order",
-  "type": "loop",
-  "loop": {
-    "over": "$.steps.listOrders.response.data",
-    "as": "order",
-    "indexAs": "i",
-    "maxIterations": 1000,
-    "maxConcurrency": 5,
-    "steps": [
-      {
-        "id": "createInvoice",
-        "name": "Create invoice for order",
-        "type": "action",
-        "action": {
-          "platform": "quickbooks",
-          "actionId": "...",
-          "connectionKey": "$.input.qbConnectionKey",
-          "data": { "amount": "$.loop.order.total" }
-        }
-      }
-    ]
-  }
-}
-\`\`\`
-
-- \`maxConcurrency\` (optional): When set > 1, loop iterations run in parallel batches of that size. Default is sequential (1).
-
-### \`parallel\` — Run steps concurrently
-
-\`\`\`json
-{
-  "id": "parallelLookups",
-  "name": "Look up in parallel",
-  "type": "parallel",
-  "parallel": {
-    "maxConcurrency": 5,
-    "steps": [
-      { "id": "getStripe", "name": "Get Stripe data", "type": "action", "action": { "...": "..." } },
-      { "id": "getHubspot", "name": "Get HubSpot data", "type": "action", "action": { "...": "..." } }
-    ]
-  }
-}
-\`\`\`
-
-### \`file-read\` — Read from filesystem
-
-\`\`\`json
-{
-  "id": "readConfig",
-  "name": "Read config file",
-  "type": "file-read",
-  "fileRead": { "path": "./data/config.json", "parseJson": true }
-}
-\`\`\`
-
-### \`file-write\` — Write to filesystem
-
-\`\`\`json
-{
-  "id": "writeResults",
-  "name": "Save results",
-  "type": "file-write",
-  "fileWrite": {
-    "path": "./output/results.json",
-    "content": "$.steps.transform.output",
-    "append": false
-  }
-}
-\`\`\`
-
-### \`while\` — Condition-driven loop (do-while)
-
-Iterates until a condition becomes falsy. The first iteration always runs (do-while semantics), then the condition is checked before each subsequent iteration. Useful for pagination.
-
-\`\`\`json
-{
-  "id": "paginate",
-  "name": "Paginate through all pages",
-  "type": "while",
-  "while": {
-    "condition": "$.steps.paginate.output.lastResult.nextPageToken != null",
-    "maxIterations": 50,
-    "steps": [
-      {
-        "id": "fetchPage",
-        "name": "Fetch next page",
-        "type": "action",
-        "action": {
-          "platform": "gmail",
-          "actionId": "GMAIL_LIST_MESSAGES_ACTION_ID",
-          "connectionKey": "$.input.gmailKey",
-          "queryParams": {
-            "pageToken": "$.steps.paginate.output.lastResult.nextPageToken"
-          }
-        }
-      }
-    ]
-  }
-}
-\`\`\`
-
-| Field | Type | Description |
-|---|---|---|
-| \`condition\` | string | JS expression evaluated before each iteration (after iteration 0) |
-| \`maxIterations\` | number | Safety cap, default: 100 |
-| \`steps\` | FlowStep[] | Steps to execute each iteration |
-
-The step output contains \`lastResult\` (last step's output from most recent iteration), \`iteration\` (count), and \`results\` (array of all iteration outputs). Reference via \`$.steps.<id>.output.lastResult\`.
-
-### \`flow\` — Execute a sub-flow
-
-Loads and executes another saved flow, enabling flow composition. Circular flows are detected and blocked.
-
-\`\`\`json
-{
-  "id": "processCustomer",
-  "name": "Run customer enrichment flow",
-  "type": "flow",
-  "flow": {
-    "key": "enrich-customer",
-    "inputs": {
-      "email": "$.steps.getCustomer.response.email",
-      "connectionKey": "$.input.hubspotConnectionKey"
-    }
-  }
-}
-\`\`\`
-
-| Field | Type | Description |
-|---|---|---|
-| \`key\` | string | Flow key or path (supports selectors) |
-| \`inputs\` | object | Input values mapped to the sub-flow's declared inputs (supports selectors) |
-
-### \`paginate\` — Auto-collect paginated API results
-
-Automatically pages through a paginated API, collecting all results into a single array.
-
-\`\`\`json
-{
-  "id": "allMessages",
-  "name": "Fetch all Gmail messages",
-  "type": "paginate",
-  "paginate": {
-    "action": {
-      "platform": "gmail",
-      "actionId": "GMAIL_LIST_MESSAGES_ACTION_ID",
-      "connectionKey": "$.input.gmailKey",
-      "queryParams": { "maxResults": 100 }
-    },
-    "pageTokenField": "nextPageToken",
-    "resultsField": "messages",
-    "inputTokenParam": "queryParams.pageToken",
-    "maxPages": 10
-  }
-}
-\`\`\`
-
-| Field | Type | Description |
-|---|---|---|
-| \`action\` | FlowActionConfig | The API action to call (same format as action steps) |
-| \`pageTokenField\` | string | Dot-path in the API response to the next page token |
-| \`resultsField\` | string | Dot-path in the API response to the results array |
-| \`inputTokenParam\` | string | Dot-path in the action config where the page token is injected |
-| \`maxPages\` | number | Maximum pages to fetch, default: 10 |
-
-### \`bash\` — Execute shell commands
-
-Runs a shell command. **Requires \`--allow-bash\` flag** for security.
-
-\`\`\`json
-{
-  "id": "analyzeData",
-  "name": "Analyze data with Claude",
-  "type": "bash",
-  "bash": {
-    "command": "claude --print 'Analyze: {{$.steps.fetchData.response}}' --output-format json",
-    "timeout": 120000,
-    "parseJson": true
-  }
-}
-\`\`\`
-
-| Field | Type | Description |
-|---|---|---|
-| \`command\` | string | Shell command to execute (supports selectors and interpolation) |
-| \`timeout\` | number | Timeout in ms, default: 30000 |
-| \`parseJson\` | boolean | Parse stdout as JSON, default: false |
-| \`cwd\` | string | Working directory (supports selectors) |
-| \`env\` | object | Additional environment variables |
-
-**Security:** Bash steps are blocked by default. Pass \`--allow-bash\` to \`one flow execute\` to enable them.
-
-## 6. Error Handling
-
-### \`onError\` strategies
-
-\`\`\`json
-{
-  "id": "riskyStep",
-  "name": "Might fail",
-  "type": "action",
-  "onError": {
-    "strategy": "retry",
-    "retries": 3,
-    "retryDelayMs": 1000
-  },
-  "action": { "...": "..." }
-}
-\`\`\`
-
-| Strategy | Behavior |
-|---|---|
-| \`fail\` | Stop the flow immediately (default) |
-| \`continue\` | Mark step as failed, continue to next step |
-| \`retry\` | Retry up to N times with delay |
-| \`fallback\` | On failure, execute a different step |
-
-### Conditional execution
-
-Skip a step based on previous results:
-
-\`\`\`json
-{
-  "id": "sendEmail",
-  "name": "Send email only if customer found",
-  "type": "action",
-  "if": "$.steps.findCustomer.response.data.length > 0",
-  "action": { "...": "..." }
-}
-\`\`\`
-
-## 7. Updating Existing Workflows
-
-To modify an existing workflow:
-
-1. Read the workflow JSON file at \`.one/flows/<key>.flow.json\`
-2. Understand its current structure
-3. Use \`one --agent actions knowledge <platform> <actionId>\` for any new actions
-4. Modify the JSON (add/remove/update steps, change data mappings, add inputs)
-5. Write back the updated workflow file
-6. Validate: \`one --agent flow validate <key>\`
-
-## 8. Complete Examples
-
-### Example 1: Simple 2-step workflow — Search Stripe customer, send Gmail email
-
-\`\`\`json
-{
-  "key": "welcome-customer",
-  "name": "Welcome New Customer",
-  "description": "Look up a Stripe customer and send them a welcome email",
-  "version": "1",
-  "inputs": {
-    "stripeConnectionKey": {
-      "type": "string",
-      "required": true,
-      "description": "Stripe connection key",
-      "connection": { "platform": "stripe" }
-    },
-    "gmailConnectionKey": {
-      "type": "string",
-      "required": true,
-      "description": "Gmail connection key",
-      "connection": { "platform": "gmail" }
-    },
-    "customerEmail": {
-      "type": "string",
-      "required": true,
-      "description": "Customer email to look up"
-    }
-  },
-  "steps": [
-    {
-      "id": "findCustomer",
-      "name": "Search for customer in Stripe",
-      "type": "action",
-      "action": {
-        "platform": "stripe",
-        "actionId": "STRIPE_SEARCH_CUSTOMERS_ACTION_ID",
-        "connectionKey": "$.input.stripeConnectionKey",
-        "data": {
-          "query": "email:'{{$.input.customerEmail}}'"
-        }
-      }
-    },
-    {
-      "id": "sendWelcome",
-      "name": "Send welcome email via Gmail",
-      "type": "action",
-      "if": "$.steps.findCustomer.response.data && $.steps.findCustomer.response.data.length > 0",
-      "action": {
-        "platform": "gmail",
-        "actionId": "GMAIL_SEND_EMAIL_ACTION_ID",
-        "connectionKey": "$.input.gmailConnectionKey",
-        "data": {
-          "to": "{{$.input.customerEmail}}",
-          "subject": "Welcome, {{$.steps.findCustomer.response.data[0].name}}!",
-          "body": "Thank you for being a customer. We're glad to have you!"
-        }
-      }
-    }
-  ]
-}
-\`\`\`
-
-### Example 2: Conditional — Check if HubSpot contact exists, create or update
-
-\`\`\`json
-{
-  "key": "sync-hubspot-contact",
-  "name": "Sync Contact to HubSpot",
-  "description": "Check if a contact exists in HubSpot, create if new or update if existing",
-  "version": "1",
-  "inputs": {
-    "hubspotConnectionKey": {
-      "type": "string",
-      "required": true,
-      "connection": { "platform": "hub-spot" }
-    },
-    "email": { "type": "string", "required": true },
-    "firstName": { "type": "string", "required": true },
-    "lastName": { "type": "string", "required": true }
-  },
-  "steps": [
-    {
-      "id": "searchContact",
-      "name": "Search for existing contact",
-      "type": "action",
-      "action": {
-        "platform": "hub-spot",
-        "actionId": "HUBSPOT_SEARCH_CONTACTS_ACTION_ID",
-        "connectionKey": "$.input.hubspotConnectionKey",
-        "data": {
-          "filterGroups": [{ "filters": [{ "propertyName": "email", "operator": "EQ", "value": "$.input.email" }] }]
-        }
-      }
-    },
-    {
-      "id": "createOrUpdate",
-      "name": "Create or update contact",
-      "type": "condition",
-      "condition": {
-        "expression": "$.steps.searchContact.response.total > 0",
-        "then": [
-          {
-            "id": "updateContact",
-            "name": "Update existing contact",
-            "type": "action",
-            "action": {
-              "platform": "hub-spot",
-              "actionId": "HUBSPOT_UPDATE_CONTACT_ACTION_ID",
-              "connectionKey": "$.input.hubspotConnectionKey",
-              "pathVars": { "contactId": "$.steps.searchContact.response.results[0].id" },
-              "data": {
-                "properties": { "firstname": "$.input.firstName", "lastname": "$.input.lastName" }
-              }
-            }
-          }
-        ],
-        "else": [
-          {
-            "id": "createContact",
-            "name": "Create new contact",
-            "type": "action",
-            "action": {
-              "platform": "hub-spot",
-              "actionId": "HUBSPOT_CREATE_CONTACT_ACTION_ID",
-              "connectionKey": "$.input.hubspotConnectionKey",
-              "data": {
-                "properties": { "email": "$.input.email", "firstname": "$.input.firstName", "lastname": "$.input.lastName" }
-              }
-            }
-          }
-        ]
-      }
-    }
-  ]
-}
-\`\`\`
-
-### Example 3: Loop workflow — Iterate over Shopify orders, create invoices
-
-\`\`\`json
-{
-  "key": "shopify-to-invoices",
-  "name": "Shopify Orders to Invoices",
-  "description": "Fetch recent Shopify orders and create an invoice for each",
-  "version": "1",
-  "inputs": {
-    "shopifyConnectionKey": {
-      "type": "string",
-      "required": true,
-      "connection": { "platform": "shopify" }
-    },
-    "qbConnectionKey": {
-      "type": "string",
-      "required": true,
-      "connection": { "platform": "quick-books" }
-    }
-  },
-  "steps": [
-    {
-      "id": "listOrders",
-      "name": "List recent Shopify orders",
-      "type": "action",
-      "action": {
-        "platform": "shopify",
-        "actionId": "SHOPIFY_LIST_ORDERS_ACTION_ID",
-        "connectionKey": "$.input.shopifyConnectionKey",
-        "queryParams": { "status": "any", "limit": "50" }
-      }
-    },
-    {
-      "id": "createInvoices",
-      "name": "Create invoice for each order",
-      "type": "loop",
-      "loop": {
-        "over": "$.steps.listOrders.response.orders",
-        "as": "order",
-        "indexAs": "i",
-        "steps": [
-          {
-            "id": "createInvoice",
-            "name": "Create QuickBooks invoice",
-            "type": "action",
-            "onError": { "strategy": "continue" },
-            "action": {
-              "platform": "quick-books",
-              "actionId": "QB_CREATE_INVOICE_ACTION_ID",
-              "connectionKey": "$.input.qbConnectionKey",
-              "data": {
-                "Line": [
-                  {
-                    "Amount": "$.loop.order.total_price",
-                    "Description": "Shopify Order #{{$.loop.order.order_number}}"
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "summary",
-      "name": "Generate summary",
-      "type": "transform",
-      "transform": {
-        "expression": "({ totalOrders: $.steps.listOrders.response.orders.length, processed: $.steps.createInvoices.output.length })"
-      }
-    }
-  ]
-}
-\`\`\`
-
-## CLI Commands Reference
-
-\`\`\`bash
-# Create a workflow
-one --agent flow create <key> --definition '<json>'
-
-# List all workflows
-one --agent flow list
-
-# Validate a workflow
-one --agent flow validate <key>
-
-# Execute a workflow
-one --agent flow execute <key> -i connectionKey=value -i param=value
-
-# Execute with dry run (validate only)
-one --agent flow execute <key> --dry-run -i connectionKey=value
-
-# Execute with mock mode (dry-run + mock API responses, runs transforms/code normally)
-one --agent flow execute <key> --dry-run --mock -i connectionKey=value
-
-# Execute with bash steps enabled
-one --agent flow execute <key> --allow-bash -i connectionKey=value
-
-# Execute with verbose output
-one --agent flow execute <key> -v -i connectionKey=value
-
-# List workflow runs
-one --agent flow runs [flowKey]
-
-# Resume a paused/failed run
-one --agent flow resume <runId>
-\`\`\`
-
-## Important Notes
-
-- **Always use \`--agent\` flag** for structured JSON output
-- **Always call \`one actions knowledge\`** before adding an action step to a workflow
-- Platform names are **kebab-case** (e.g., \`hub-spot\`, not \`HubSpot\`)
-- Connection keys are **inputs**, not hardcoded — makes workflows portable and shareable
-- Use \`$.input.*\` for input values, \`$.steps.*\` for step results
-- Action IDs in examples (like \`STRIPE_SEARCH_CUSTOMERS_ACTION_ID\`) are placeholders — always use \`one actions search\` to find the real IDs
-- **Parallel step outputs** are accessible both by index (\`$.steps.parallelStep.output[0]\`) and by substep ID (\`$.steps.substepId.response\`)
-- **Loop step outputs** include iteration details via \`$.steps.myLoop.response.iterations[0].innerStepId.response\`
-- **Code steps** support \`await require('crypto')\`, \`await require('buffer')\`, \`await require('url')\`, \`await require('path')\` — \`fs\`, \`http\`, \`child_process\`, etc. are blocked
-- **Bash steps** require \`--allow-bash\` flag for security
-- **State is persisted** after every step completion — resume picks up where it left off
+- Connection keys are **inputs**, not hardcoded
+- Action IDs in examples are placeholders — always use \`actions search\`
+- Code steps allow \`crypto\`, \`buffer\`, \`url\`, \`path\` — \`fs\`, \`http\`, \`child_process\` are blocked
+- Bash steps require \`--allow-bash\` flag
+- State is persisted after every step — resume picks up where it left off
 `;
 
-type GuideTopic = 'overview' | 'actions' | 'flows' | 'all';
+export const GUIDE_RELAY = `# One Relay — Reference
+
+## Overview
+
+Webhook relay receives events from platforms (Stripe, GitHub, Airtable, Attio, Google Calendar) and forwards them to any connected platform using passthrough actions with Handlebars templates.
+
+## Commands
+
+\`\`\`bash
+one --agent relay event-types <platform>          # List available events
+one --agent relay create --connection-key <key> --create-webhook --event-filters '["event.type"]'
+one --agent relay activate <id> --actions '<json>' # Add forwarding actions
+one --agent relay list                             # List endpoints
+one --agent relay get <id>                         # Get endpoint details
+one --agent relay update <id> --actions '<json>'   # Update endpoint
+one --agent relay delete <id>                      # Delete endpoint
+one --agent relay events --platform <p>            # List received events
+one --agent relay event <id>                       # Get event with payload
+one --agent relay deliveries --endpoint-id <id>    # Check delivery status
+\`\`\`
+
+## Building a Relay
+
+1. **Discover connections** — identify source and destination platforms
+2. **Get event types** — \`one --agent relay event-types <platform>\`
+3. **Get source knowledge** — understand the incoming webhook payload shape (\`{{payload.*}}\` paths)
+4. **Get destination knowledge** — understand the outgoing API body shape
+5. **Create endpoint** — with \`--create-webhook\` and \`--event-filters\`
+6. **Activate** — with passthrough action mapping source fields to destination fields
+
+## Template Context
+
+| Variable | Description |
+|----------|-------------|
+| \`{{relayEventId}}\` | Unique event UUID |
+| \`{{platform}}\` | Source platform (e.g., \`stripe\`) |
+| \`{{eventType}}\` | Event type (e.g., \`customer.created\`) |
+| \`{{payload}}\` | Full incoming webhook body |
+| \`{{timestamp}}\` | When the event was received |
+| \`{{connectionId}}\` | Source connection UUID |
+| \`{{json payload}}\` | Embed full payload as JSON string |
+
+Access nested fields: \`{{payload.data.object.email}}\`
+
+## Action Types
+
+**passthrough** (primary) — forward to another platform's API:
+\`\`\`json
+{
+  "type": "passthrough",
+  "actionId": "<action-id>",
+  "connectionKey": "<dest-connection-key>",
+  "body": { "channel": "#alerts", "text": "New customer: {{payload.data.object.name}}" },
+  "eventFilters": ["customer.created"]
+}
+\`\`\`
+
+**url** — forward raw event to a URL:
+\`\`\`json
+{"type": "url", "url": "https://your-app.com/webhook", "eventFilters": ["customer.created"]}
+\`\`\`
+
+**agent** — send to an agent:
+\`\`\`json
+{"type": "agent", "agentId": "<uuid>", "eventFilters": ["customer.created"]}
+\`\`\`
+
+## Supported Source Platforms
+
+Airtable, Attio, GitHub, Google Calendar, Stripe
+
+Any connected platform can be a destination via passthrough actions.
+
+## Debugging
+
+1. \`relay get <id>\` — verify endpoint is active with actions configured
+2. \`relay events --platform <p>\` — check events are arriving
+3. \`relay deliveries --event-id <id>\` — check delivery status and errors
+4. \`relay event <id>\` — inspect full payload to verify template paths
+`;
+
+type GuideTopic = 'overview' | 'actions' | 'flows' | 'relay' | 'all';
 
 const TOPICS: { topic: GuideTopic; description: string }[] = [
-  { topic: 'overview', description: 'Setup, --agent flag, discovery workflow' },
+  { topic: 'overview', description: 'Setup, features, and quick start for each' },
   { topic: 'actions', description: 'Search, read docs, and execute platform actions' },
   { topic: 'flows', description: 'Build and execute multi-step workflows' },
+  { topic: 'relay', description: 'Receive webhooks and forward to other platforms' },
   { topic: 'all', description: 'Complete guide (all topics combined)' },
 ];
 
@@ -917,14 +345,49 @@ export function getGuideContent(topic: GuideTopic): { title: string; content: st
       return { title: 'One CLI — Agent Guide: Actions', content: GUIDE_ACTIONS };
     case 'flows':
       return { title: 'One CLI — Agent Guide: Workflows', content: GUIDE_FLOWS };
+    case 'relay':
+      return { title: 'One CLI — Agent Guide: Relay', content: GUIDE_RELAY };
     case 'all':
       return {
         title: 'One CLI — Agent Guide: Complete',
-        content: [GUIDE_OVERVIEW, GUIDE_ACTIONS, GUIDE_FLOWS].join('\n---\n\n'),
+        content: [GUIDE_OVERVIEW, GUIDE_ACTIONS, GUIDE_FLOWS, GUIDE_RELAY].join('\n---\n\n'),
       };
   }
 }
 
 export function getAvailableTopics(): { topic: string; description: string }[] {
   return TOPICS;
+}
+
+// Platform demo actions (used by onboard)
+export const PLATFORM_DEMO_ACTIONS: Record<string, { description: string; query: string }> = {
+  'gmail': { description: 'List recent emails', query: 'list messages' },
+  'google-calendar': { description: 'List upcoming events', query: 'list events' },
+  'slack': { description: 'List channels', query: 'list channels' },
+  'shopify': { description: 'List products', query: 'list products' },
+  'hub-spot': { description: 'List contacts', query: 'list contacts' },
+  'github': { description: 'List repositories', query: 'list repos' },
+  'stripe': { description: 'List customers', query: 'list customers' },
+  'notion': { description: 'Search pages', query: 'search' },
+  'airtable': { description: 'List bases', query: 'list bases' },
+  'linear': { description: 'List issues', query: 'list issues' },
+};
+
+export function getWorkflowExamples(connectedPlatforms: string[]): string[] {
+  const examples: string[] = [];
+  const has = (p: string) => connectedPlatforms.includes(p);
+
+  if (has('gmail') && has('slack')) examples.push('Gmail → Slack: Forward important emails to a channel');
+  if (has('stripe') && has('slack')) examples.push('Stripe → Slack: Notify on new payments');
+  if (has('shopify') && has('gmail')) examples.push('Shopify → Gmail: Send order confirmation emails');
+  if (has('hub-spot') && has('gmail')) examples.push('HubSpot → Gmail: Auto-email new leads');
+  if (has('github') && has('slack')) examples.push('GitHub → Slack: Notify on new issues/PRs');
+
+  if (examples.length === 0) {
+    examples.push('Connect 2+ platforms to unlock cross-platform workflows');
+    examples.push('Example: Stripe + Slack → Notify on new payments');
+    examples.push('Example: Gmail + HubSpot → Auto-create contacts from emails');
+  }
+
+  return examples;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,8 @@ export interface Connection {
   platform: string;
   key: string;
   state: 'operational' | 'degraded' | 'failed' | 'unknown';
+  name?: string;
+  tags?: string[];
   createdAt?: string;
 }
 
@@ -104,5 +106,77 @@ export interface SanitizedRequestConfig {
 export interface ExecutePassthroughResponse {
   requestConfig: SanitizedRequestConfig;
   responseData: unknown;
+}
+
+// Webhook Relay types
+
+export type RelayAction =
+  | { type: 'url'; url: string; secret?: string; eventFilters?: string[]; hasSecret?: boolean }
+  | { type: 'passthrough'; actionId: string; connectionKey: string; body?: unknown; headers?: unknown; query?: unknown; eventFilters?: string[] }
+  | { type: 'agent'; agentId: string; eventFilters?: string[] };
+
+export interface RelayEndpoint {
+  id: string;
+  connectionId: string;
+  userId: string;
+  url: string;
+  active: boolean;
+  deleted: boolean;
+  description?: string;
+  eventFilters?: string[];
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  actions: RelayAction[];
+  webhookPayload?: unknown;
+  warning?: string;
+  version?: string;
+  changeLog?: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RelayEvent {
+  id: string;
+  connectionId: string;
+  userId: string;
+  platform: string;
+  eventType: string;
+  payload: unknown;
+  headers?: unknown;
+  metadata?: unknown;
+  signatureValid?: boolean;
+  active: boolean;
+  deleted: boolean;
+  timestamp: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RelayDelivery {
+  id: string;
+  relayEventId: string;
+  endpointId: string;
+  actionIndex: number;
+  status: string;
+  statusCode?: number;
+  responseBody?: string;
+  error?: string;
+  attempt: number;
+  deliveredAt?: string;
+  createdAt: string;
+}
+
+export interface RelayEndpointsResponse {
+  rows: RelayEndpoint[];
+  total: number;
+  pages: number;
+  page: number;
+}
+
+export interface RelayEventsResponse {
+  rows: RelayEvent[];
+  total: number;
+  pages: number;
+  page: number;
 }
 


### PR DESCRIPTION
## Summary
- **Relay CLI commands** — 10 new commands under `one relay` (create, list, get, update, delete, activate, events, event, deliveries, event-types) for setting up webhook event forwarding between platforms
- **Relay skill** (`skills/one-relay/SKILL.md`) — teaches agents the full workflow: discover connections → get event types → get knowledge for source + destination → create relay → activate with passthrough actions using Handlebars templates
- **Guide rewrite** — replaced 930 lines of stale duplicate content with concise topic-based references (~300 lines), added `relay` topic, each section now routes to skills for details
- **Onboarding update** — CLAUDE.md content now includes "learn before you use" instruction and relay quick reference
- **Connection list** — now includes `tags` and `name` fields so agents can distinguish connections (e.g., test vs production Stripe)

## Test plan
- [x] Sub-agent successfully built Stripe → Slack relay using only CLI commands
- [x] Sub-agent completed full test: onboard → execute action → build flow → set up relay
- [x] All 10 relay commands verified against live API
- [x] `npm run build` passes
- [x] Create GitHub release tag `v1.15.0` after merge to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)