### PR TITLE
chore: bump version to 1.18.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,16 @@ Do NOT run `npm publish` directly. The release is automated via GitHub.
 5. Once merged to `main`, create a **release tag** in GitHub for that version
 6. The GitHub release triggers the automated deploy to npm
 
+### Version bump checklist
+
+Every feature PR must include a version bump before shipping:
+
+1. Bump `version` in `package.json` (semver: patch for fixes, minor for features, major for breaking)
+2. Run `npm install` so `package-lock.json` updates
+3. Commit both `package.json` and `package-lock.json` in the same PR
+
+Do NOT forget this — the PR cannot be released without it.
+
 ### Branch workflow
 
 Always create a branch and PR for changes — do not commit directly to `main`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.17.2",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-<<<<<<< HEAD
-      "version": "1.17.2",
-=======
-      "version": "1.17.1",
->>>>>>> origin/main
+      "version": "1.18.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.17.2",
+  "version": "1.18.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

- Bump version to 1.18.0 for the local caching feature release
- Update package-lock.json
- Add version bump checklist to CLAUDE.md

## Test plan

- [x] `package.json` shows 1.18.0
- [x] `package-lock.json` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)