### PR TITLE
docs: improve parallel step examples and guidance in flow skill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -172,13 +172,46 @@ A pure `$.xxx` value resolves to the raw type. A string containing `{{$.xxx}}` d
 
 ### `parallel` — Run steps concurrently
 
+Use when fetching from 2+ independent data sources before combining results. Each substep must have the full step schema (`id`, `name`, `type`, and type-specific config).
+
 ```json
 {
-  "id": "lookups",
+  "id": "fetchAll",
+  "name": "Fetch email and calendar data in parallel",
   "type": "parallel",
-  "parallel": { "maxConcurrency": 5, "steps": [...] }
+  "parallel": {
+    "maxConcurrency": 5,
+    "steps": [
+      {
+        "id": "fetchEmails",
+        "name": "Fetch recent emails",
+        "type": "action",
+        "action": {
+          "platform": "gmail",
+          "actionId": "conn_mod_def::GmailListMessages::xxx",
+          "connectionKey": "$.input.gmailKey",
+          "pathVars": { "userId": "me" },
+          "queryParams": { "maxResults": 10 }
+        }
+      },
+      {
+        "id": "fetchEvents",
+        "name": "Fetch today's calendar events",
+        "type": "action",
+        "action": {
+          "platform": "google-calendar",
+          "actionId": "conn_mod_def::CalendarListEvents::xxx",
+          "connectionKey": "$.input.calendarKey",
+          "pathVars": { "calendarId": "primary" },
+          "queryParams": { "maxResults": 10 }
+        }
+      }
+    ]
+  }
 }
 ```
+
+After a parallel step, access each substep's output by its `id`: `$.steps.fetchEmails.response`, `$.steps.fetchEvents.response`.
 
 ### `file-read` / `file-write` — Filesystem access
 
@@ -247,7 +280,18 @@ Strategies: `fail` (default), `continue`, `retry`, `fallback`.
 
 Conditional execution: `"if": "$.steps.find.response.data.length > 0"`
 
-## AI-Augmented Pattern: file-write -> bash -> code
+## AI-Augmented Patterns
+
+### When to use parallel steps
+
+Use `parallel` when your workflow fetches from 2+ independent data sources before combining them. Common patterns:
+- Fetch Gmail + Calendar + Sheets → compile into daily briefing
+- Search Exa + scrape with Firecrawl → merge research data
+- Query BigQuery + list Google Drive files → combine for analysis
+
+Each substep inside `parallel.steps` must have the full step schema: `id`, `name`, `type`, and the type-specific config (`action`, `code`, etc.). Follow a parallel step with a `code` or `transform` step to combine the results.
+
+### file-write -> bash -> code
 
 When raw data needs analysis, use this pattern:
 1. `file-write` — save data to temp file (API responses are too large to inline)


### PR DESCRIPTION
## Summary

Closes #16

AI agents almost never use the `parallel` step type when building workflows, even when the workflow has independent data fetches that could run concurrently. Two root causes:

1. The parallel step reference had a minimal 4-line skeleton with `[...]` placeholders, giving the AI no indication of what substeps should look like
2. All prominent examples and the AI-Augmented Patterns section were entirely sequential, so agents modeled their work after those

### Changes

- **Expanded the `parallel` step reference** with a complete example showing two full substeps (Gmail + Calendar actions) with all required fields (`id`, `name`, `type`, and type-specific config). Added a note showing how to access substep results via `$.steps.<id>.response`.

- **Added a "When to use parallel steps" subsection** under AI-Augmented Patterns with common parallel use cases (multi-platform fetches, search + scrape, query + list) and a reminder that each substep must use the full step schema.

- **Bumped version to 1.20.2**