### PR TITLE
feat: folder-layout flows + code modules + executor safety rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ one flow validate welcome-customer
 one flow execute welcome-customer -i email=jane@example.com
 ```
 
-Workflows are stored as JSON at `.one/flows/<key>.flow.json` and support conditions, loops, while loops, parallel steps, transforms, sub-flows, pagination, bash steps, and more. Run `one guide flows` for the full reference.
+Workflows live under `.one/flows/<key>/flow.json` with an optional `lib/` subfolder for `.mjs` code modules — create new flows in this folder layout. (The legacy single-file layout `.one/flows/<key>.flow.json` is deprecated but still loads for backward compatibility.) Flows support conditions, loops, while loops, parallel steps, transforms, sub-flows, pagination, bash steps, and external `.mjs` code modules. Run `one guide flows` for the full reference.
 
 ## How it works
 
@@ -284,7 +284,7 @@ In agent mode (`--agent`), the JSON response includes the guide content and an `
 
 ### `one flow create [key]`
 
-Create a workflow from a JSON definition. Workflows are saved to `.one/flows/<key>.flow.json`.
+Create a workflow from a JSON definition. New workflows are always saved to the folder layout at `.one/flows/<key>/flow.json` (with a `lib/` subfolder scaffolded for code modules). The legacy `.one/flows/<key>.flow.json` single-file layout is deprecated; existing legacy files continue to load and run unchanged for backward compatibility.
 
 ```bash
 # From a --definition flag
@@ -300,7 +300,7 @@ one flow create my-flow --definition '...' -o ./custom/path.json
 | Option | What it does |
 |--------|-------------|
 | `--definition <json>` | Workflow definition as a JSON string |
-| `-o, --output <path>` | Custom output path (default: `.one/flows/<key>.flow.json`) |
+| `-o, --output <path>` | Custom output path (default: `.one/flows/<key>/flow.json`) |
 
 ### `one flow execute <key>`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.20.3",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.20.3",
+      "version": "1.21.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.20.3",
+  "version": "1.21.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -1,6 +1,33 @@
 # One Workflows — Multi-Step API Workflows
 
-Workflows chain actions across platforms as JSON files stored at `.one/flows/<key>.flow.json`. Like n8n/Zapier but file-based.
+Workflows chain actions across platforms. Like n8n/Zapier but file-based.
+
+## Before you execute a flow you did NOT author — READ THIS
+
+Nothing about a flow's runtime requirements is guessable from its name. Before `flow execute`, do one of these:
+
+1. **Recommended:** `one --agent flow list` — the JSON output includes `requiresBash`, `usesCodeModules`, `inputs` (with `autoResolvable`), `stepTypes`, and the flow's `description`. Fastest path to knowing what you need.
+2. Read the flow's `description` field from the JSON. Authors are required (see "Author conventions" below) to state `--allow-bash` requirements and non-auto-resolving inputs there.
+3. `one --agent flow execute <key> --dry-run` to see resolved inputs and step plan without side effects.
+
+If you skip this, you will hit errors like *"Workflow X contains bash steps. Re-run with --allow-bash."* — the CLI pre-flights and fails fast, but the error is entirely avoidable by reading first.
+
+## Author conventions — write flows that are safe to execute blind
+
+The `description` field is the contract with future executors. It MUST state:
+
+- **`--allow-bash` if any step is type `bash`.** e.g. *"Fetches recent Gmail and summarizes with Claude Haiku. Requires `--allow-bash`."*
+- **Every input that does NOT have a `connection` hint.** Connection inputs auto-resolve when exactly one matching connection exists; everything else must be passed via `-i name=value`.
+- **Any files/directories the flow writes to.**
+
+If a flow's description doesn't tell you how to run it, treat that as a bug in the flow and fix it.
+
+**Storage layout:**
+
+- **Folder layout (REQUIRED for new flows):** `.one/flows/<key>/flow.json`, with an optional `lib/` subfolder for `.mjs` code modules. Like a skill — the folder groups the spec with its helper code, so the whole flow is shareable. **Always create new flows here.**
+- **Legacy single-file layout (DEPRECATED):** `.one/flows/<key>.flow.json`. Still loads and runs for backward compatibility, but do not create new flows in this layout. When touching an existing single-file flow, migrate it: move `<key>.flow.json` to `<key>/flow.json` and extract any non-trivial `code.source` blocks into `<key>/lib/*.mjs` modules.
+
+`one flow create` always writes the folder layout.
 
 ## Building a Workflow
 
@@ -37,7 +64,65 @@ You MUST call knowledge for every action in the workflow — it tells you the ex
 one --agent flow create <key> --definition '<json>'
 ```
 
-Or write directly to `.one/flows/<key>.flow.json`.
+Or write directly to `.one/flows/<key>/flow.json` (folder layout) or the legacy `.one/flows/<key>.flow.json`.
+
+### Code modules (`lib/` folder)
+
+A `code` step can reference an external `.mjs` module instead of inlining JS as a JSON string:
+
+```
+.one/flows/my-flow/
+├── flow.json
+└── lib/
+    └── process-data.mjs
+```
+
+```js
+// lib/process-data.mjs
+const $ = JSON.parse(await new Response(process.stdin).text());
+const items = $.steps.fetch.response.data ?? [];
+process.stdout.write(JSON.stringify(items.filter(i => i.active)));
+```
+
+```json
+{
+  "id": "processData",
+  "name": "Process",
+  "type": "code",
+  "code": { "module": "lib/process-data.mjs" }
+}
+```
+
+The module runs as a child `node` process: the flow context `$` is piped to stdin as JSON, and stdout is parsed as JSON and used as the step's output. Modules have full Node APIs available (unlike inline `code.source`, which is sandboxed). Use `code.module` for anything non-trivial; keep `code.source` for one-liners.
+
+Whatever JSON a module writes to stdout becomes both `$.steps.<id>.output` and `$.steps.<id>.response` (aliases). Downstream steps can reference either.
+
+### Migrating a legacy single-file flow
+
+If you touch an existing `.one/flows/<key>.flow.json`, migrate it:
+
+1. `mkdir -p .one/flows/<key>/lib`
+2. `mv .one/flows/<key>.flow.json .one/flows/<key>/flow.json`
+3. Extract non-trivial `code.source` blocks into `lib/<step-id>.mjs` and swap the step config from `{ "source": "..." }` to `{ "module": "lib/<step-id>.mjs" }`. One-liners can stay inline.
+4. `one --agent flow validate <key>`
+5. Execute and confirm behavior is unchanged.
+
+**Inline source → module translation.** Inline `code.source` is an async function body where `$` is in scope and you `return` the result. A module reads `$` from stdin and writes the result to stdout. Mechanical transform:
+
+Before (inline):
+```js
+const items = $.steps.fetch.response.data;
+return { active: items.filter(i => i.active) };
+```
+
+After (`lib/<step-id>.mjs`):
+```js
+const $ = JSON.parse(await new Response(process.stdin).text());
+const items = $.steps.fetch.response.data;
+process.stdout.write(JSON.stringify({ active: items.filter(i => i.active) }));
+```
+
+Two rules: (1) prepend the stdin-read line, (2) replace `return X` with `process.stdout.write(JSON.stringify(X))`.
 
 ### Step 5: Validate
 

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -4,7 +4,7 @@ import { OneApi } from '../lib/api.js';
 import * as output from '../lib/output.js';
 import { printTable } from '../lib/table.js';
 import { validateFlow } from '../lib/flow-validator.js';
-import { FlowRunner, loadFlow, listFlows, saveFlow, resolveFlowPath } from '../lib/flow-runner.js';
+import { FlowRunner, loadFlowWithMeta, listFlows, saveFlow, resolveFlowPath, flowRequiresBash } from '../lib/flow-runner.js';
 import type { Flow, FlowEvent } from '../lib/flow-types.js';
 import type { PermissionLevel } from '../lib/types.js';
 import fs from 'node:fs';
@@ -159,8 +159,13 @@ export async function flowExecuteCommand(
   spinner.start(`Loading workflow "${keyOrPath}"...`);
 
   let flow: Flow;
+  let rootDir: string;
+  let flowFilePath: string;
   try {
-    flow = loadFlow(keyOrPath);
+    const loaded = loadFlowWithMeta(keyOrPath);
+    flow = loaded.flow;
+    rootDir = loaded.rootDir;
+    flowFilePath = loaded.filePath;
   } catch (err) {
     spinner.stop('Workflow not found');
     output.error(err instanceof Error ? err.message : String(err));
@@ -168,6 +173,27 @@ export async function flowExecuteCommand(
   }
 
   spinner.stop(`Workflow: ${flow.name} (${flow.steps.length} steps)`);
+
+  // Deprecation warning: legacy single-file layout (`.one/flows/<key>.flow.json`)
+  if (flowFilePath.endsWith('.flow.json')) {
+    const msg = `Workflow "${flow.key}" uses the deprecated single-file layout. Migrate to .one/flows/${flow.key}/flow.json (see: one guide flows).`;
+    if (output.isAgentMode()) {
+      output.json({ event: 'flow:deprecation', flowKey: flow.key, warning: msg });
+    } else {
+      console.error(pc.yellow(`⚠ ${msg}`));
+    }
+  }
+
+  // Pre-flight: if the flow has bash steps, require --allow-bash upfront so
+  // we fail fast instead of partway through a long run.
+  if (!options.allowBash && flowRequiresBash(flow)) {
+    const msg = `Workflow "${flow.key}" contains bash steps. Re-run with --allow-bash to permit shell execution.`;
+    if (output.isAgentMode()) {
+      output.json({ error: msg, requiresBash: true, flowKey: flow.key });
+      process.exit(1);
+    }
+    output.error(msg);
+  }
 
   const inputs = parseInputs(options.input || []);
   const resolvedInputs = await autoResolveConnectionInputs(flow, inputs, api);
@@ -212,6 +238,7 @@ export async function flowExecuteCommand(
       mock: options.mock,
       verbose: options.verbose,
       allowBash: options.allowBash,
+      rootDir,
       onEvent,
     });
 
@@ -291,16 +318,18 @@ export async function flowListCommand(): Promise<void> {
     [
       { key: 'key', label: 'Key' },
       { key: 'name', label: 'Name' },
-      { key: 'description', label: 'Description' },
+      { key: 'layout', label: 'Layout' },
       { key: 'inputCount', label: 'Inputs' },
       { key: 'stepCount', label: 'Steps' },
+      { key: 'flags', label: 'Requires' },
     ],
     flows.map(f => ({
       key: f.key,
       name: f.name,
-      description: f.description || '',
+      layout: f.layout,
       inputCount: String(f.inputCount),
       stepCount: String(f.stepCount),
+      flags: f.requiresBash ? '--allow-bash' : '',
     })),
   );
   console.log();
@@ -366,8 +395,11 @@ export async function flowResumeCommand(runId: string): Promise<void> {
   const api = new OneApi(apiKey, getApiBase());
 
   let flow: Flow;
+  let rootDir: string;
   try {
-    flow = loadFlow(state!.flowKey);
+    const loaded = loadFlowWithMeta(state!.flowKey);
+    flow = loaded.flow;
+    rootDir = loaded.rootDir;
   } catch (err) {
     output.error(`Could not load workflow "${state!.flowKey}": ${err instanceof Error ? err.message : String(err)}`);
     return;
@@ -385,7 +417,7 @@ export async function flowResumeCommand(runId: string): Promise<void> {
   spinner.start(`Resuming run ${runId} (${state!.completedSteps.length} steps already completed)...`);
 
   try {
-    const context = await runner.resume(flow, api, permissions, actionIds, { onEvent });
+    const context = await runner.resume(flow, api, permissions, actionIds, { onEvent, rootDir });
     spinner.stop('Workflow completed');
 
     if (output.isAgentMode()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,7 +237,7 @@ flow
   .command('create [key]')
   .description('Create a new workflow from JSON definition')
   .option('--definition <json>', 'Workflow definition as JSON string')
-  .option('-o, --output <path>', 'Custom output path (default .one/flows/<key>.flow.json)')
+  .option('-o, --output <path>', 'Custom output path (default .one/flows/<key>/flow.json)')
   .action(async (key: string | undefined, options: { definition?: string; output?: string }) => {
     await flowCreateCommand(key, options);
   });

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { exec } from 'node:child_process';
+import { exec, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { OneApi } from './api.js';
 import { isMethodAllowed, isActionAllowed } from './api.js';
@@ -216,13 +216,104 @@ function executeTransformStep(step: FlowStep, context: FlowContext): StepResult 
   return { status: 'success', output, response: output };
 }
 
-async function executeCodeStep(step: FlowStep, context: FlowContext): Promise<StepResult> {
-  const source = step.code!.source;
+async function executeCodeStep(
+  step: FlowStep,
+  context: FlowContext,
+  options: FlowExecuteOptions,
+): Promise<StepResult> {
+  const config = step.code!;
+
+  if (config.module) {
+    const output = await executeCodeModule(step.id, config.module, context, options);
+    return { status: 'success', output, response: output };
+  }
+
+  if (typeof config.source !== 'string') {
+    throw new Error(`Code step "${step.id}" must define either "source" or "module"`);
+  }
+
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
   const sandboxedRequire = createSandboxedRequire();
-  const fn = new AsyncFunction('$', 'require', source);
+  const fn = new AsyncFunction('$', 'require', config.source);
   const output = await fn(context, sandboxedRequire);
   return { status: 'success', output, response: output };
+}
+
+/**
+ * Execute a code step that references an external .mjs module. The module is
+ * spawned as a child `node` process; the flow context `$` is piped to stdin
+ * as JSON and the module's stdout is parsed as JSON and returned.
+ *
+ * Contract for module authors (see guide):
+ *
+ *   const $ = JSON.parse(await new Response(process.stdin).text());
+ *   // ...compute...
+ *   process.stdout.write(JSON.stringify(result));
+ */
+async function executeCodeModule(
+  stepId: string,
+  modulePath: string,
+  context: FlowContext,
+  options: FlowExecuteOptions,
+): Promise<unknown> {
+  const rootDir = options.rootDir;
+  if (!rootDir) {
+    throw new Error(`Code step "${stepId}" uses module "${modulePath}" but no flow rootDir is available. Flows that use code modules must be loaded via loadFlowWithMeta.`);
+  }
+
+  // Safety: reject absolute paths and path traversal outside rootDir.
+  if (path.isAbsolute(modulePath)) {
+    throw new Error(`Code module path must be relative to the flow root, got absolute: "${modulePath}"`);
+  }
+  const absPath = path.resolve(rootDir, modulePath);
+  const relFromRoot = path.relative(rootDir, absPath);
+  if (relFromRoot.startsWith('..') || path.isAbsolute(relFromRoot)) {
+    throw new Error(`Code module "${modulePath}" resolves outside the flow directory`);
+  }
+
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Code module not found: ${absPath}`);
+  }
+
+  // Strip `env` — don't leak process.env into arbitrary user scripts via $.
+  const { env: _omitEnv, ...safeContext } = context;
+  void _omitEnv;
+  const stdinPayload = JSON.stringify(safeContext);
+
+  return await new Promise<unknown>((resolve, reject) => {
+    const child = spawn(process.execPath, [absPath], {
+      cwd: rootDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on('data', (c: Buffer) => stdoutChunks.push(c));
+    child.stderr.on('data', (c: Buffer) => stderrChunks.push(c));
+
+    child.on('error', err => reject(err));
+    child.on('close', (code) => {
+      const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+      if (code !== 0) {
+        reject(new Error(`Code module "${modulePath}" exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`));
+        return;
+      }
+      const trimmed = stdout.trim();
+      if (trimmed === '') {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(stripCodeFences(trimmed)));
+      } catch (err) {
+        reject(new Error(`Code module "${modulePath}" did not print valid JSON to stdout: ${(err as Error).message}`));
+      }
+    });
+
+    child.stdin.write(stdinPayload);
+    child.stdin.end();
+  });
 }
 
 async function executeConditionStep(
@@ -482,16 +573,17 @@ async function executeSubflowStep(
   }
 
   // Dynamic import to avoid circular dependency at module level
-  const { loadFlow } = await import('./flow-runner.js');
-  const subFlow = loadFlow(resolvedKey);
+  const { loadFlowWithMeta } = await import('./flow-runner.js');
+  const { flow: subFlow, rootDir: subRootDir } = loadFlowWithMeta(resolvedKey);
 
+  // Sub-flows resolve their own code modules against their own rootDir.
   const subContext = await executeFlow(
     subFlow,
     resolvedInputs,
     api,
     permissions,
     allowedActionIds,
-    options,
+    { ...options, rootDir: subRootDir },
     undefined,
     [...flowStack, resolvedKey],
   );
@@ -671,7 +763,7 @@ export async function executeSingleStep(
           result = executeTransformStep(step, context);
           break;
         case 'code':
-          result = await executeCodeStep(step, context);
+          result = await executeCodeStep(step, context, options);
           break;
         case 'condition':
           result = await executeConditionStep(step, context, api, permissions, allowedActionIds, options, flowStack);

--- a/src/lib/flow-runner.ts
+++ b/src/lib/flow-runner.ts
@@ -11,6 +11,8 @@ import type {
   FlowExecuteOptions,
 } from './flow-types.js';
 import { executeFlow } from './flow-engine.js';
+import { getNestedStepsKeys } from './flow-schema.js';
+import type { FlowStep, FlowStepType } from './flow-types.js';
 
 const FLOWS_DIR = '.one/flows';
 const RUNS_DIR = '.one/flows/.runs';
@@ -276,60 +278,208 @@ export class FlowRunner {
 
 // ── Flow File Helpers ──
 
+/**
+ * Resolve a flow key or path to its file location.
+ *
+ * Resolution order for bare keys:
+ *   1. `.one/flows/<key>/flow.json` (folder layout — preferred for new flows)
+ *   2. `.one/flows/<key>.flow.json` (legacy single-file layout)
+ *
+ * Returns the first existing path. If neither exists, returns the folder-layout
+ * path so error messages point at the modern convention.
+ */
 export function resolveFlowPath(keyOrPath: string): string {
-  // If it looks like a file path (contains / or \ or ends with .json)
+  // Explicit path or .json filename → use as-is
   if (keyOrPath.includes('/') || keyOrPath.includes('\\') || keyOrPath.endsWith('.json')) {
     return path.resolve(keyOrPath);
   }
-  // Otherwise treat as a flow key
-  return path.resolve(FLOWS_DIR, `${keyOrPath}.flow.json`);
+  const folderPath = path.resolve(FLOWS_DIR, keyOrPath, 'flow.json');
+  const legacyPath = path.resolve(FLOWS_DIR, `${keyOrPath}.flow.json`);
+  if (fs.existsSync(folderPath)) return folderPath;
+  if (fs.existsSync(legacyPath)) return legacyPath;
+  return folderPath;
+}
+
+/**
+ * Given a flow's JSON file path, return the directory that code modules
+ * should resolve against. For folder flows this is the directory containing
+ * `flow.json`; for legacy single-file flows it's `.one/flows/`.
+ */
+export function getFlowRootDir(flowFilePath: string): string {
+  const dir = path.dirname(flowFilePath);
+  const base = path.basename(flowFilePath);
+  // Folder layout: <key>/flow.json → root is <key>/
+  if (base === 'flow.json') return dir;
+  // Legacy: .one/flows/<key>.flow.json → root is .one/flows/
+  return dir;
+}
+
+export interface LoadedFlow {
+  flow: Flow;
+  filePath: string;
+  rootDir: string;
+}
+
+export function loadFlowWithMeta(keyOrPath: string): LoadedFlow {
+  const filePath = resolveFlowPath(keyOrPath);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Flow not found: ${filePath}`);
+  }
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const flow = JSON.parse(content) as Flow;
+  return { flow, filePath, rootDir: getFlowRootDir(filePath) };
 }
 
 export function loadFlow(keyOrPath: string): Flow {
-  const flowPath = resolveFlowPath(keyOrPath);
-
-  if (!fs.existsSync(flowPath)) {
-    throw new Error(`Flow not found: ${flowPath}`);
-  }
-
-  const content = fs.readFileSync(flowPath, 'utf-8');
-  return JSON.parse(content) as Flow;
+  return loadFlowWithMeta(keyOrPath).flow;
 }
 
-export function listFlows(): { key: string; name: string; description?: string; inputCount: number; stepCount: number; path: string }[] {
+/**
+ * Walk a flow's steps (including nested steps in condition/loop/parallel/while)
+ * and invoke `visit` for each step. Returns true if any visit returned true —
+ * useful for "does this flow contain a bash step" type queries.
+ */
+export function walkSteps(steps: FlowStep[], visit: (step: FlowStep) => boolean | void): boolean {
+  const nested = getNestedStepsKeys();
+  for (const step of steps) {
+    if (visit(step)) return true;
+    for (const { configKey, fieldName } of nested) {
+      const config = (step as Record<string, unknown>)[configKey] as Record<string, unknown> | undefined;
+      if (config && Array.isArray(config[fieldName])) {
+        if (walkSteps(config[fieldName] as FlowStep[], visit)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Collect unique step types used in the flow (recursively). */
+export function collectStepTypes(flow: Flow): FlowStepType[] {
+  const types = new Set<FlowStepType>();
+  walkSteps(flow.steps, step => { types.add(step.type); });
+  return Array.from(types).sort();
+}
+
+/** True if any step (recursively) is a bash step. */
+export function flowRequiresBash(flow: Flow): boolean {
+  return walkSteps(flow.steps, step => step.type === 'bash');
+}
+
+/** True if any code step (recursively) uses an external module file. */
+export function flowUsesCodeModules(flow: Flow): boolean {
+  return walkSteps(flow.steps, step => step.type === 'code' && !!step.code?.module);
+}
+
+export interface FlowInputSummary {
+  name: string;
+  type: string;
+  required: boolean;
+  default?: unknown;
+  description?: string;
+  connection?: { platform: string };
+  autoResolvable: boolean;
+}
+
+export function summarizeFlowInputs(flow: Flow): FlowInputSummary[] {
+  return Object.entries(flow.inputs).map(([name, decl]) => ({
+    name,
+    type: decl.type,
+    required: decl.required !== false,
+    default: decl.default,
+    description: decl.description,
+    connection: decl.connection,
+    // An input is auto-resolvable if it points to a connection (the engine
+    // will pick it automatically when exactly one matching connection exists).
+    autoResolvable: !!decl.connection,
+  }));
+}
+
+type FlowListEntry = {
+  key: string;
+  name: string;
+  description?: string;
+  inputCount: number;
+  stepCount: number;
+  path: string;
+  layout: 'folder' | 'legacy';
+  stepTypes: FlowStepType[];
+  requiresBash: boolean;
+  usesCodeModules: boolean;
+  inputs: FlowInputSummary[];
+};
+
+export function listFlows(): FlowListEntry[] {
   const flowsDir = path.resolve(FLOWS_DIR);
   if (!fs.existsSync(flowsDir)) return [];
 
-  const files = fs.readdirSync(flowsDir).filter(f => f.endsWith('.flow.json'));
-  const flows: { key: string; name: string; description?: string; inputCount: number; stepCount: number; path: string }[] = [];
+  const flows: FlowListEntry[] = [];
+  const seenKeys = new Set<string>();
 
-  for (const file of files) {
+  const readFlowFile = (filePath: string): void => {
     try {
-      const content = fs.readFileSync(path.join(flowsDir, file), 'utf-8');
+      const content = fs.readFileSync(filePath, 'utf-8');
       const flow = JSON.parse(content) as Flow;
+      if (seenKeys.has(flow.key)) return;
+      seenKeys.add(flow.key);
       flows.push({
         key: flow.key,
         name: flow.name,
         description: flow.description,
         inputCount: Object.keys(flow.inputs).length,
         stepCount: flow.steps.length,
-        path: path.join(flowsDir, file),
+        path: filePath,
+        layout: path.basename(filePath) === 'flow.json' ? 'folder' : 'legacy',
+        stepTypes: collectStepTypes(flow),
+        requiresBash: flowRequiresBash(flow),
+        usesCodeModules: flowUsesCodeModules(flow),
+        inputs: summarizeFlowInputs(flow),
       });
     } catch {
       // Skip malformed flow files
+    }
+  };
+
+  for (const entry of fs.readdirSync(flowsDir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue; // skip .runs, .logs, etc.
+    const full = path.join(flowsDir, entry.name);
+    if (entry.isDirectory()) {
+      const flowJson = path.join(full, 'flow.json');
+      if (fs.existsSync(flowJson)) readFlowFile(flowJson);
+    } else if (entry.isFile() && entry.name.endsWith('.flow.json')) {
+      readFlowFile(full);
     }
   }
 
   return flows;
 }
 
+/**
+ * Save a flow. New flows default to the folder layout
+ * (`.one/flows/<key>/flow.json`), creating `<key>/lib/` alongside. An explicit
+ * `outputPath` is respected as-is for backward compatibility.
+ */
 export function saveFlow(flow: Flow, outputPath?: string): string {
-  const flowPath = outputPath
-    ? path.resolve(outputPath)
-    : path.resolve(FLOWS_DIR, `${flow.key}.flow.json`);
+  let flowPath: string;
+  if (outputPath) {
+    flowPath = path.resolve(outputPath);
+  } else {
+    const legacyPath = path.resolve(FLOWS_DIR, `${flow.key}.flow.json`);
+    const folderPath = path.resolve(FLOWS_DIR, flow.key, 'flow.json');
+    // Preserve layout if a flow with this key already exists
+    if (fs.existsSync(legacyPath) && !fs.existsSync(folderPath)) {
+      flowPath = legacyPath;
+    } else {
+      flowPath = folderPath;
+    }
+  }
 
   const dir = path.dirname(flowPath);
   ensureDir(dir);
+
+  // For folder layout, scaffold an empty lib/ so users know where modules go.
+  if (path.basename(flowPath) === 'flow.json') {
+    ensureDir(path.join(dir, 'lib'));
+  }
 
   fs.writeFileSync(flowPath, JSON.stringify(flow, null, 2) + '\n');
   return flowPath;

--- a/src/lib/flow-schema.ts
+++ b/src/lib/flow-schema.ts
@@ -109,13 +109,14 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
     {
       type: 'code',
       configKey: 'code',
-      description: 'Multi-line async JS with explicit return',
+      description: 'JS code — inline source or an external .mjs module under the flow\'s lib/ folder',
       fields: {
-        source: { type: 'string', required: true, description: 'JS function body (flow context as $, supports await)' },
+        source: { type: 'string', required: false, description: 'Inline JS function body (flow context as $, supports await). Mutually exclusive with "module".' },
+        module: { type: 'string', required: false, description: 'Relative path to a .mjs file under the flow folder (e.g. "lib/normalize.mjs"). Reads $ from stdin as JSON, writes result to stdout as JSON. Mutually exclusive with "source".' },
       },
       example: {
         id: 'processData', name: 'Process and enrich data', type: 'code',
-        code: { source: 'const items = $.steps.fetch.response.data;\nreturn items.filter(i => i.active);' },
+        code: { module: 'lib/process-data.mjs' },
       },
     },
     {
@@ -254,11 +255,11 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
     {
       type: 'bash',
       configKey: 'bash',
-      description: 'Shell command (requires --allow-bash)',
+      description: 'Shell command (requires --allow-bash). Output shape: $.steps.<id>.output is the parsed JSON when parseJson:true, otherwise the trimmed stdout string. $.steps.<id>.response always exposes { stdout, stderr, exitCode }.',
       fields: {
         command:   { type: 'string', required: true, description: 'Shell command to execute (supports selectors)' },
         timeout:   { type: 'number', required: false, description: 'Timeout in ms (default: 30000)' },
-        parseJson: { type: 'boolean', required: false, description: 'Parse stdout as JSON (default: false)' },
+        parseJson: { type: 'boolean', required: false, description: 'Parse stdout as JSON (default: false). When true, $.steps.<id>.output is the parsed object/array; when false, it is the trimmed stdout string.' },
         cwd:       { type: 'string', required: false, description: 'Working directory (supports selectors)' },
         env:       { type: 'object', required: false, description: 'Additional environment variables' },
       },
@@ -318,7 +319,32 @@ export function generateFlowGuide(): string {
 
 ## Overview
 
-Workflows are JSON files at \`.one/flows/<key>.flow.json\` that chain actions across platforms.
+Workflows live in \`.one/flows/\` (relative to your current working directory — the CLI does NOT walk up parent directories or fall back to a global location) and chain actions across platforms. Two layouts are supported:
+
+- **Folder layout (REQUIRED for new flows)** — \`.one/flows/<key>/flow.json\`, with an optional \`lib/\` subfolder for JavaScript modules. This is like a skill: the folder groups the JSON spec with any JavaScript modules it needs, so the whole flow is shareable. **Always create new flows in this layout.**
+- **Single-file layout (DEPRECATED)** — \`.one/flows/<key>.flow.json\`. Still loads and runs for backward compatibility, but is deprecated. Do not create new flows in this layout. When editing an existing single-file flow, migrate it to the folder layout: move \`<key>.flow.json\` to \`<key>/flow.json\` and extract any non-trivial \`code.source\` blocks into \`<key>/lib/*.mjs\` modules.
+
+When resolving a flow by key, the CLI checks the folder layout first, then the deprecated legacy file. The \`loadFlow\` helper in agent integrations behaves the same.
+
+## Before you execute a flow you did NOT author — READ THIS
+
+**Agents: always inspect a flow before running it.** Nothing about a flow's runtime requirements is guessable from its name. Before \`flow execute\`, do one of these:
+
+1. Run \`one --agent flow list\` — the JSON output includes \`requiresBash\`, \`usesCodeModules\`, \`inputs\` (with \`autoResolvable\` flags), \`stepTypes\`, and the flow's \`description\`. This is the fastest path.
+2. Read the flow's \`description\` field directly from the JSON. Flow authors are required (see "Author conventions" below) to state any \`--allow-bash\` requirement and any non-auto-resolving inputs in the description.
+3. Run \`one --agent flow execute <key> --dry-run\` to see the resolved inputs and step plan without side effects.
+
+If you skip this step you will hit errors like *"Workflow X contains bash steps. Re-run with --allow-bash."* — the CLI now pre-flights and fails fast, so you won't waste a long run, but the error is still avoidable by reading first.
+
+## Author conventions — WRITE flows that are safe to execute blind
+
+When you create a flow, its \`description\` field is the contract with future executors (human or agent). It MUST state:
+
+- **\`--allow-bash\` if any step is type \`bash\`.** Example: *"Fetches recent Gmail threads and summarizes them with Claude Haiku. Requires \`--allow-bash\`."*
+- **Every input that does NOT have a \`connection\` hint.** Connection inputs auto-resolve when exactly one matching connection exists; everything else must be passed via \`-i name=value\` and the description must name it.
+- **Any files/directories the flow writes to** so operators know what will be modified on disk.
+
+A good description is one paragraph. If a flow's description doesn't tell you how to run it, treat that as a bug in the flow and fix it.
 
 ## Commands
 
@@ -335,7 +361,69 @@ one --agent flow resume <runId>                        # Resume failed run
 one --agent flow scaffold [template]                   # Generate a starter template
 \`\`\`
 
-You can also write the JSON file directly to \`.one/flows/<key>.flow.json\` — this is often easier than passing large JSON via --definition.
+You can also write the JSON file directly to \`.one/flows/<key>/flow.json\` — often easier than passing large JSON via --definition. (The legacy \`.one/flows/<key>.flow.json\` single-file location is deprecated; don't use it for new flows.)
+
+## Code modules (flow \`lib/\` folder)
+
+A \`code\` step can either inline JS (\`code.source\`) or reference an external \`.mjs\` module (\`code.module\`). Modules live under the flow's \`lib/\` folder and run as a child \`node\` process:
+
+\`\`\`
+.one/flows/my-flow/
+├── flow.json
+└── lib/
+    └── process-data.mjs
+\`\`\`
+
+**Module contract:** the flow context \`$\` is piped to stdin as JSON; the module writes its result to stdout as JSON. That's the whole interface — no framework imports, no magic.
+
+\`\`\`js
+// lib/process-data.mjs
+const $ = JSON.parse(await new Response(process.stdin).text());
+const items = $.steps.fetch.response.data ?? [];
+process.stdout.write(JSON.stringify(items.filter(i => i.active)));
+\`\`\`
+
+\`\`\`json
+{
+  "id": "processData",
+  "name": "Process and enrich data",
+  "type": "code",
+  "code": { "module": "lib/process-data.mjs" }
+}
+\`\`\`
+
+Modules are full Node processes — \`fs\`, \`https\`, any npm package installed in the host project, etc. are all available. Use this for anything non-trivial; keep \`code.source\` for one-liners.
+
+**Step output shape:** whatever JSON a module writes to stdout becomes both \`$.steps.<id>.output\` and \`$.steps.<id>.response\` (aliases). Downstream steps can reference either; convention is to use \`.output\` for code/transform step results and \`.response\` for action step API payloads.
+
+## Migrating a legacy single-file flow to the folder layout
+
+If you're editing an existing \`.one/flows/<key>.flow.json\`, migrate it — it takes a minute and the result is cleaner. Checklist:
+
+1. \`mkdir -p .one/flows/<key>/lib\`
+2. Move the file: \`mv .one/flows/<key>.flow.json .one/flows/<key>/flow.json\`
+3. For each non-trivial \`code\` step with inline \`source\`, extract it into \`lib/<step-id>.mjs\` (see translation pattern below) and swap the step config from \`{ "source": "..." }\` to \`{ "module": "lib/<step-id>.mjs" }\`. One-liners can stay inline.
+4. Validate: \`one --agent flow validate <key>\`.
+5. Run it and confirm behavior is unchanged.
+
+**Inline source → module translation pattern.** Inline \`code.source\` is an async function body where \`$\` is already in scope and you \`return\` the result. A module is a standalone script where you read \`$\` from stdin and write the result to stdout as JSON. The transform is mechanical:
+
+Before (inline \`code.source\`):
+\`\`\`js
+const items = $.steps.fetch.response.data;
+const active = items.filter(i => i.active);
+return { active, count: active.length };
+\`\`\`
+
+After (\`lib/<step-id>.mjs\`):
+\`\`\`js
+const $ = JSON.parse(await new Response(process.stdin).text());
+const items = $.steps.fetch.response.data;
+const active = items.filter(i => i.active);
+process.stdout.write(JSON.stringify({ active, count: active.length }));
+\`\`\`
+
+The only differences: (1) prepend the stdin-read line, (2) replace \`return X\` with \`process.stdout.write(JSON.stringify(X))\`. That's it.
 
 ## Building a Workflow
 
@@ -584,7 +672,8 @@ Set timeout to at least 180000ms (3 min). Run Claude-heavy flows sequentially, n
 
 - Connection keys are **inputs**, not hardcoded
 - Action IDs in examples are placeholders — always use \`actions search\`
-- Code steps allow \`crypto\`, \`buffer\`, \`url\`, \`path\` — \`fs\`, \`http\`, \`child_process\` are blocked
+- Inline \`code.source\` steps allow \`require('crypto' | 'buffer' | 'url' | 'path')\` — \`fs\`, \`http\`, \`child_process\` are blocked
+- For anything beyond one-liners, use \`code.module\` to point at a \`.mjs\` file in the flow's \`lib/\` folder — runs as a child \`node\` process with full Node APIs, reads \`$\` from stdin, writes JSON to stdout
 - Bash steps require \`--allow-bash\` flag
 - State is persisted after every step — resume picks up where it left off`);
 

--- a/src/lib/flow-types.ts
+++ b/src/lib/flow-types.ts
@@ -52,7 +52,10 @@ export interface FlowFileWriteConfig {
 }
 
 export interface FlowCodeConfig {
-  source: string;
+  /** Inline JS source (async function body). Mutually exclusive with `module`. */
+  source?: string;
+  /** Path to a .mjs file relative to the flow's root directory (e.g. "lib/normalize.mjs"). Mutually exclusive with `source`. */
+  module?: string;
 }
 
 export interface FlowWhileConfig {
@@ -164,5 +167,7 @@ export interface FlowExecuteOptions {
   mock?: boolean;
   verbose?: boolean;
   allowBash?: boolean;
+  /** Absolute directory that contains this flow's `flow.json` (or the legacy `.one/flows/` dir). Used to resolve code.module paths. */
+  rootDir?: string;
   onEvent?: (event: FlowEvent) => void;
 }

--- a/src/lib/flow-validator.ts
+++ b/src/lib/flow-validator.ts
@@ -173,6 +173,27 @@ function validateStepsArray(steps: unknown[], pathPrefix: string, errors: Valida
         }
       }
     }
+
+    // Special: code step — require exactly one of source/module and validate module path
+    if (descriptor.type === 'code') {
+      const hasSource = typeof config.source === 'string' && (config.source as string).length > 0;
+      const hasModule = typeof config.module === 'string' && (config.module as string).length > 0;
+      if (!hasSource && !hasModule) {
+        errors.push({ path: `${path}.${configKey}`, message: 'Code step must define either "source" (inline JS) or "module" (path to .mjs file)' });
+      } else if (hasSource && hasModule) {
+        errors.push({ path: `${path}.${configKey}`, message: 'Code step cannot define both "source" and "module" — pick one' });
+      }
+      if (hasModule) {
+        const m = config.module as string;
+        if (m.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(m)) {
+          errors.push({ path: `${path}.${configKey}.module`, message: 'Code module path must be relative to the flow folder (no absolute paths)' });
+        } else if (m.split(/[\\/]/).includes('..')) {
+          errors.push({ path: `${path}.${configKey}.module`, message: 'Code module path must not escape the flow folder ("..")' });
+        } else if (!m.endsWith('.mjs')) {
+          errors.push({ path: `${path}.${configKey}.module`, message: 'Code module must be a .mjs file' });
+        }
+      }
+    }
   }
 }
 

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -58,7 +58,8 @@ one --agent flow list                                 # List all workflows
 \`\`\`
 
 **Key concepts:**
-- Workflows are JSON files at \`.one/flows/<key>.flow.json\`
+- Workflows live at \`.one/flows/<key>/flow.json\` (folder layout — REQUIRED for new flows). The legacy \`.one/flows/<key>.flow.json\` single-file layout is DEPRECATED but still loads for backward compatibility
+- Code steps can reference an external \`.mjs\` module under the flow's \`lib/\` folder (stdin JSON in, stdout JSON out) — keeps JS out of JSON strings and makes flows shareable
 - 12 step types: action, transform, code, condition, loop, parallel, file-read, file-write, while, flow, paginate, bash
 - Data wiring via selectors: \`$.input.param\`, \`$.steps.stepId.response\`, \`$.loop.item\`
 - AI analysis via bash steps: \`claude --print\` with \`parseJson: true\`


### PR DESCRIPTION
## Summary

- **Folder-layout flows** — `.one/flows/<key>/flow.json` with optional `lib/*.mjs` subfolder. Legacy single-file layout still loads but is deprecated (runtime warning). Flows are now composable and shareable like skills.
- **`code.module` step config** — a code step can reference a standalone `.mjs` file instead of inlining JS in a JSON string. The module runs as a child `node` process: `$` piped in via stdin as JSON, result written to stdout as JSON. Modules get the full Node API (unlike inline `code.source`, which remains sandboxed). Validator enforces exactly-one-of source/module, rejects path traversal, and requires `.mjs`.
- **Executor safety rails** so agents can run flows blind:
  - Pre-flight: flows with bash steps fail fast without `--allow-bash`, with a structured error naming the fix.
  - `flow list --agent` surfaces `layout`, `stepTypes`, `requiresBash`, `usesCodeModules`, and per-input `autoResolvable` — everything an executing agent needs in one call.
  - Legacy flows emit a `flow:deprecation` event on load with migration instructions.
- **Docs updated** (docs-first rule): guide, skill reference, README, generated flow guide. Adds a "Before you execute a flow you did NOT author" checklist, author convention for descriptions, migration walkthrough with before/after source→module translation, and documents `bash.parseJson` output shape.
- **Version bump:** 1.20.3 → 1.21.0.

## Test plan

Verified end-to-end with a 4-agent parallel test swarm, all green:

- [x] Agent 1: create a folder-layout flow with two `lib/*.mjs` modules from scratch, validate, execute. ✅
- [x] Agent 2: create a bash flow, exercise the pre-flight `--allow-bash` check, confirm `flow list --agent` exposes `requiresBash: true`. ✅
- [x] Agent 3: migrate the legacy `daily-sent-brief` flow to folder layout, extract inline `code.source` into `lib/*.mjs`, confirm deprecation warning disappears post-migration. ✅
- [x] Agent 4: blind execution — given only a flow key, discover all runtime requirements (flags + inputs) using only `flow list --agent`. ✅ Single command revealed everything.
- [x] Legacy single-file flows in `.one/flows/*.flow.json` still list and execute unchanged.
- [x] Real-world validation: converted `~/CEO/.one/flows/email-rubric-builder.flow.json` (13 code steps, 285 lines of inline JS) to folder layout with 14 `lib/*.mjs` modules and ran it end-to-end on 10 sent emails.
- [x] Validator negative cases: both `source`+`module`, neither, `../` traversal, non-`.mjs` extension — all rejected.
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)