### PR TITLE
feat: auto-sync installed skills to running CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,17 @@ one config
 
 Settings propagate automatically to all installed agent configs.
 
+#### `one config skills status` / `one config skills sync`
+
+`one init` copies the packaged skill files (`SKILL.md`, `references/`) into `~/.agents/skills/one/` and symlinks per-agent paths to that canonical directory. When the CLI self-updates, the skill files in the canonical dir would normally stay frozen at the version that was installed. To prevent stale docs, every CLI command checks a `.one-cli-version` marker in the canonical dir and silently refreshes the skill files if they don't match the running CLI version. No user action required.
+
+| Command | What it does |
+|---------|--------------|
+| `one config skills status` | Show installed skill version, current CLI version, and path |
+| `one config skills sync` | Force a re-copy of packaged skill files (for troubleshooting) |
+
+Auto-sync refuses to resurrect skills if you opted out of skill installation during `one init` — the canonical dir has to already exist.
+
 ## The workflow
 
 The power of One is in the workflow. Every interaction follows the same pattern:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -21,6 +21,8 @@ import { configCommand } from './config.js';
 import open from 'open';
 import * as output from '../lib/output.js';
 import type { Agent } from '../lib/types.js';
+import { writeInstalledSkillVersion } from '../lib/skill-sync.js';
+import { getCurrentVersion } from './update.js';
 
 export async function initCommand(options: { yes?: boolean; global?: boolean; project?: boolean }): Promise<void> {
   if (output.isAgentMode()) {
@@ -407,6 +409,9 @@ function installSkillForAgents(agentIds: string[]): { installed: string[]; faile
       fs.rmSync(canonical, { recursive: true });
     }
     copyDirSync(source, canonical);
+    // Stamp the canonical install with the CLI version so skill-sync can
+    // auto-refresh it on future CLI upgrades without re-running `one init`.
+    writeInstalledSkillVersion(getCurrentVersion());
   } catch {
     return { installed: [], failed: ['canonical copy'] };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,8 @@ import { cacheClearCommand, cacheListCommand, cacheUpdateAllCommand } from './co
 import { guideCommand } from './commands/guide.js';
 import { onboardCommand } from './commands/onboard.js';
 import { updateCommand, checkLatestVersionCached, getCurrentVersion, isNewerVersion, autoUpdate } from './commands/update.js';
-import { setAgentMode } from './lib/output.js';
+import { setAgentMode, isAgentMode, json as outputJson } from './lib/output.js';
+import { syncSkillsIfStale, forceSyncSkills, getSkillStatus } from './lib/skill-sync.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json');
@@ -110,6 +111,12 @@ program.hook('preAction', (thisCommand) => {
   if (commandName !== 'update') {
     updateCheckPromise = checkLatestVersionCached();
   }
+  // Keep the installed skill files in lockstep with the CLI version. Cheap
+  // no-op when the marker matches current version; copies packaged skills
+  // into the canonical install dir when they drift. See lib/skill-sync.ts.
+  if (commandName !== 'init' && commandName !== 'update') {
+    try { syncSkillsIfStale(); } catch { /* best-effort, never block a command */ }
+  }
 });
 
 program.hook('postAction', async () => {
@@ -132,11 +139,62 @@ program
     await initCommand(options);
   });
 
-program
+const config = program
   .command('config')
-  .description('Configure MCP access control (permissions, connections, actions)')
+  .description('Configure the CLI (access control, skills, ...)')
   .action(async () => {
+    // Default action: interactive access-control editor (unchanged behavior).
     await configCommand();
+  });
+
+const configSkills = config
+  .command('skills')
+  .description('Manage locally-installed skill files');
+
+configSkills
+  .command('sync')
+  .description('Re-copy packaged skill files over the local install (runs automatically after CLI upgrades)')
+  .action(async () => {
+    const result = forceSyncSkills();
+    if (isAgentMode()) {
+      outputJson({ command: 'config skills sync', ...result });
+      return;
+    }
+    if (result.reason === 'not-installed') {
+      console.log("No skill is installed yet. Run 'one init' first and opt in to skill installation.");
+      return;
+    }
+    if (result.synced) {
+      console.log(`✓ Skills synced to v${result.to}`);
+      return;
+    }
+    if (result.reason === 'source-missing') {
+      console.log('✗ Packaged skill source not found in this CLI build');
+      return;
+    }
+    console.log(`✗ Sync failed${result.error ? ': ' + result.error : ''}`);
+  });
+
+configSkills
+  .command('status')
+  .description('Show installed skill version and whether it matches the current CLI')
+  .action(async () => {
+    const status = getSkillStatus();
+    if (isAgentMode()) {
+      outputJson({ command: 'config skills status', ...status });
+      return;
+    }
+    if (!status.installed) {
+      console.log("Skill is not installed. Run 'one init' to install it.");
+      console.log(`Canonical path (empty): ${status.canonicalPath}`);
+      return;
+    }
+    const marker = status.installedVersion ?? '(no marker — pre-sync install)';
+    const state = status.upToDate ? '✓ up to date' : '⚠ stale — will sync on next command';
+    console.log(`Skill: ${state}`);
+    console.log(`  installed: ${marker}`);
+    console.log(`  current:   ${status.currentVersion}`);
+    console.log(`  path:      ${status.canonicalPath}`);
   });
 
 const connection = program

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -101,6 +101,7 @@ Request specific sections:
 - Always use the **exact action ID** from search results — don't guess
 - Always read **knowledge** before executing any action
 - Connection keys come from \`one connection list\` — don't hardcode them
+- Skills stay in lockstep with the CLI version automatically — every command checks a \`.one-cli-version\` marker in the canonical skill dir and refreshes the files if the CLI has been upgraded. Check manually with \`one config skills status\`; force a resync with \`one config skills sync\`
 `;
 
 export const GUIDE_ACTIONS = `# One Actions — Reference

--- a/src/lib/skill-sync.ts
+++ b/src/lib/skill-sync.ts
@@ -1,0 +1,166 @@
+/**
+ * Skill sync — keeps the user's installed skill files in lockstep with the
+ * CLI version they're running.
+ *
+ * Background: `one init` copies the packaged `skills/one/` directory from the
+ * npm package into `~/.agents/skills/one/` (the canonical location) and
+ * symlinks per-agent paths (`~/.claude/skills/one`, `~/.codex/skills/one`,
+ * etc.) to it. When the CLI self-updates via `autoUpdate()` in update.ts the
+ * packaged skill content on disk gets newer — but the copies in
+ * `~/.agents/skills/one/` stay frozen at whatever version was installed. The
+ * user's agent then reads stale docs.
+ *
+ * Fix: stamp the canonical install dir with a `.one-cli-version` marker file
+ * containing the installing CLI's version. On every command (via the
+ * preAction hook), `syncSkillsIfStale` compares the marker to the current
+ * version and, if they differ, recopies the packaged skill directory over
+ * the canonical path. Symlinks don't need touching because they point at the
+ * canonical dir. If no marker exists (pre-marker CLI versions) but the skill
+ * is installed, a one-time catch-up sync runs. If the skill isn't installed
+ * at all, this is a no-op — don't resurrect a skill the user opted out of.
+ *
+ * The steady-state cost is one tiny `readFileSync` + string compare. The
+ * stale path copies ~50KB of markdown. Both sub-millisecond; fine to run
+ * synchronously in preAction.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getCurrentVersion } from '../commands/update.js';
+
+const CANONICAL_SKILL_DIR = '.agents/skills';
+const VERSION_MARKER = '.one-cli-version';
+
+export function getPackagedSkillDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, '..', 'skills', 'one');
+}
+
+export function getCanonicalSkillPath(): string {
+  return path.join(os.homedir(), CANONICAL_SKILL_DIR, 'one');
+}
+
+function getVersionMarkerPath(): string {
+  return path.join(getCanonicalSkillPath(), VERSION_MARKER);
+}
+
+export function isSkillInstalled(): boolean {
+  return fs.existsSync(path.join(getCanonicalSkillPath(), 'SKILL.md'));
+}
+
+export function readInstalledSkillVersion(): string | null {
+  try {
+    return fs.readFileSync(getVersionMarkerPath(), 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeInstalledSkillVersion(version: string): void {
+  try {
+    fs.mkdirSync(getCanonicalSkillPath(), { recursive: true });
+    fs.writeFileSync(getVersionMarkerPath(), `${version}\n`);
+  } catch {
+    // best-effort
+  }
+}
+
+function copyDirSync(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirSync(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+export interface SyncResult {
+  synced: boolean;
+  reason?: 'not-installed' | 'up-to-date' | 'stale' | 'missing-marker' | 'forced' | 'source-missing' | 'error';
+  from?: string | null;
+  to?: string;
+  error?: string;
+}
+
+/**
+ * Sync packaged skills to the canonical install location if the marker is
+ * missing or older than the current CLI version. Safe to call on every
+ * command — returns { synced: false } quickly when nothing needs doing.
+ */
+export function syncSkillsIfStale(): SyncResult {
+  // Never resurrect a skill the user opted out of at init time.
+  if (!isSkillInstalled()) {
+    return { synced: false, reason: 'not-installed' };
+  }
+
+  const current = getCurrentVersion();
+  const installed = readInstalledSkillVersion();
+
+  if (installed === current) {
+    return { synced: false, reason: 'up-to-date', from: installed, to: current };
+  }
+
+  return performSync(current, installed === null ? 'missing-marker' : 'stale');
+}
+
+/**
+ * Force a sync regardless of marker state. Used by `one config skills sync`.
+ */
+export function forceSyncSkills(): SyncResult {
+  if (!isSkillInstalled()) {
+    // For a forced sync we still require an existing install — we don't want
+    // this command to do the job of `one init`, which picks agents + symlinks.
+    return { synced: false, reason: 'not-installed' };
+  }
+  return performSync(getCurrentVersion(), 'forced');
+}
+
+function performSync(current: string, reason: SyncResult['reason']): SyncResult {
+  const source = getPackagedSkillDir();
+  if (!fs.existsSync(path.join(source, 'SKILL.md'))) {
+    return { synced: false, reason: 'source-missing' };
+  }
+
+  const canonical = getCanonicalSkillPath();
+
+  try {
+    // Copy packaged files over the canonical path. We intentionally do NOT
+    // rm-rf first — we overlay so symlinks/marker stay intact and any files
+    // the user may have added (not recommended but possible) aren't lost.
+    // Files that exist in source will be overwritten.
+    copyDirSync(source, canonical);
+    writeInstalledSkillVersion(current);
+    return { synced: true, reason, from: readInstalledSkillVersion() ?? null, to: current };
+  } catch (err) {
+    return { synced: false, reason: 'error', error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export interface SkillStatus {
+  installed: boolean;
+  canonicalPath: string;
+  installedVersion: string | null;
+  currentVersion: string;
+  upToDate: boolean;
+  markerExists: boolean;
+}
+
+export function getSkillStatus(): SkillStatus {
+  const installed = isSkillInstalled();
+  const installedVersion = readInstalledSkillVersion();
+  const currentVersion = getCurrentVersion();
+  return {
+    installed,
+    canonicalPath: getCanonicalSkillPath(),
+    installedVersion,
+    currentVersion,
+    upToDate: installed && installedVersion === currentVersion,
+    markerExists: installedVersion !== null,
+  };
+}


### PR DESCRIPTION
## Summary

- Skill files now auto-sync whenever the running CLI version differs from the version that installed them. No user action required after an upgrade.
- New `~/.agents/skills/one/.one-cli-version` marker is written by `one init` and checked on every command in the preAction hook.
- Silent fast path: steady state is one `readFileSync` + string compare. Stale path copies ~50KB of packaged skill markdown into the canonical dir. Symlinks at `~/.claude/skills/one`, `~/.codex/skills/one`, etc. point at the canonical dir and inherit the refresh automatically.
- Refuses to resurrect a skill the user opted out of during `one init` — auto-sync skips entirely if `SKILL.md` isn't in the canonical dir.
- New commands under `one config skills` (nested per the config convention):
  - `one config skills status` — installed version, current CLI version, path, stale?
  - `one config skills sync` — force a resync (troubleshooting escape hatch)
- Version bump 1.21.0 -> 1.22.0.

## Test plan

- [x] Fresh state: `config skills status` reports up-to-date.
- [x] Missing marker (pre-sync install): preAction auto-creates marker and refreshes files.
- [x] Stale marker (`1.21.0` while CLI is `1.22.0`): preAction syncs silently; next `status` call reports up-to-date.
- [x] Sentinel test: clobber `SKILL.md` with garbage + set stale marker; confirm the next command restores real content.
- [x] Uninstalled skill (canonical dir moved away): auto-sync and `config skills sync` both correctly refuse to resurrect it.
- [x] `flow list` and other commands unaffected; preAction hook is non-blocking in the happy path and swallows errors.
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)