### PR TITLE
fix: warn when Handlebars interpolation stringifies an object/array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.22.0",
+      "version": "1.22.1",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -187,6 +187,16 @@ Connection inputs with a `connection` field auto-resolve if the user has exactly
 
 A pure `$.xxx` value resolves to the raw type. A string containing `{{$.xxx}}` does string interpolation.
 
+**Passing objects and arrays:** `{{ }}` interpolation always produces a string — if the resolved value is an object or array it will be JSON-stringified and the engine will log a warning. To pass an object/array as a native value to the next step, use a **direct selector without `{{ }}`**:
+
+```json
+// ✗ Wrong — becomes a JSON string, triggers a runtime warning
+"files": "{{$.steps.extract.output.allFiles}}"
+
+// ✓ Right — passes the array as an array
+"files": "$.steps.extract.output.allFiles"
+```
+
 ### Selectors vs expressions
 
 Selectors in data fields (`data`, `queryParams`, `pathVars`, `connectionKey`) are **dot-path lookups only** — they do not support JavaScript operators like `||` or `&&`. For default values, use the `default` field on the input definition:

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -64,7 +64,13 @@ export function interpolateString(str: string, context: FlowContext): string {
   return str.replace(/\{\{(\$\.[^}]+)\}\}/g, (_match, selector) => {
     const value = resolveSelector(selector, context);
     if (value === undefined || value === null) return '';
-    if (typeof value === 'object') return JSON.stringify(value);
+    if (typeof value === 'object') {
+      console.warn(
+        `[flow] WARNING: Handlebars expression "{{${selector}}}" resolved to ${Array.isArray(value) ? 'an array' : 'an object'} and was stringified as JSON. ` +
+        `To pass objects/arrays as native values, use a direct selector without {{ }}: "${selector}"`
+      );
+      return JSON.stringify(value);
+    }
     return String(value);
   });
 }


### PR DESCRIPTION
## Summary
- `interpolateString` now logs a warning when a `{{$.x}}` expression resolves to an object/array, instead of silently JSON-stringifying it
- Updates `skills/one/references/flows.md` to document that objects/arrays must be passed via direct selectors (no `{{ }}`)

Part of the batched fixes release. Closes #41.

## Test plan
- [ ] Run a flow that interpolates an object with `{{ }}` and confirm the warning fires
- [ ] Confirm direct-selector form still passes the native value through