### PR TITLE
feat: add one login and one logout commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ one init
 Or authenticate directly:
 
 ```bash
-one login              # Opens browser for authentication
-one logout             # Clear local credentials
+one login              # Opens browser for authentication (global or per-directory)
+one logout             # Clear credentials (with scope picker and confirmation)
 ```
 
 Requires Node.js 18+.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Or authenticate directly:
 
 ```bash
 one login              # Opens browser for authentication
-one login --key sk_live_...  # Authenticate with an existing API key
 one logout             # Clear local credentials
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ npm install -g @withone/cli
 one init
 ```
 
-`one init` walks you through setup: enter your [API key](https://app.withone.ai/settings/api-keys), pick your AI agents, and you're done. The MCP server gets installed automatically.
+`one init` walks you through setup: authenticate via browser or enter your [API key](https://app.withone.ai/settings/api-keys), pick your AI agents, and you're done. The MCP server gets installed automatically.
+
+Or authenticate directly:
+
+```bash
+one login              # Opens browser for authentication
+one login --key sk_live_...  # Authenticate with an existing API key
+one logout             # Clear local credentials
+```
 
 Requires Node.js 18+.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "better-sqlite3": "^11.10.0"
+        "better-sqlite3": "^11.7.0"
       }
     },
     "node_modules/@clack/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.32.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
+        "better-sqlite3": "^11.10.0",
         "commander": "^13.1.0",
         "open": "^10.1.0",
         "picocolors": "^1.1.1",
@@ -27,7 +28,7 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "better-sqlite3": "^11.7.0"
+        "better-sqlite3": "^11.10.0"
       }
     },
     "node_modules/@clack/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "smol-toml": "^1.6.0"
   },
   "optionalDependencies": {
-    "better-sqlite3": "^11.7.0"
+    "better-sqlite3": "^11.10.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "smol-toml": "^1.6.0"
   },
   "optionalDependencies": {
-    "better-sqlite3": "^11.10.0"
+    "better-sqlite3": "^11.7.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -31,7 +31,7 @@ one login                    # Browser-based login (opens app.withone.ai)
 one logout                   # Clear local credentials
 ```
 
-`one login` opens the browser for OAuth authentication and automatically creates and stores an API key. For CI/CD or headless environments, use `one init` to paste a key manually.
+`one login` opens the browser for OAuth authentication and automatically creates and stores an API key. If already logged in, the user can choose to log in globally or for the current directory. `one logout` shows current session info and confirms before clearing credentials. For CI/CD or headless environments, use `one init` to paste a key manually.
 
 ## Core Workflow: search -> knowledge -> execute
 

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -28,11 +28,10 @@ If the user wants a separate API key / connections for a specific project (vs. t
 
 ```bash
 one login                    # Browser-based login (opens app.withone.ai)
-one login --key sk_live_...  # Authenticate with an existing API key
 one logout                   # Clear local credentials
 ```
 
-`one login` opens the browser for OAuth authentication and automatically creates and stores an API key. Use `--key` for CI/CD or headless environments where a browser is not available.
+`one login` opens the browser for OAuth authentication and automatically creates and stores an API key. For CI/CD or headless environments, use `one init` to paste a key manually.
 
 ## Core Workflow: search -> knowledge -> execute
 

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -24,6 +24,16 @@ You have access to the One CLI which lets you interact with 250+ third-party pla
 
 If the user wants a separate API key / connections for a specific project (vs. their default), walk them through running `one init` from that project folder and picking the "project" scope — see `references/scoping.md`.
 
+## Authentication
+
+```bash
+one login                    # Browser-based login (opens app.withone.ai)
+one login --key sk_live_...  # Authenticate with an existing API key
+one logout                   # Clear local credentials
+```
+
+`one login` opens the browser for OAuth authentication and automatically creates and stores an API key. Use `--key` for CI/CD or headless environments where a browser is not available.
+
 ## Core Workflow: search -> knowledge -> execute
 
 Always follow this sequence when the user wants to do something on a connected platform:

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import {
   writeConfig,
   readConfig,
+  getApiKey,
   getConfigPath,
   getApiBase,
   getAccessControl,
@@ -797,64 +798,94 @@ async function freshSetup(
   scope: ConfigScope,
   options: { yes?: boolean; global?: boolean; project?: boolean },
 ): Promise<void> {
-  // Step 1: Get API key
-  p.note(`Get your API key at:\n${pc.cyan(getApiKeyUrl())}`, `API Key ${scopeLabel(scope)}`);
-
-  const openBrowser = await p.confirm({
-    message: scopedMessage(scope, 'Open browser to get API key?'),
-    initialValue: true,
+  // Step 1: Get API key (browser login or manual paste)
+  const authMethod = await p.select({
+    message: scopedMessage(scope, 'How would you like to authenticate?'),
+    options: [
+      { value: 'browser', label: 'Browser login', hint: 'recommended — opens app.withone.ai' },
+      { value: 'manual', label: 'Paste API key manually' },
+    ],
   });
 
-  if (p.isCancel(openBrowser)) {
+  if (p.isCancel(authMethod)) {
     p.cancel('Setup cancelled.');
     process.exit(0);
   }
 
-  if (openBrowser) {
-    await openApiKeyPage();
+  let apiKey: string;
+
+  if (authMethod === 'browser') {
+    // Import and run the login command inline
+    const { loginCommand } = await import('./login.js');
+    await loginCommand({});
+    // After login, read the key from config
+    const storedKey = getApiKey();
+    if (!storedKey) {
+      p.cancel('Browser login did not complete. Try: one init');
+      process.exit(1);
+    }
+    apiKey = storedKey;
+  } else {
+    p.note(`Get your API key at:\n${pc.cyan(getApiKeyUrl())}`, `API Key ${scopeLabel(scope)}`);
+
+    const openBrowser = await p.confirm({
+      message: scopedMessage(scope, 'Open browser to get API key?'),
+      initialValue: true,
+    });
+
+    if (p.isCancel(openBrowser)) {
+      p.cancel('Setup cancelled.');
+      process.exit(0);
+    }
+
+    if (openBrowser) {
+      await openApiKeyPage();
+    }
+
+    const inputKey = await p.text({
+      message: scopedMessage(scope, 'Enter your One API key:'),
+      placeholder: 'sk_live_...',
+      validate: (value) => {
+        if (!value) return 'API key is required';
+        if (!value.startsWith('sk_live_') && !value.startsWith('sk_test_')) {
+          return 'API key should start with sk_live_ or sk_test_';
+        }
+        return undefined;
+      },
+    });
+
+    if (p.isCancel(inputKey)) {
+      p.cancel('Setup cancelled.');
+      process.exit(0);
+    }
+
+    apiKey = inputKey;
+
+    // Validate API key
+    const spinner = p.spinner();
+    spinner.start('Validating API key...');
+
+    const api = new OneApi(apiKey, getApiBase());
+    const isValid = await api.validateApiKey();
+
+    if (!isValid) {
+      spinner.stop('Invalid API key');
+      p.cancel(`Invalid API key. Get a valid key at ${getApiKeyUrl()}`);
+      process.exit(1);
+    }
+
+    spinner.stop('API key validated');
+
+    // Save API key to config at the chosen scope
+    writeConfig(
+      {
+        apiKey,
+        installedAgents: [],
+        createdAt: new Date().toISOString(),
+      },
+      scope,
+    );
   }
-
-  const apiKey = await p.text({
-    message: scopedMessage(scope, 'Enter your One API key:'),
-    placeholder: 'sk_live_...',
-    validate: (value) => {
-      if (!value) return 'API key is required';
-      if (!value.startsWith('sk_live_') && !value.startsWith('sk_test_')) {
-        return 'API key should start with sk_live_ or sk_test_';
-      }
-      return undefined;
-    },
-  });
-
-  if (p.isCancel(apiKey)) {
-    p.cancel('Setup cancelled.');
-    process.exit(0);
-  }
-
-  // Validate API key
-  const spinner = p.spinner();
-  spinner.start('Validating API key...');
-
-  const api = new OneApi(apiKey, getApiBase());
-  const isValid = await api.validateApiKey();
-
-  if (!isValid) {
-    spinner.stop('Invalid API key');
-    p.cancel(`Invalid API key. Get a valid key at ${getApiKeyUrl()}`);
-    process.exit(1);
-  }
-
-  spinner.stop('API key validated');
-
-  // Save API key to config at the chosen scope
-  writeConfig(
-    {
-      apiKey,
-      installedAgents: [],
-      createdAt: new Date().toISOString(),
-    },
-    scope,
-  );
 
   // Step 2: Install skill
   await promptSkillInstall();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -817,7 +817,7 @@ async function freshSetup(
   if (authMethod === 'browser') {
     // Import and run the login command inline
     const { loginCommand } = await import('./login.js');
-    await loginCommand({});
+    await loginCommand();
     // After login, read the key from config
     const storedKey = getApiKey();
     if (!storedKey) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -41,6 +41,7 @@ import * as output from '../lib/output.js';
 import type { Agent } from '../lib/types.js';
 import { writeInstalledSkillVersion } from '../lib/skill-sync.js';
 import { getCurrentVersion } from './update.js';
+import { browserLogin } from './login.js';
 
 export async function initCommand(options: { yes?: boolean; global?: boolean; project?: boolean }): Promise<void> {
   if (output.isAgentMode()) {
@@ -287,53 +288,82 @@ async function handleExistingConfig(
 // ── Action handlers ──────────────────────────────────────────────────
 
 async function handleUpdateKey(statuses: AgentStatus[], scope: ConfigScope): Promise<void> {
-  p.note(`Get your API key at:\n${pc.cyan(getApiKeyUrl())}`, `API Key ${scopeLabel(scope)}`);
-
-  const openBrowser = await p.confirm({
-    message: scopedMessage(scope, 'Open browser to get API key?'),
-    initialValue: true,
+  const authMethod = await p.select({
+    message: scopedMessage(scope, 'How would you like to authenticate?'),
+    options: [
+      { value: 'browser', label: 'Browser login', hint: 'recommended — opens app.withone.ai' },
+      { value: 'manual', label: 'Paste API key manually' },
+    ],
   });
 
-  if (p.isCancel(openBrowser)) {
+  if (p.isCancel(authMethod)) {
     p.cancel('Cancelled.');
     process.exit(0);
   }
 
-  if (openBrowser) {
-    await openApiKeyPage();
+  let newKey: string;
+  let whoamiResult: import('../lib/types.js').WhoAmIResponse;
+
+  if (authMethod === 'browser') {
+    const result = await browserLogin();
+    if (!result) {
+      p.cancel('Browser login did not complete.');
+      process.exit(1);
+    }
+    newKey = result.apiKey;
+    whoamiResult = result.whoami;
+  } else {
+    p.note(`Get your API key at:\n${pc.cyan(getApiKeyUrl())}`, `API Key ${scopeLabel(scope)}`);
+
+    const openBrowser = await p.confirm({
+      message: scopedMessage(scope, 'Open browser to get API key?'),
+      initialValue: true,
+    });
+
+    if (p.isCancel(openBrowser)) {
+      p.cancel('Cancelled.');
+      process.exit(0);
+    }
+
+    if (openBrowser) {
+      await openApiKeyPage();
+    }
+
+    const inputKey = await p.text({
+      message: scopedMessage(scope, 'Enter your new One API key:'),
+      placeholder: 'sk_live_...',
+      validate: (value) => {
+        if (!value) return 'API key is required';
+        if (!value.startsWith('sk_live_') && !value.startsWith('sk_test_')) {
+          return 'API key should start with sk_live_ or sk_test_';
+        }
+        return undefined;
+      },
+    });
+
+    if (p.isCancel(inputKey)) {
+      p.cancel('Cancelled.');
+      process.exit(0);
+    }
+
+    newKey = inputKey;
+
+    // Validate
+    const spinner = p.spinner();
+    spinner.start('Validating API key...');
+
+    const api = new OneApi(newKey, getApiBase());
+    const validated = await api.validateApiKey();
+
+    if (!validated) {
+      spinner.stop('Invalid API key');
+      p.cancel(`Invalid API key. Get a valid key at ${getApiKeyUrl()}`);
+      process.exit(1);
+    }
+
+    spinner.stop('API key validated');
+    whoamiResult = validated;
   }
-
-  const newKey = await p.text({
-    message: scopedMessage(scope, 'Enter your new One API key:'),
-    placeholder: 'sk_live_...',
-    validate: (value) => {
-      if (!value) return 'API key is required';
-      if (!value.startsWith('sk_live_') && !value.startsWith('sk_test_')) {
-        return 'API key should start with sk_live_ or sk_test_';
-      }
-      return undefined;
-    },
-  });
-
-  if (p.isCancel(newKey)) {
-    p.cancel('Cancelled.');
-    process.exit(0);
-  }
-
-  // Validate
-  const spinner = p.spinner();
-  spinner.start('Validating API key...');
-
-  const api = new OneApi(newKey, getApiBase());
-  const whoamiResult = await api.validateApiKey();
-
-  if (!whoamiResult) {
-    spinner.stop('Invalid API key');
-    p.cancel(`Invalid API key. Get a valid key at ${getApiKeyUrl()}`);
-    process.exit(1);
-  }
-
-  spinner.stop('API key validated');
 
   // Show key context
   const env = getEnvFromApiKey(newKey);
@@ -837,16 +867,35 @@ async function freshSetup(
   let apiKey: string;
 
   if (authMethod === 'browser') {
-    // Import and run the login command inline
-    const { loginCommand } = await import('./login.js');
-    await loginCommand();
-    // After login, read the key from config
-    const storedKey = getApiKey();
-    if (!storedKey) {
+    const result = await browserLogin();
+    if (!result) {
       p.cancel('Browser login did not complete. Try: one init');
       process.exit(1);
     }
-    apiKey = storedKey;
+    apiKey = result.apiKey;
+
+    // Show account context
+    const env = getEnvFromApiKey(apiKey);
+    const contextParts: string[] = [];
+    if (result.whoami.organization) contextParts.push(result.whoami.organization.name);
+    if (result.whoami.project) contextParts.push(result.whoami.project.name);
+    const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
+    const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
+    p.note(
+      `${scopeDisplay} ${pc.dim('·')} ${envLabel}\n${result.whoami.user.name} ${pc.dim(`(${result.whoami.user.email})`)}`,
+      'Account',
+    );
+
+    // Save API key + whoami to config at the chosen scope
+    writeConfig(
+      {
+        apiKey,
+        installedAgents: [],
+        createdAt: new Date().toISOString(),
+        whoami: result.whoami,
+      },
+      scope,
+    );
   } else {
     p.note(`Get your API key at:\n${pc.cyan(getApiKeyUrl())}`, `API Key ${scopeLabel(scope)}`);
 
@@ -903,12 +952,12 @@ async function freshSetup(
     const contextParts: string[] = [];
     if (whoami.organization) contextParts.push(whoami.organization.name);
     if (whoami.project) contextParts.push(whoami.project.name);
-    const scope_label = contextParts.length > 0
+    const scopeDisplay = contextParts.length > 0
       ? contextParts.join(' / ')
       : 'Personal';
     const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
     p.note(
-      `${scope_label} ${pc.dim('·')} ${envLabel}\n${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`,
+      `${scopeDisplay} ${pc.dim('·')} ${envLabel}\n${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`,
       'Account',
     );
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -21,16 +21,12 @@ const SUCCESS_HTML = `<!DOCTYPE html>
 <p style="color:#a1a1aa;font-size:14px">Return to your terminal. You can close this tab.</p>
 </div></body></html>`;
 
-function saveCredentials(opts: {
-  apiKey: string;
-  keyId?: string;
-}): void {
+function saveCredentials(apiKey: string): void {
   const resolved = resolveConfig();
   const scope = resolved.scope ?? 'global';
   const existing = resolved.config;
   writeConfig({
-    apiKey: opts.apiKey,
-    keyId: opts.keyId,
+    apiKey,
     installedAgents: existing?.installedAgents ?? [],
     createdAt: new Date().toISOString(),
     accessControl: existing?.accessControl,
@@ -41,7 +37,6 @@ function saveCredentials(opts: {
 
 interface CallbackPayload {
   apiKey: string;
-  keyId: string;
   state: string;
 }
 
@@ -74,7 +69,6 @@ function startCallbackServer(
         }
 
         const encodedKey = url.searchParams.get('s');
-        const keyId = url.searchParams.get('k') || '';
         const state = url.searchParams.get('state');
 
         const apiKey = encodedKey ? Buffer.from(encodedKey, 'base64').toString('utf-8') : null;
@@ -94,7 +88,7 @@ function startCallbackServer(
         // Serve success page to the browser
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(SUCCESS_HTML);
-        resolveResult({ apiKey, keyId, state });
+        resolveResult({ apiKey, state });
       });
 
       server.on('error', (err: NodeJS.ErrnoException) => {
@@ -182,7 +176,7 @@ export async function loginCommand(): Promise<void> {
     spin.stop('Authentication received!');
 
     // Save key first
-    saveCredentials({ apiKey: payload.apiKey, keyId: payload.keyId });
+    saveCredentials(payload.apiKey);
 
     // Call whoami to get user info and store it
     const apiBase = getApiBase();

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,8 +1,8 @@
 import http from 'node:http';
 import crypto from 'node:crypto';
 import * as p from '@clack/prompts';
-import { ApiError } from '../lib/api.js';
-import { getApiKey, writeConfig, resolveConfig } from '../lib/config.js';
+import { OneApi, ApiError } from '../lib/api.js';
+import { getApiKey, writeConfig, resolveConfig, getApiBase } from '../lib/config.js';
 import { getCliAuthUrl, openCliAuthPage } from '../lib/browser.js';
 import * as output from '../lib/output.js';
 
@@ -24,8 +24,6 @@ const SUCCESS_HTML = `<!DOCTYPE html>
 function saveCredentials(opts: {
   apiKey: string;
   keyId?: string;
-  userName?: string;
-  userEmail?: string;
 }): void {
   const resolved = resolveConfig();
   const scope = resolved.scope ?? 'global';
@@ -38,11 +36,6 @@ function saveCredentials(opts: {
     accessControl: existing?.accessControl,
     cacheTtl: existing?.cacheTtl,
     apiBase: existing?.apiBase,
-    whoami: opts.userName || opts.userEmail ? {
-      user: { id: '', name: opts.userName || '', email: opts.userEmail || '' },
-      organization: null,
-      project: null,
-    } : existing?.whoami,
   }, scope);
 }
 
@@ -50,8 +43,6 @@ interface CallbackPayload {
   apiKey: string;
   keyId: string;
   state: string;
-  userEmail?: string;
-  userName?: string;
 }
 
 function randomPort(): number {
@@ -85,8 +76,6 @@ function startCallbackServer(
         const encodedKey = url.searchParams.get('s');
         const keyId = url.searchParams.get('k') || '';
         const state = url.searchParams.get('state');
-        const userEmail = url.searchParams.get('e') || undefined;
-        const userName = url.searchParams.get('n') || undefined;
 
         const apiKey = encodedKey ? Buffer.from(encodedKey, 'base64').toString('utf-8') : null;
 
@@ -105,7 +94,7 @@ function startCallbackServer(
         // Serve success page to the browser
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(SUCCESS_HTML);
-        resolveResult({ apiKey, keyId, state, userEmail, userName });
+        resolveResult({ apiKey, keyId, state });
       });
 
       server.on('error', (err: NodeJS.ErrnoException) => {
@@ -192,20 +181,24 @@ export async function loginCommand(): Promise<void> {
     const payload = await Promise.race([resultPromise, timeout]);
     spin.stop('Authentication received!');
 
-    const displayName = payload.userName || payload.userEmail || 'Unknown';
+    // Save key first
+    saveCredentials({ apiKey: payload.apiKey, keyId: payload.keyId });
 
-    saveCredentials({
-      apiKey: payload.apiKey,
-      keyId: payload.keyId,
-      userEmail: payload.userEmail,
-      userName: payload.userName,
-    });
+    // Call whoami to get user info and store it
+    const apiBase = getApiBase();
+    const api = new OneApi(payload.apiKey, apiBase);
+    const whoami = await api.whoami();
 
-    if (displayName !== 'Unknown') {
-      p.log.success(`Authenticated as ${displayName}${payload.userEmail ? ` (${payload.userEmail})` : ''}`);
+    // Update config with whoami data
+    const resolved = resolveConfig();
+    if (resolved.config) {
+      writeConfig({ ...resolved.config, whoami }, resolved.scope ?? 'global');
     }
-    const { scope: savedScope } = resolveConfig();
-    const scopeLabel = savedScope === 'project' ? 'project config' : '~/.one/config.json';
+
+    const displayName = whoami.user.name || whoami.user.email;
+    p.log.success(`Authenticated as ${displayName} (${whoami.user.email})`);
+
+    const scopeLabel = resolved.scope === 'project' ? 'project config' : '~/.one/config.json';
     p.log.success(`API key stored in ${scopeLabel}`);
     p.outro('You\'re all set!');
   } catch (err) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -202,7 +202,9 @@ export async function loginCommand(): Promise<void> {
     const scopeInfo = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
 
     p.log.success(`Authenticated as ${displayName} (${whoami.user.email})`);
-    p.log.info(`Account: ${scopeInfo}`);
+    if (whoami.organization || whoami.project) {
+      p.log.info(scopeInfo);
+    }
 
     const configLabel = resolved.scope === 'project' ? 'project config' : '~/.one/config.json';
     p.log.success(`API key stored in ${configLabel}`);

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,7 +2,7 @@ import http from 'node:http';
 import crypto from 'node:crypto';
 import * as p from '@clack/prompts';
 import { OneApi, ApiError } from '../lib/api.js';
-import { getApiKey, writeConfig, resolveConfig, getApiBase } from '../lib/config.js';
+import { getApiKey, writeConfig, resolveConfig, getApiBase, getEnvFromApiKey } from '../lib/config.js';
 import { getCliAuthUrl, openCliAuthPage } from '../lib/browser.js';
 import * as output from '../lib/output.js';
 
@@ -195,19 +195,25 @@ export async function loginCommand(): Promise<void> {
       writeConfig({ ...resolved.config, whoami }, resolved.scope ?? 'global');
     }
 
-    const displayName = whoami.user.name || whoami.user.email;
+    // Display in same format as `one whoami`
+    const pc = (await import('picocolors')).default;
+    const env = getEnvFromApiKey(payload.apiKey);
     const contextParts: string[] = [];
     if (whoami.organization) contextParts.push(whoami.organization.name);
     if (whoami.project) contextParts.push(whoami.project.name);
-    const scopeInfo = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
+    const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
+    const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
+    const configLabel = resolved.scope === 'project'
+      ? pc.cyan('project config')
+      : pc.magenta('global config');
 
-    p.log.success(`Authenticated as ${displayName} (${whoami.user.email})`);
-    if (whoami.organization || whoami.project) {
-      p.log.info(scopeInfo);
-    }
-
-    const configLabel = resolved.scope === 'project' ? 'project config' : '~/.one/config.json';
-    p.log.success(`API key stored in ${configLabel}`);
+    console.log();
+    console.log(`  ${pc.bold(scopeDisplay)} ${pc.dim('·')} ${envLabel}`);
+    console.log(`  ${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`);
+    if (whoami.organization) console.log(`  ${pc.dim('Org:')} ${whoami.organization.name}`);
+    if (whoami.project) console.log(`  ${pc.dim('Project:')} ${whoami.project.name}`);
+    console.log();
+    console.log(`  ${pc.dim('Stored in')} ${configLabel}`);
     p.outro('Run `one whoami` for full details.');
   } catch (err) {
     spin.stop('Authentication failed.');

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,270 @@
+import http from 'node:http';
+import crypto from 'node:crypto';
+import * as p from '@clack/prompts';
+import { OneApi, ApiError } from '../lib/api.js';
+import { getApiKey, writeConfig, readConfig, getApiBase } from '../lib/config.js';
+import { getCliAuthUrl, openCliAuthPage } from '../lib/browser.js';
+import * as output from '../lib/output.js';
+
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const PORT_RANGE_START = 49152;
+const PORT_RANGE_END = 65535;
+const MAX_PORT_ATTEMPTS = 5;
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html><head><title>One CLI</title></head>
+<body style="font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#0a0a0a;color:#fafafa">
+<div style="text-align:center">
+<div style="width:48px;height:48px;border-radius:50%;background:rgba(34,197,94,0.1);display:flex;align-items:center;justify-content:center;margin:0 auto 16px">
+<svg width="24" height="24" fill="none" stroke="#22c55e" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+</div>
+<h1 style="font-size:20px;margin:0 0 8px">You're all set!</h1>
+<p style="color:#a1a1aa;font-size:14px">Return to your terminal. You can close this tab.</p>
+</div></body></html>`;
+
+function saveCredentials(opts: {
+  apiKey: string;
+  keyId?: string;
+  userEmail?: string;
+  userName?: string;
+}): void {
+  const existing = readConfig();
+  writeConfig({
+    apiKey: opts.apiKey,
+    keyId: opts.keyId,
+    userEmail: opts.userEmail,
+    userName: opts.userName,
+    installedAgents: existing?.installedAgents ?? [],
+    createdAt: new Date().toISOString(),
+    accessControl: existing?.accessControl,
+    cacheTtl: existing?.cacheTtl,
+    apiBase: existing?.apiBase,
+  }, 'global');
+}
+
+interface CallbackPayload {
+  apiKey: string;
+  keyId: string;
+  state: string;
+  userEmail?: string;
+  userName?: string;
+}
+
+function randomPort(): number {
+  return PORT_RANGE_START + Math.floor(Math.random() * (PORT_RANGE_END - PORT_RANGE_START));
+}
+
+function startCallbackServer(
+  expectedState: string
+): Promise<{ server: http.Server; port: number; result: Promise<CallbackPayload> }> {
+  return new Promise((resolveSetup, rejectSetup) => {
+    let attempts = 0;
+
+    function tryListen() {
+      const port = randomPort();
+      attempts++;
+
+      let resolveResult: (value: CallbackPayload) => void;
+      const result = new Promise<CallbackPayload>((res) => {
+        resolveResult = res;
+      });
+
+      const server = http.createServer((req, res) => {
+        const url = new URL(req.url || '/', `http://localhost:${port}`);
+
+        if (url.pathname !== '/callback') {
+          res.writeHead(404, { 'Content-Type': 'text/plain' });
+          res.end('Not found');
+          return;
+        }
+
+        const apiKey = url.searchParams.get('apiKey');
+        const keyId = url.searchParams.get('keyId') || '';
+        const state = url.searchParams.get('state');
+        const userEmail = url.searchParams.get('userEmail') || undefined;
+        const userName = url.searchParams.get('userName') || undefined;
+
+        if (!apiKey || !state) {
+          res.writeHead(400, { 'Content-Type': 'text/plain' });
+          res.end('Missing required parameters');
+          return;
+        }
+
+        if (state !== expectedState) {
+          res.writeHead(403, { 'Content-Type': 'text/plain' });
+          res.end('State mismatch');
+          return;
+        }
+
+        // Serve success page to the browser
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(SUCCESS_HTML);
+        resolveResult({ apiKey, keyId, state, userEmail, userName });
+      });
+
+      server.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE' && attempts < MAX_PORT_ATTEMPTS) {
+          tryListen();
+          return;
+        }
+        rejectSetup(err);
+      });
+
+      server.listen(port, '127.0.0.1', () => {
+        resolveSetup({ server, port, result });
+      });
+    }
+
+    tryListen();
+  });
+}
+
+export async function loginCommand(options: { key?: string }): Promise<void> {
+  // --key flag: manual key input
+  if (options.key) {
+    await loginWithKey(options.key);
+    return;
+  }
+
+  // Check if already logged in
+  const existingKey = getApiKey();
+  if (existingKey) {
+    if (output.isAgentMode()) {
+      output.json({ status: 'already_authenticated', message: 'Already logged in. Use --key to update.' });
+      return;
+    }
+    const shouldOverwrite = await p.confirm({
+      message: 'You are already logged in. Overwrite with new credentials?',
+    });
+    if (p.isCancel(shouldOverwrite) || !shouldOverwrite) {
+      p.cancel('Login cancelled.');
+      return;
+    }
+  }
+
+  const state = crypto.randomUUID();
+
+  if (output.isAgentMode()) {
+    output.json({ error: 'Browser login not available in agent mode. Use: one login --key <api-key>' });
+    return;
+  }
+
+  const spin = p.spinner();
+
+  // Start localhost callback server
+  let server: http.Server;
+  let port: number;
+  let resultPromise: Promise<CallbackPayload>;
+
+  try {
+    ({ server, port, result: resultPromise } = await startCallbackServer(state));
+  } catch (err) {
+    output.error('Could not start local server. Try: one login --key <api-key>');
+    return;
+  }
+
+  const authUrl = getCliAuthUrl(port, state);
+
+  p.note(
+    `If the browser doesn't open, visit:\n${authUrl}`,
+    'Opening browser for authentication...'
+  );
+
+  // Open browser
+  try {
+    await openCliAuthPage(port, state);
+  } catch {
+    // Browser open failed — URL is already displayed above
+  }
+
+  spin.start('Waiting for authentication... (timeout: 5 min)');
+
+  // Wait for callback or timeout
+  const timeout = new Promise<never>((_, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('timeout'));
+    }, LOGIN_TIMEOUT_MS);
+    // Allow process to exit if the timeout is the only thing keeping it alive
+    timer.unref();
+  });
+
+  try {
+    const payload = await Promise.race([resultPromise, timeout]);
+    spin.stop('Authentication received!');
+
+    const displayName = payload.userName || payload.userEmail || 'Unknown';
+
+    saveCredentials({
+      apiKey: payload.apiKey,
+      keyId: payload.keyId,
+      userEmail: payload.userEmail,
+      userName: payload.userName,
+    });
+
+    if (displayName !== 'Unknown') {
+      p.log.success(`Authenticated as ${displayName}${payload.userEmail ? ` (${payload.userEmail})` : ''}`);
+    }
+    p.log.success('API key stored in ~/.one/config.json');
+    p.outro('You\'re all set!');
+  } catch (err) {
+    spin.stop('Authentication failed.');
+    if (err instanceof Error && err.message === 'timeout') {
+      output.error('Authentication timed out (5 min). Try again with: one login');
+    } else if (err instanceof ApiError) {
+      output.error(`Authentication failed: ${err.message}`);
+    } else {
+      output.error('Authentication failed. Try: one login --key <api-key>');
+    }
+  } finally {
+    server!.close();
+  }
+}
+
+async function loginWithKey(key: string): Promise<void> {
+  // Validate format
+  if (!key.startsWith('sk_live_') && !key.startsWith('sk_test_')) {
+    output.error('Invalid key format. Keys start with sk_live_ or sk_test_');
+    return;
+  }
+
+  if (!output.isAgentMode()) {
+    const spin = p.spinner();
+    spin.start('Validating API key...');
+
+    try {
+      const apiBase = getApiBase();
+      const api = new OneApi(key, apiBase);
+      const isValid = await api.validateApiKey();
+      if (!isValid) throw new ApiError(401, 'Invalid API key');
+      spin.stop('Key validated!');
+
+      saveCredentials({ apiKey: key });
+
+      p.log.success('API key stored in ~/.one/config.json');
+      p.outro('You\'re all set!');
+    } catch (err) {
+      spin.stop('Validation failed.');
+      if (err instanceof ApiError && err.status === 401) {
+        output.error('Invalid API key. Check your key and try again.');
+      } else {
+        output.error('Could not validate key. Check your network connection.');
+      }
+    }
+  } else {
+    try {
+      const apiBase = getApiBase();
+      const api = new OneApi(key, apiBase);
+      await api.validateApiKey();
+
+      saveCredentials({ apiKey: key });
+
+      output.json({ status: 'authenticated', message: 'API key stored successfully.' });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        output.json({ error: 'Invalid API key.' });
+      } else {
+        output.json({ error: 'Could not validate key.' });
+      }
+      process.exit(1);
+    }
+  }
+}

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -5,6 +5,7 @@ import { OneApi, ApiError } from '../lib/api.js';
 import { getApiKey, writeConfig, resolveConfig, readGlobalConfig, readProjectConfig, getApiBase, getEnvFromApiKey, type ConfigScope } from '../lib/config.js';
 import { getCliAuthUrl, openCliAuthPage } from '../lib/browser.js';
 import * as output from '../lib/output.js';
+import type { WhoAmIResponse } from '../lib/types.js';
 
 const LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const PORT_RANGE_START = 49152;
@@ -20,19 +21,6 @@ const SUCCESS_HTML = `<!DOCTYPE html>
 <h1 style="font-size:20px;margin:0 0 8px">You're all set!</h1>
 <p style="color:#a1a1aa;font-size:14px">Return to your terminal. You can close this tab.</p>
 </div></body></html>`;
-
-function saveCredentials(apiKey: string, scope: ConfigScope): void {
-  // Read existing config for the target scope to preserve settings
-  const existing = scope === 'project' ? readProjectConfig() : readGlobalConfig();
-  writeConfig({
-    apiKey,
-    installedAgents: existing?.installedAgents ?? [],
-    createdAt: new Date().toISOString(),
-    accessControl: existing?.accessControl,
-    cacheTtl: existing?.cacheTtl,
-    apiBase: existing?.apiBase,
-  }, scope);
-}
 
 interface CallbackPayload {
   apiKey: string;
@@ -107,6 +95,93 @@ function startCallbackServer(
   });
 }
 
+// ── Reusable browser auth flow ──────────────────────────────────────
+// Returns { apiKey, whoami } on success, null on failure/cancel.
+// Handles the local callback server, browser open, and whoami validation.
+// Does NOT handle scope selection, credential saving, or post-login UX.
+
+export interface BrowserLoginResult {
+  apiKey: string;
+  whoami: WhoAmIResponse;
+}
+
+export async function browserLogin(): Promise<BrowserLoginResult | null> {
+  const state = crypto.randomUUID();
+  const spin = p.spinner();
+
+  let server: http.Server;
+  let port: number;
+  let resultPromise: Promise<CallbackPayload>;
+
+  try {
+    ({ server, port, result: resultPromise } = await startCallbackServer(state));
+  } catch {
+    output.error('Could not start local server. Try: one init');
+    return null;
+  }
+
+  const authUrl = getCliAuthUrl(port, state);
+
+  p.note(
+    `If the browser doesn't open, visit:\n${authUrl}`,
+    'Opening browser for authentication...'
+  );
+
+  try {
+    await openCliAuthPage(port, state);
+  } catch {
+    // Browser open failed — URL is already displayed above
+  }
+
+  spin.start('Waiting for authentication... (timeout: 5 min)');
+
+  const timeout = new Promise<never>((_, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('timeout'));
+    }, LOGIN_TIMEOUT_MS);
+    timer.unref();
+  });
+
+  try {
+    const payload = await Promise.race([resultPromise, timeout]);
+    spin.stop('Authentication received!');
+
+    // Fetch whoami
+    const apiBase = getApiBase();
+    const api = new OneApi(payload.apiKey, apiBase);
+    const whoami = await api.whoami();
+
+    return { apiKey: payload.apiKey, whoami };
+  } catch (err) {
+    spin.stop('Authentication failed.');
+    if (err instanceof Error && err.message === 'timeout') {
+      output.error('Authentication timed out (5 min). Try again with: one login');
+    } else if (err instanceof ApiError) {
+      output.error(`Authentication failed: ${err.message}`);
+    } else {
+      output.error('Authentication failed. Try: one init');
+    }
+    return null;
+  } finally {
+    server!.closeAllConnections();
+    server!.close();
+  }
+}
+
+// ── Standalone login command ────────────────────────────────────────
+
+function saveCredentials(apiKey: string, scope: ConfigScope): void {
+  const existing = scope === 'project' ? readProjectConfig() : readGlobalConfig();
+  writeConfig({
+    apiKey,
+    installedAgents: existing?.installedAgents ?? [],
+    createdAt: new Date().toISOString(),
+    accessControl: existing?.accessControl,
+    cacheTtl: existing?.cacheTtl,
+    apiBase: existing?.apiBase,
+  }, scope);
+}
+
 export async function loginCommand(): Promise<void> {
   if (output.isAgentMode()) {
     output.json({ error: 'Browser login not available in agent mode. Use: one init' });
@@ -158,117 +233,58 @@ export async function loginCommand(): Promise<void> {
     targetScope = scopeChoice as ConfigScope;
   }
 
-  const state = crypto.randomUUID();
+  // Run browser auth
+  const result = await browserLogin();
+  if (!result) return;
 
-  const spin = p.spinner();
+  const { apiKey, whoami } = result;
 
-  // Start localhost callback server
-  let server: http.Server;
-  let port: number;
-  let resultPromise: Promise<CallbackPayload>;
-
-  try {
-    ({ server, port, result: resultPromise } = await startCallbackServer(state));
-  } catch (err) {
-    output.error('Could not start local server. Try: one init');
-    return;
+  // Save credentials and whoami
+  saveCredentials(apiKey, targetScope);
+  const resolved = resolveConfig();
+  if (resolved.config) {
+    writeConfig({ ...resolved.config, whoami }, targetScope);
   }
 
-  const authUrl = getCliAuthUrl(port, state);
+  // Display result
+  const pc = (await import('picocolors')).default;
+  const env = getEnvFromApiKey(apiKey);
+  const contextParts: string[] = [];
+  if (whoami.organization) contextParts.push(whoami.organization.name);
+  if (whoami.project) contextParts.push(whoami.project.name);
+  const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
+  const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
+  const configLabel = targetScope === 'project'
+    ? pc.cyan('local config')
+    : pc.magenta('global config');
 
-  p.note(
-    `If the browser doesn't open, visit:\n${authUrl}`,
-    'Opening browser for authentication...'
-  );
+  const infoLines = [
+    `${pc.bold(scopeDisplay)} ${pc.dim('·')} ${envLabel}`,
+    `${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`,
+  ];
+  if (whoami.organization) infoLines.push(`${pc.dim('Org:')} ${whoami.organization.name}`);
+  if (whoami.project) infoLines.push(`${pc.dim('Project:')} ${whoami.project.name}`);
+  infoLines.push('');
+  infoLines.push(`${pc.dim('Stored in')} ${configLabel}`);
+  p.note(infoLines.join('\n'), 'Logged in');
 
-  // Open browser
-  try {
-    await openCliAuthPage(port, state);
-  } catch {
-    // Browser open failed — URL is already displayed above
-  }
-
-  spin.start('Waiting for authentication... (timeout: 5 min)');
-
-  // Wait for callback or timeout
-  const timeout = new Promise<never>((_, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error('timeout'));
-    }, LOGIN_TIMEOUT_MS);
-    // Allow process to exit if the timeout is the only thing keeping it alive
-    timer.unref();
-  });
-
-  try {
-    const payload = await Promise.race([resultPromise, timeout]);
-    spin.stop('Authentication received!');
-
-    // Save key first
-    saveCredentials(payload.apiKey, targetScope);
-
-    // Call whoami to get user info and store it
-    const apiBase = getApiBase();
-    const api = new OneApi(payload.apiKey, apiBase);
-    const whoami = await api.whoami();
-
-    // Update config with whoami data
-    const resolved = resolveConfig();
-    if (resolved.config) {
-      writeConfig({ ...resolved.config, whoami }, targetScope);
-    }
-
-    // Display in same format as `one whoami`
-    const pc = (await import('picocolors')).default;
-    const env = getEnvFromApiKey(payload.apiKey);
-    const contextParts: string[] = [];
-    if (whoami.organization) contextParts.push(whoami.organization.name);
-    if (whoami.project) contextParts.push(whoami.project.name);
-    const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
-    const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
-    const configLabel = targetScope === 'project'
-      ? pc.cyan('local config')
-      : pc.magenta('global config');
-
-    const infoLines = [
-      `${pc.bold(scopeDisplay)} ${pc.dim('·')} ${envLabel}`,
-      `${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`,
-    ];
-    if (whoami.organization) infoLines.push(`${pc.dim('Org:')} ${whoami.organization.name}`);
-    if (whoami.project) infoLines.push(`${pc.dim('Project:')} ${whoami.project.name}`);
-    infoLines.push('');
-    infoLines.push(`${pc.dim('Stored in')} ${configLabel}`);
-    p.note(infoLines.join('\n'), 'Logged in');
-
-    console.log();
-    console.log(`  ${pc.dim('Next steps:')}`);
-    console.log(`  ${pc.cyan('one add <platform>')}  ${pc.dim('—')} Connect a platform (e.g. gmail, slack, stripe)`);
-    console.log();
-    console.log(pc.bold('  Copy-paste this to your AI agent:'));
-    console.log();
-    console.log(pc.cyan('  ┌─────────────────────────────────────────────────────────────'));
-    console.log(pc.cyan('  │'));
-    console.log(pc.cyan('  │  The One CLI (`one`) is now installed on this machine. It'));
-    console.log(pc.cyan('  │  lets you interact with 250+ third-party platforms (Gmail,'));
-    console.log(pc.cyan('  │  Slack, Shopify, HubSpot, Stripe, GitHub, etc.) through'));
-    console.log(pc.cyan('  │  their APIs. Whenever you need to interact with any'));
-    console.log(pc.cyan('  │  third-party platform or external service, use the `one`'));
-    console.log(pc.cyan('  │  skill. Please save this to your project instructions or'));
-    console.log(pc.cyan('  │  memory so you remember it in future conversations.'));
-    console.log(pc.cyan('  │'));
-    console.log(pc.cyan('  └─────────────────────────────────────────────────────────────'));
-    console.log();
-    p.outro('Happy building!');
-  } catch (err) {
-    spin.stop('Authentication failed.');
-    if (err instanceof Error && err.message === 'timeout') {
-      output.error('Authentication timed out (5 min). Try again with: one login');
-    } else if (err instanceof ApiError) {
-      output.error(`Authentication failed: ${err.message}`);
-    } else {
-      output.error('Authentication failed. Try: one init');
-    }
-  } finally {
-    server!.closeAllConnections();
-    server!.close();
-  }
+  console.log();
+  console.log(`  ${pc.dim('Next steps:')}`);
+  console.log(`  ${pc.cyan('one add <platform>')}  ${pc.dim('—')} Connect a platform (e.g. gmail, slack, stripe)`);
+  console.log();
+  console.log(pc.bold('  Copy-paste this to your AI agent:'));
+  console.log();
+  console.log(pc.cyan('  ┌─────────────────────────────────────────────────────────────'));
+  console.log(pc.cyan('  │'));
+  console.log(pc.cyan('  │  The One CLI (`one`) is now installed on this machine. It'));
+  console.log(pc.cyan('  │  lets you interact with 250+ third-party platforms (Gmail,'));
+  console.log(pc.cyan('  │  Slack, Shopify, HubSpot, Stripe, GitHub, etc.) through'));
+  console.log(pc.cyan('  │  their APIs. Whenever you need to interact with any'));
+  console.log(pc.cyan('  │  third-party platform or external service, use the `one`'));
+  console.log(pc.cyan('  │  skill. Please save this to your project instructions or'));
+  console.log(pc.cyan('  │  memory so you remember it in future conversations.'));
+  console.log(pc.cyan('  │'));
+  console.log(pc.cyan('  └─────────────────────────────────────────────────────────────'));
+  console.log();
+  p.outro('Happy building!');
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,8 +1,8 @@
 import http from 'node:http';
 import crypto from 'node:crypto';
 import * as p from '@clack/prompts';
-import { OneApi, ApiError } from '../lib/api.js';
-import { getApiKey, writeConfig, readConfig, getApiBase } from '../lib/config.js';
+import { ApiError } from '../lib/api.js';
+import { getApiKey, writeConfig, resolveConfig } from '../lib/config.js';
 import { getCliAuthUrl, openCliAuthPage } from '../lib/browser.js';
 import * as output from '../lib/output.js';
 
@@ -27,7 +27,9 @@ function saveCredentials(opts: {
   userEmail?: string;
   userName?: string;
 }): void {
-  const existing = readConfig();
+  const resolved = resolveConfig();
+  const scope = resolved.scope ?? 'global';
+  const existing = resolved.config;
   writeConfig({
     apiKey: opts.apiKey,
     keyId: opts.keyId,
@@ -38,7 +40,7 @@ function saveCredentials(opts: {
     accessControl: existing?.accessControl,
     cacheTtl: existing?.cacheTtl,
     apiBase: existing?.apiBase,
-  }, 'global');
+  }, scope);
 }
 
 interface CallbackPayload {
@@ -77,11 +79,13 @@ function startCallbackServer(
           return;
         }
 
-        const apiKey = url.searchParams.get('apiKey');
-        const keyId = url.searchParams.get('keyId') || '';
+        const encodedKey = url.searchParams.get('s');
+        const keyId = url.searchParams.get('k') || '';
         const state = url.searchParams.get('state');
-        const userEmail = url.searchParams.get('userEmail') || undefined;
-        const userName = url.searchParams.get('userName') || undefined;
+        const userEmail = url.searchParams.get('e') || undefined;
+        const userName = url.searchParams.get('n') || undefined;
+
+        const apiKey = encodedKey ? Buffer.from(encodedKey, 'base64').toString('utf-8') : null;
 
         if (!apiKey || !state) {
           res.writeHead(400, { 'Content-Type': 'text/plain' });
@@ -118,18 +122,12 @@ function startCallbackServer(
   });
 }
 
-export async function loginCommand(options: { key?: string }): Promise<void> {
-  // --key flag: manual key input
-  if (options.key) {
-    await loginWithKey(options.key);
-    return;
-  }
-
+export async function loginCommand(): Promise<void> {
   // Check if already logged in
   const existingKey = getApiKey();
   if (existingKey) {
     if (output.isAgentMode()) {
-      output.json({ status: 'already_authenticated', message: 'Already logged in. Use --key to update.' });
+      output.json({ status: 'already_authenticated', message: 'Already logged in. Run one init to update key manually.' });
       return;
     }
     const shouldOverwrite = await p.confirm({
@@ -144,7 +142,7 @@ export async function loginCommand(options: { key?: string }): Promise<void> {
   const state = crypto.randomUUID();
 
   if (output.isAgentMode()) {
-    output.json({ error: 'Browser login not available in agent mode. Use: one login --key <api-key>' });
+    output.json({ error: 'Browser login not available in agent mode. Use: one init' });
     return;
   }
 
@@ -158,7 +156,7 @@ export async function loginCommand(options: { key?: string }): Promise<void> {
   try {
     ({ server, port, result: resultPromise } = await startCallbackServer(state));
   } catch (err) {
-    output.error('Could not start local server. Try: one login --key <api-key>');
+    output.error('Could not start local server. Try: one init');
     return;
   }
 
@@ -203,7 +201,9 @@ export async function loginCommand(options: { key?: string }): Promise<void> {
     if (displayName !== 'Unknown') {
       p.log.success(`Authenticated as ${displayName}${payload.userEmail ? ` (${payload.userEmail})` : ''}`);
     }
-    p.log.success('API key stored in ~/.one/config.json');
+    const { scope: savedScope } = resolveConfig();
+    const scopeLabel = savedScope === 'project' ? 'project config' : '~/.one/config.json';
+    p.log.success(`API key stored in ${scopeLabel}`);
     p.outro('You\'re all set!');
   } catch (err) {
     spin.stop('Authentication failed.');
@@ -212,59 +212,9 @@ export async function loginCommand(options: { key?: string }): Promise<void> {
     } else if (err instanceof ApiError) {
       output.error(`Authentication failed: ${err.message}`);
     } else {
-      output.error('Authentication failed. Try: one login --key <api-key>');
+      output.error('Authentication failed. Try: one init');
     }
   } finally {
     server!.close();
-  }
-}
-
-async function loginWithKey(key: string): Promise<void> {
-  // Validate format
-  if (!key.startsWith('sk_live_') && !key.startsWith('sk_test_')) {
-    output.error('Invalid key format. Keys start with sk_live_ or sk_test_');
-    return;
-  }
-
-  if (!output.isAgentMode()) {
-    const spin = p.spinner();
-    spin.start('Validating API key...');
-
-    try {
-      const apiBase = getApiBase();
-      const api = new OneApi(key, apiBase);
-      const isValid = await api.validateApiKey();
-      if (!isValid) throw new ApiError(401, 'Invalid API key');
-      spin.stop('Key validated!');
-
-      saveCredentials({ apiKey: key });
-
-      p.log.success('API key stored in ~/.one/config.json');
-      p.outro('You\'re all set!');
-    } catch (err) {
-      spin.stop('Validation failed.');
-      if (err instanceof ApiError && err.status === 401) {
-        output.error('Invalid API key. Check your key and try again.');
-      } else {
-        output.error('Could not validate key. Check your network connection.');
-      }
-    }
-  } else {
-    try {
-      const apiBase = getApiBase();
-      const api = new OneApi(key, apiBase);
-      await api.validateApiKey();
-
-      saveCredentials({ apiKey: key });
-
-      output.json({ status: 'authenticated', message: 'API key stored successfully.' });
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 401) {
-        output.json({ error: 'Invalid API key.' });
-      } else {
-        output.json({ error: 'Could not validate key.' });
-      }
-      process.exit(1);
-    }
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,7 +2,7 @@ import http from 'node:http';
 import crypto from 'node:crypto';
 import * as p from '@clack/prompts';
 import { OneApi, ApiError } from '../lib/api.js';
-import { getApiKey, writeConfig, resolveConfig, getApiBase, getEnvFromApiKey } from '../lib/config.js';
+import { getApiKey, writeConfig, resolveConfig, readGlobalConfig, readProjectConfig, getApiBase, getEnvFromApiKey, type ConfigScope } from '../lib/config.js';
 import { getCliAuthUrl, openCliAuthPage } from '../lib/browser.js';
 import * as output from '../lib/output.js';
 
@@ -21,10 +21,9 @@ const SUCCESS_HTML = `<!DOCTYPE html>
 <p style="color:#a1a1aa;font-size:14px">Return to your terminal. You can close this tab.</p>
 </div></body></html>`;
 
-function saveCredentials(apiKey: string): void {
-  const resolved = resolveConfig();
-  const scope = resolved.scope ?? 'global';
-  const existing = resolved.config;
+function saveCredentials(apiKey: string, scope: ConfigScope): void {
+  // Read existing config for the target scope to preserve settings
+  const existing = scope === 'project' ? readProjectConfig() : readGlobalConfig();
   writeConfig({
     apiKey,
     installedAgents: existing?.installedAgents ?? [],
@@ -109,28 +108,57 @@ function startCallbackServer(
 }
 
 export async function loginCommand(): Promise<void> {
-  // Check if already logged in
-  const existingKey = getApiKey();
-  if (existingKey) {
-    if (output.isAgentMode()) {
-      output.json({ status: 'already_authenticated', message: 'Already logged in. Run one init to update key manually.' });
-      return;
-    }
-    const shouldOverwrite = await p.confirm({
-      message: 'You are already logged in. Overwrite with new credentials?',
-    });
-    if (p.isCancel(shouldOverwrite) || !shouldOverwrite) {
-      p.cancel('Login cancelled.');
-      return;
-    }
-  }
-
-  const state = crypto.randomUUID();
-
   if (output.isAgentMode()) {
     output.json({ error: 'Browser login not available in agent mode. Use: one init' });
     return;
   }
+
+  // Determine login scope
+  let targetScope: ConfigScope = 'global';
+  const existingKey = getApiKey();
+
+  if (existingKey) {
+    // Show current session info (same format as `one whoami`)
+    const pc = (await import('picocolors')).default;
+    const resolved = resolveConfig();
+    const whoami = resolved.config?.whoami;
+    const env = getEnvFromApiKey(existingKey);
+    const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
+    const currentScope = resolved.scope === 'project'
+      ? pc.cyan('local config')
+      : pc.magenta('global config');
+
+    const lines: string[] = ['You are already logged in.', ''];
+    if (whoami) {
+      const contextParts: string[] = [];
+      if (whoami.organization) contextParts.push(whoami.organization.name);
+      if (whoami.project) contextParts.push(whoami.project.name);
+      const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
+      lines.push(`${pc.bold(scopeDisplay)} ${pc.dim('·')} ${envLabel}`);
+      lines.push(`${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`);
+      if (whoami.organization) lines.push(`${pc.dim('Org:')} ${whoami.organization.name}`);
+      if (whoami.project) lines.push(`${pc.dim('Project:')} ${whoami.project.name}`);
+    }
+    lines.push('');
+    lines.push(`${pc.dim('Stored in')} ${currentScope}`);
+    p.note(lines.join('\n'));
+
+    // Let user pick scope for new login
+    const scopeChoice = await p.select({
+      message: 'Where would you like to log in?',
+      options: [
+        { value: 'global', label: 'Globally', hint: 'applies everywhere' },
+        { value: 'project', label: 'This directory', hint: 'only this project' },
+      ],
+    });
+    if (p.isCancel(scopeChoice)) {
+      p.cancel('Login cancelled.');
+      return;
+    }
+    targetScope = scopeChoice as ConfigScope;
+  }
+
+  const state = crypto.randomUUID();
 
   const spin = p.spinner();
 
@@ -176,7 +204,7 @@ export async function loginCommand(): Promise<void> {
     spin.stop('Authentication received!');
 
     // Save key first
-    saveCredentials(payload.apiKey);
+    saveCredentials(payload.apiKey, targetScope);
 
     // Call whoami to get user info and store it
     const apiBase = getApiBase();
@@ -186,7 +214,7 @@ export async function loginCommand(): Promise<void> {
     // Update config with whoami data
     const resolved = resolveConfig();
     if (resolved.config) {
-      writeConfig({ ...resolved.config, whoami }, resolved.scope ?? 'global');
+      writeConfig({ ...resolved.config, whoami }, targetScope);
     }
 
     // Display in same format as `one whoami`
@@ -197,18 +225,39 @@ export async function loginCommand(): Promise<void> {
     if (whoami.project) contextParts.push(whoami.project.name);
     const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
     const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
-    const configLabel = resolved.scope === 'project'
-      ? pc.cyan('project config')
+    const configLabel = targetScope === 'project'
+      ? pc.cyan('local config')
       : pc.magenta('global config');
 
+    const infoLines = [
+      `${pc.bold(scopeDisplay)} ${pc.dim('·')} ${envLabel}`,
+      `${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`,
+    ];
+    if (whoami.organization) infoLines.push(`${pc.dim('Org:')} ${whoami.organization.name}`);
+    if (whoami.project) infoLines.push(`${pc.dim('Project:')} ${whoami.project.name}`);
+    infoLines.push('');
+    infoLines.push(`${pc.dim('Stored in')} ${configLabel}`);
+    p.note(infoLines.join('\n'), 'Logged in');
+
     console.log();
-    console.log(`  ${pc.bold(scopeDisplay)} ${pc.dim('·')} ${envLabel}`);
-    console.log(`  ${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`);
-    if (whoami.organization) console.log(`  ${pc.dim('Org:')} ${whoami.organization.name}`);
-    if (whoami.project) console.log(`  ${pc.dim('Project:')} ${whoami.project.name}`);
+    console.log(`  ${pc.dim('Next steps:')}`);
+    console.log(`  ${pc.cyan('one add <platform>')}  ${pc.dim('—')} Connect a platform (e.g. gmail, slack, stripe)`);
     console.log();
-    console.log(`  ${pc.dim('Stored in')} ${configLabel}`);
-    p.outro('Run `one whoami` for full details.');
+    console.log(pc.bold('  Copy-paste this to your AI agent:'));
+    console.log();
+    console.log(pc.cyan('  ┌─────────────────────────────────────────────────────────────'));
+    console.log(pc.cyan('  │'));
+    console.log(pc.cyan('  │  The One CLI (`one`) is now installed on this machine. It'));
+    console.log(pc.cyan('  │  lets you interact with 250+ third-party platforms (Gmail,'));
+    console.log(pc.cyan('  │  Slack, Shopify, HubSpot, Stripe, GitHub, etc.) through'));
+    console.log(pc.cyan('  │  their APIs. Whenever you need to interact with any'));
+    console.log(pc.cyan('  │  third-party platform or external service, use the `one`'));
+    console.log(pc.cyan('  │  skill. Please save this to your project instructions or'));
+    console.log(pc.cyan('  │  memory so you remember it in future conversations.'));
+    console.log(pc.cyan('  │'));
+    console.log(pc.cyan('  └─────────────────────────────────────────────────────────────'));
+    console.log();
+    p.outro('Happy building!');
   } catch (err) {
     spin.stop('Authentication failed.');
     if (err instanceof Error && err.message === 'timeout') {
@@ -219,6 +268,7 @@ export async function loginCommand(): Promise<void> {
       output.error('Authentication failed. Try: one init');
     }
   } finally {
+    server!.closeAllConnections();
     server!.close();
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -196,11 +196,17 @@ export async function loginCommand(): Promise<void> {
     }
 
     const displayName = whoami.user.name || whoami.user.email;
-    p.log.success(`Authenticated as ${displayName} (${whoami.user.email})`);
+    const contextParts: string[] = [];
+    if (whoami.organization) contextParts.push(whoami.organization.name);
+    if (whoami.project) contextParts.push(whoami.project.name);
+    const scopeInfo = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
 
-    const scopeLabel = resolved.scope === 'project' ? 'project config' : '~/.one/config.json';
-    p.log.success(`API key stored in ${scopeLabel}`);
-    p.outro('You\'re all set!');
+    p.log.success(`Authenticated as ${displayName} (${whoami.user.email})`);
+    p.log.info(`Account: ${scopeInfo}`);
+
+    const configLabel = resolved.scope === 'project' ? 'project config' : '~/.one/config.json';
+    p.log.success(`API key stored in ${configLabel}`);
+    p.outro('Run `one whoami` for full details.');
   } catch (err) {
     spin.stop('Authentication failed.');
     if (err instanceof Error && err.message === 'timeout') {

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import * as p from '@clack/prompts';
-import { getApiKey, getGlobalConfigPath } from '../lib/config.js';
+import { getApiKey, resolveConfig } from '../lib/config.js';
 import * as output from '../lib/output.js';
 
 export async function logoutCommand(): Promise<void> {
@@ -15,7 +15,8 @@ export async function logoutCommand(): Promise<void> {
     return;
   }
 
-  const configPath = getGlobalConfigPath();
+  const resolved = resolveConfig();
+  const configPath = resolved.path;
   if (fs.existsSync(configPath)) {
     fs.unlinkSync(configPath);
   }

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import * as p from '@clack/prompts';
+import { getApiKey, getGlobalConfigPath } from '../lib/config.js';
+import * as output from '../lib/output.js';
+
+export async function logoutCommand(): Promise<void> {
+  const apiKey = getApiKey();
+
+  if (!apiKey) {
+    if (output.isAgentMode()) {
+      output.json({ error: 'Not logged in.' });
+      process.exit(1);
+    }
+    output.error('Not logged in. Run: one login');
+    return;
+  }
+
+  const configPath = getGlobalConfigPath();
+  if (fs.existsSync(configPath)) {
+    fs.unlinkSync(configPath);
+  }
+
+  if (output.isAgentMode()) {
+    output.json({ status: 'logged_out', message: 'Local credentials cleared.' });
+  } else {
+    p.log.success('Local credentials cleared.');
+    p.log.info('Your API key is still active. Manage keys at app.withone.ai/settings');
+    p.outro('Logged out.');
+  }
+}

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,7 +1,35 @@
 import fs from 'node:fs';
 import * as p from '@clack/prompts';
-import { getApiKey, resolveConfig } from '../lib/config.js';
+import {
+  getApiKey,
+  readGlobalConfig,
+  readProjectConfig,
+  getGlobalConfigPath,
+  getProjectConfigPath,
+  getEnvFromApiKey,
+} from '../lib/config.js';
 import * as output from '../lib/output.js';
+import type { Config } from '../lib/types.js';
+
+function formatWhoami(config: Config, apiKey: string, pc: typeof import('picocolors').default): string[] {
+  const whoami = config.whoami;
+  const env = getEnvFromApiKey(apiKey);
+  const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
+  const lines: string[] = [];
+
+  if (whoami) {
+    const contextParts: string[] = [];
+    if (whoami.organization) contextParts.push(whoami.organization.name);
+    if (whoami.project) contextParts.push(whoami.project.name);
+    const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
+    lines.push(`${pc.bold(scopeDisplay)} ${pc.dim('·')} ${envLabel}`);
+    lines.push(`${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`);
+  } else {
+    lines.push(`${pc.dim('Key:')} ${apiKey.slice(0, 8)}... ${pc.dim('·')} ${envLabel}`);
+  }
+
+  return lines;
+}
 
 export async function logoutCommand(): Promise<void> {
   const apiKey = getApiKey();
@@ -15,17 +43,99 @@ export async function logoutCommand(): Promise<void> {
     return;
   }
 
-  const resolved = resolveConfig();
-  const configPath = resolved.path;
-  if (fs.existsSync(configPath)) {
-    fs.unlinkSync(configPath);
+  if (output.isAgentMode()) {
+    // Agent mode: clear resolved config, no prompts
+    const globalPath = getGlobalConfigPath();
+    const projectPath = getProjectConfigPath();
+    let cleared = false;
+    if (fs.existsSync(projectPath)) { fs.unlinkSync(projectPath); cleared = true; }
+    if (fs.existsSync(globalPath)) { fs.unlinkSync(globalPath); cleared = true; }
+    output.json({ status: cleared ? 'logged_out' : 'not_logged_in', message: cleared ? 'Credentials cleared.' : 'No config found.' });
+    return;
   }
 
-  if (output.isAgentMode()) {
-    output.json({ status: 'logged_out', message: 'Local credentials cleared.' });
+  const pc = (await import('picocolors')).default;
+  const globalConfig = readGlobalConfig();
+  const projectConfig = readProjectConfig();
+  const hasGlobal = globalConfig?.apiKey != null;
+  const hasProject = projectConfig?.apiKey != null;
+
+  // Build scope options based on what exists
+  type LogoutScope = 'global' | 'project' | 'both';
+  let targetScope: LogoutScope;
+
+  if (hasGlobal && hasProject) {
+    // Both exist — let user choose
+    const infoLines = ['You are logged in with multiple configs.', ''];
+    if (projectConfig) {
+      infoLines.push(`${pc.cyan('Local config:')}`);
+      infoLines.push(...formatWhoami(projectConfig, projectConfig.apiKey, pc));
+      infoLines.push('');
+    }
+    if (globalConfig) {
+      infoLines.push(`${pc.magenta('Global config:')}`);
+      infoLines.push(...formatWhoami(globalConfig, globalConfig.apiKey, pc));
+    }
+    p.note(infoLines.join('\n'));
+
+    const choice = await p.select({
+      message: 'What would you like to log out of?',
+      options: [
+        { value: 'project', label: 'This directory', hint: 'local config only' },
+        { value: 'global', label: 'Globally', hint: 'global config only' },
+        { value: 'both', label: 'Both', hint: 'remove all credentials' },
+      ],
+    });
+    if (p.isCancel(choice)) {
+      p.cancel('Logout cancelled.');
+      return;
+    }
+    targetScope = choice as LogoutScope;
+  } else if (hasProject) {
+    const infoLines = ['You are logged in.', ''];
+    infoLines.push(`${pc.dim('Stored in')} ${pc.cyan('local config')}`);
+    infoLines.push(...formatWhoami(projectConfig!, projectConfig!.apiKey, pc));
+    p.note(infoLines.join('\n'));
+    targetScope = 'project';
+  } else if (hasGlobal) {
+    const infoLines = ['You are logged in.', ''];
+    infoLines.push(`${pc.dim('Stored in')} ${pc.magenta('global config')}`);
+    infoLines.push(...formatWhoami(globalConfig!, globalConfig!.apiKey, pc));
+    p.note(infoLines.join('\n'));
+    targetScope = 'global';
   } else {
-    p.log.success('Local credentials cleared.');
-    p.log.info('Your API key is still active. Manage keys at app.withone.ai/settings');
-    p.outro('Logged out.');
+    // Key comes from env var or .onerc — no config file to delete
+    p.log.warn('Credentials are set via environment variable or .onerc, not a config file.');
+    p.log.info('Remove the ONE_SECRET variable from your environment or .onerc file.');
+    p.outro('Nothing to remove.');
+    return;
   }
+
+  // Confirm
+  const scopeLabels: Record<LogoutScope, string> = {
+    project: 'local',
+    global: 'global',
+    both: 'all',
+  };
+  const confirm = await p.confirm({
+    message: `Remove ${scopeLabels[targetScope]} credentials?`,
+  });
+  if (p.isCancel(confirm) || !confirm) {
+    p.cancel('Logout cancelled.');
+    return;
+  }
+
+  // Delete
+  if (targetScope === 'project' || targetScope === 'both') {
+    const projectPath = getProjectConfigPath();
+    if (fs.existsSync(projectPath)) fs.unlinkSync(projectPath);
+  }
+  if (targetScope === 'global' || targetScope === 'both') {
+    const globalPath = getGlobalConfigPath();
+    if (fs.existsSync(globalPath)) fs.unlinkSync(globalPath);
+  }
+
+  p.log.success('Credentials cleared.');
+  p.log.info('Your API key is still active. Manage keys at app.withone.ai/settings');
+  p.outro('Logged out.');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,6 @@ program
 
   Setup:
     one login                             Authenticate via browser (opens app.withone.ai)
-    one login --key <key>                 Authenticate with an API key directly
     one logout                            Clear local credentials
     one init                              Set up API key and install MCP server
     one add <platform>                    Connect a platform via OAuth (e.g. gmail, slack, shopify)
@@ -163,10 +162,9 @@ program
 
 program
   .command('login')
-  .description('Authenticate with One via browser or API key')
-  .option('-k, --key <api-key>', 'Authenticate with an API key directly (for CI/CD or manual setup)')
-  .action(async (options) => {
-    await loginCommand(options);
+  .description('Authenticate with One via browser')
+  .action(async () => {
+    await loginCommand();
   });
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,8 @@ import { registerSyncCommands } from './lib/sync/index.js';
 import { cacheClearCommand, cacheListCommand, cacheUpdateAllCommand } from './commands/cache.js';
 import { guideCommand } from './commands/guide.js';
 import { onboardCommand } from './commands/onboard.js';
+import { loginCommand } from './commands/login.js';
+import { logoutCommand } from './commands/logout.js';
 import { updateCommand, checkLatestVersionCached, getCurrentVersion, isNewerVersion, autoUpdate } from './commands/update.js';
 import { setAgentMode, isAgentMode, json as outputJson, error as outputError } from './lib/output.js';
 import { syncSkillsIfStale, forceSyncSkills, getSkillStatus } from './lib/skill-sync.js';
@@ -56,6 +58,9 @@ program
   .description(`One CLI — Connect AI agents to 250+ platforms through one interface.
 
   Setup:
+    one login                             Authenticate via browser (opens app.withone.ai)
+    one login --key <key>                 Authenticate with an API key directly
+    one logout                            Clear local credentials
     one init                              Set up API key and install MCP server
     one add <platform>                    Connect a platform via OAuth (e.g. gmail, slack, shopify)
     one connection delete <key>           Remove a connection (alias: one connection rm)
@@ -154,6 +159,21 @@ program
   .option('-p, --project', 'Write the One config for this project only (~/.one/projects/<slug>/) — skips the scope picker')
   .action(async (options) => {
     await initCommand(options);
+  });
+
+program
+  .command('login')
+  .description('Authenticate with One via browser or API key')
+  .option('-k, --key <api-key>', 'Authenticate with an API key directly (for CI/CD or manual setup)')
+  .action(async (options) => {
+    await loginCommand(options);
+  });
+
+program
+  .command('logout')
+  .description('Clear local credentials')
+  .action(async () => {
+    await logoutCommand();
   });
 
 const config = program

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -18,3 +18,12 @@ export async function openConnectionPage(platform: string): Promise<void> {
 export async function openApiKeyPage(): Promise<void> {
   await open(getApiKeyUrl());
 }
+
+export function getCliAuthUrl(port: number, state: string): string {
+  return `${ONE_APP_URL}/cli/auth?port=${port}&state=${encodeURIComponent(state)}`;
+}
+
+export async function openCliAuthPage(port: number, state: string): Promise<void> {
+  const url = getCliAuthUrl(port, state);
+  await open(url);
+}

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -5,11 +5,11 @@ export const GUIDE_OVERVIEW = `# One CLI — Agent Guide
 
 ## Setup
 
-1. Run \`one login\` to authenticate via browser (opens app.withone.ai, creates API key automatically)
+1. Run \`one init\` for full interactive setup (authentication, skill installation, and platform connections)
 2. Run \`one add <platform>\` to connect platforms via OAuth
 3. Run \`one --agent connection list\` to verify connections
 
-Alternatively, run \`one init\` for the full interactive setup (includes MCP installation and platform connections).
+You can also use \`one login\` / \`one logout\` to manage authentication separately (global or per-directory).
 
 ## The --agent Flag
 

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -6,7 +6,6 @@ export const GUIDE_OVERVIEW = `# One CLI — Agent Guide
 ## Setup
 
 1. Run \`one login\` to authenticate via browser (opens app.withone.ai, creates API key automatically)
-   - Or use \`one login --key sk_live_...\` to authenticate with an existing API key
 2. Run \`one add <platform>\` to connect platforms via OAuth
 3. Run \`one --agent connection list\` to verify connections
 

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -5,9 +5,12 @@ export const GUIDE_OVERVIEW = `# One CLI — Agent Guide
 
 ## Setup
 
-1. Run \`one init\` to configure your API key (interactive — can be global or per-project)
+1. Run \`one login\` to authenticate via browser (opens app.withone.ai, creates API key automatically)
+   - Or use \`one login --key sk_live_...\` to authenticate with an existing API key
 2. Run \`one add <platform>\` to connect platforms via OAuth
 3. Run \`one --agent connection list\` to verify connections
+
+Alternatively, run \`one init\` for the full interactive setup (includes MCP installation and platform connections).
 
 ## The --agent Flag
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,6 +47,9 @@ export interface AccessControlSettings {
 
 export interface Config {
   apiKey: string;
+  keyId?: string;
+  userEmail?: string;
+  userName?: string;
   installedAgents: string[];
   createdAt: string;
   accessControl?: AccessControlSettings;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,7 +56,6 @@ export interface WhoAmIResponse {
 
 export interface Config {
   apiKey: string;
-  keyId?: string;
   installedAgents: string[];
   createdAt: string;
   accessControl?: AccessControlSettings;


### PR DESCRIPTION
Browser-based authentication flow: CLI starts a localhost server, opens the dashboard in the browser, user authenticates via GitHub/Google, dashboard creates an API key and redirects back to the CLI's localhost server with the key. Supports existing users (instant) and new users (sign-up → onboarding → auto-redirect back).

- one login: browser auth flow with localhost callback
- one login --key: manual API key input for CI/CD
- one logout: clears local credentials
- Updated one init to offer browser login as primary option
- Zero backend changes, all new endpoints use existing APIs
- Version bump 1.31.0 → 1.32.0