### PR TITLE
feat: whoami, scoped connection URLs, relay table fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -262,6 +262,7 @@ export async function configCommand(): Promise<void> {
   const updatedConfig = readConfig();
   if (updatedConfig && newApiKey !== config.apiKey) {
     updatedConfig.apiKey = newApiKey;
+    delete updatedConfig.whoami;
     writeConfig(updatedConfig);
   }
 

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -1,8 +1,8 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
-import { getApiKey, getApiBase, getAccessControlFromAllSources } from '../lib/config.js';
+import { getApiKey, getApiBase, getAccessControlFromAllSources, ensureWhoAmI, getEnvFromApiKey } from '../lib/config.js';
 import { OneApi, TimeoutError } from '../lib/api.js';
-import { openConnectionPage, getConnectionUrl } from '../lib/browser.js';
+import { openConnectionPage, getConnectionUrl, type ConnectionUrlParams } from '../lib/browser.js';
 import { findPlatform, findSimilarPlatforms } from '../lib/platforms.js';
 import { printTable } from '../lib/table.js';
 import * as output from '../lib/output.js';
@@ -92,13 +92,21 @@ export async function connectionAddCommand(platformArg?: string): Promise<void> 
     }
   }
 
+  // Resolve org/project scope for the connection URL
+  const whoami = await ensureWhoAmI(api);
+  const connParams: ConnectionUrlParams = {
+    env: getEnvFromApiKey(apiKey),
+    ...(whoami?.organization && { orgId: whoami.organization.id }),
+    ...(whoami?.project && { projectId: whoami.project.id }),
+  };
+
   // Open browser
-  const url = getConnectionUrl(platform);
+  const url = getConnectionUrl(platform, connParams);
   p.log.info(`Opening browser to connect ${pc.cyan(platform)}...`);
   p.note(pc.dim(url), 'URL');
 
   try {
-    await openConnectionPage(platform);
+    await openConnectionPage(platform, connParams);
   } catch {
     p.log.warn('Could not open browser automatically.');
     p.note(`Open this URL manually:\n${url}`);
@@ -209,7 +217,10 @@ export async function connectionListCommand(options?: { search?: string; limit?:
       platform: conn.platform,
       state: conn.state,
       key: conn.key,
+      tags: conn.tags?.length ? conn.tags.join(', ') : '',
     }));
+
+    const hasTags = rows.some(r => r.tags);
 
     printTable(
       [
@@ -217,6 +228,7 @@ export async function connectionListCommand(options?: { search?: string; limit?:
         { key: 'platform', label: 'Platform' },
         { key: 'state', label: 'Status' },
         { key: 'key', label: 'Connection Key', color: pc.dim },
+        ...(hasTags ? [{ key: 'tags', label: 'Tags', color: pc.dim }] : []),
       ],
       rows
     );

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,6 +18,8 @@ import {
   getProjectRoot,
   globalConfigExists,
   projectConfigExists,
+  getEnvFromApiKey,
+  getWhoAmI,
   type ConfigScope,
 } from '../lib/config.js';
 import {
@@ -31,7 +33,7 @@ import {
   type AgentStatus,
 } from '../lib/agents.js';
 import { OneApi, TimeoutError } from '../lib/api.js';
-import { getApiKeyUrl, openApiKeyPage, openConnectionPage, getConnectionUrl } from '../lib/browser.js';
+import { getApiKeyUrl, openApiKeyPage, openConnectionPage, getConnectionUrl, type ConnectionUrlParams } from '../lib/browser.js';
 import { configCommand } from './config.js';
 import open from 'open';
 import * as output from '../lib/output.js';
@@ -258,10 +260,17 @@ async function handleExistingConfig(
       printOnboardingPrompt();
       p.outro('Paste the prompt above to your AI agent.');
       break;
-    case 'add-connection':
-      await promptConnectIntegrations(apiKey);
+    case 'add-connection': {
+      const whoamiCached = getWhoAmI();
+      const addConnParams: ConnectionUrlParams = {
+        env: getEnvFromApiKey(apiKey),
+        ...(whoamiCached?.organization && { orgId: whoamiCached.organization.id }),
+        ...(whoamiCached?.project && { projectId: whoamiCached.project.id }),
+      };
+      await promptConnectIntegrations(apiKey, addConnParams);
       p.outro('Done.');
       break;
+    }
     case 'update-key':
       await handleUpdateKey(statuses, scope);
       break;
@@ -315,15 +324,27 @@ async function handleUpdateKey(statuses: AgentStatus[], scope: ConfigScope): Pro
   spinner.start('Validating API key...');
 
   const api = new OneApi(newKey, getApiBase());
-  const isValid = await api.validateApiKey();
+  const whoamiResult = await api.validateApiKey();
 
-  if (!isValid) {
+  if (!whoamiResult) {
     spinner.stop('Invalid API key');
     p.cancel(`Invalid API key. Get a valid key at ${getApiKeyUrl()}`);
     process.exit(1);
   }
 
   spinner.stop('API key validated');
+
+  // Show key context
+  const env = getEnvFromApiKey(newKey);
+  const contextParts: string[] = [];
+  if (whoamiResult.organization) contextParts.push(whoamiResult.organization.name);
+  if (whoamiResult.project) contextParts.push(whoamiResult.project.name);
+  const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
+  const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
+  p.note(
+    `${scopeDisplay} ${pc.dim('·')} ${envLabel}\n${whoamiResult.user.name} ${pc.dim(`(${whoamiResult.user.email})`)}`,
+    'Account',
+  );
 
   // Re-install MCP to every agent that currently has it (preserve scopes)
   const ac = getAccessControl();
@@ -339,7 +360,7 @@ async function handleUpdateKey(statuses: AgentStatus[], scope: ConfigScope): Pro
     }
   }
 
-  // Update config (preserve accessControl) at the active scope.
+  // Update config (preserve accessControl, refresh whoami) at the active scope.
   const current = scope === 'project' ? readProjectConfig() : readGlobalConfig();
   writeConfig(
     {
@@ -349,6 +370,7 @@ async function handleUpdateKey(statuses: AgentStatus[], scope: ConfigScope): Pro
       accessControl: current?.accessControl,
       apiBase: current?.apiBase,
       cacheTtl: current?.cacheTtl,
+      whoami: whoamiResult,
     },
     scope,
   );
@@ -836,9 +858,9 @@ async function freshSetup(
   spinner.start('Validating API key...');
 
   const api = new OneApi(apiKey, getApiBase());
-  const isValid = await api.validateApiKey();
+  const whoami = await api.validateApiKey();
 
-  if (!isValid) {
+  if (!whoami) {
     spinner.stop('Invalid API key');
     p.cancel(`Invalid API key. Get a valid key at ${getApiKeyUrl()}`);
     process.exit(1);
@@ -846,12 +868,27 @@ async function freshSetup(
 
   spinner.stop('API key validated');
 
-  // Save API key to config at the chosen scope
+  // Show key context (org/project scope)
+  const env = getEnvFromApiKey(apiKey);
+  const contextParts: string[] = [];
+  if (whoami.organization) contextParts.push(whoami.organization.name);
+  if (whoami.project) contextParts.push(whoami.project.name);
+  const scope_label = contextParts.length > 0
+    ? contextParts.join(' / ')
+    : 'Personal';
+  const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
+  p.note(
+    `${scope_label} ${pc.dim('·')} ${envLabel}\n${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`,
+    'Account',
+  );
+
+  // Save API key + whoami to config at the chosen scope
   writeConfig(
     {
       apiKey,
       installedAgents: [],
       createdAt: new Date().toISOString(),
+      whoami,
     },
     scope,
   );
@@ -860,7 +897,12 @@ async function freshSetup(
   await promptSkillInstall();
 
   // Step 3: Connect integrations
-  await promptConnectIntegrations(apiKey);
+  const connParams: ConnectionUrlParams = {
+    env,
+    ...(whoami.organization && { orgId: whoami.organization.id }),
+    ...(whoami.project && { projectId: whoami.project.id }),
+  };
+  await promptConnectIntegrations(apiKey, connParams);
 
   const savedPath =
     scope === 'project' ? getProjectConfigPath() : getGlobalConfigPath();
@@ -906,7 +948,7 @@ const TOP_INTEGRATIONS = [
   { value: 'notion', label: 'Notion', hint: 'Access pages, databases, and docs' },
 ];
 
-async function promptConnectIntegrations(apiKey: string): Promise<void> {
+async function promptConnectIntegrations(apiKey: string, connParams?: ConnectionUrlParams): Promise<void> {
   const api = new OneApi(apiKey, getApiBase());
   const connected: string[] = [];
 
@@ -966,9 +1008,9 @@ async function promptConnectIntegrations(apiKey: string): Promise<void> {
     p.log.info(`Opening browser to connect ${pc.cyan(label)}...`);
 
     try {
-      await openConnectionPage(platform);
+      await openConnectionPage(platform, connParams);
     } catch {
-      const url = getConnectionUrl(platform);
+      const url = getConnectionUrl(platform, connParams);
       p.log.warn('Could not open browser automatically.');
       p.note(url, 'Open manually');
     }

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -115,14 +115,20 @@ export async function relayListCommand(options: {
     }
 
     printTable(
-      ['Status', 'Description', 'Events', 'Actions', 'ID'],
-      endpoints.map((e: any) => [
-        e.active ? pc.green('●') : pc.dim('○'),
-        e.description || pc.dim('(none)'),
-        e.eventFilters?.join(', ') || pc.dim('all'),
-        String(e.actions?.length || 0),
-        pc.dim(e.id.slice(0, 8)),
-      ])
+      [
+        { key: 'status', label: '' },
+        { key: 'description', label: 'Description' },
+        { key: 'events', label: 'Events' },
+        { key: 'actions', label: 'Actions' },
+        { key: 'id', label: 'ID', color: pc.dim },
+      ],
+      endpoints.map((e: any) => ({
+        status: e.active ? pc.green('●') : pc.dim('○'),
+        description: e.description || pc.dim('(none)'),
+        events: e.eventFilters?.join(', ') || pc.dim('all'),
+        actions: String(e.actions?.length || 0),
+        id: e.id.slice(0, 8),
+      }))
     );
   } catch (error) {
     spinner.stop('Failed to list relay endpoints');
@@ -308,13 +314,18 @@ export async function relayEventsCommand(options: {
     }
 
     printTable(
-      ['Platform', 'Event Type', 'Timestamp', 'ID'],
-      events.map((e: any) => [
-        e.platform,
-        e.eventType || pc.dim('unknown'),
-        e.timestamp || e.createdAt,
-        pc.dim(e.id.slice(0, 8)),
-      ])
+      [
+        { key: 'platform', label: 'Platform' },
+        { key: 'eventType', label: 'Event Type' },
+        { key: 'timestamp', label: 'Timestamp' },
+        { key: 'id', label: 'ID', color: pc.dim },
+      ],
+      events.map((e: any) => ({
+        platform: e.platform,
+        eventType: e.eventType || pc.dim('unknown'),
+        timestamp: e.timestamp || e.createdAt,
+        id: e.id.slice(0, 8),
+      }))
     );
   } catch (error) {
     spinner.stop('Failed to list relay events');
@@ -384,14 +395,20 @@ export async function relayDeliveriesCommand(options: {
     }
 
     printTable(
-      ['Status', 'Code', 'Attempt', 'Delivered At', 'Error'],
-      items.map((d: any) => [
-        d.status === 'success' ? pc.green(d.status) : pc.red(d.status),
-        d.statusCode != null ? String(d.statusCode) : pc.dim('-'),
-        String(d.attempt),
-        d.deliveredAt || pc.dim('-'),
-        d.error ? pc.red(d.error.slice(0, 50)) : pc.dim('-'),
-      ])
+      [
+        { key: 'status', label: 'Status' },
+        { key: 'code', label: 'Code' },
+        { key: 'attempt', label: 'Attempt' },
+        { key: 'deliveredAt', label: 'Delivered At' },
+        { key: 'error', label: 'Error' },
+      ],
+      items.map((d: any) => ({
+        status: d.status === 'success' ? pc.green(d.status) : pc.red(d.status),
+        code: d.statusCode != null ? String(d.statusCode) : pc.dim('-'),
+        attempt: String(d.attempt),
+        deliveredAt: d.deliveredAt || pc.dim('-'),
+        error: d.error ? pc.red(d.error.slice(0, 50)) : pc.dim('-'),
+      }))
     );
   } catch (error) {
     spinner.stop('Failed to load deliveries');

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,14 @@ import {
   getProjectConfigPath,
   globalConfigExists,
   projectConfigExists,
+  getApiKey,
+  getApiBase,
+  getWhoAmI,
+  updateWhoAmI,
+  getEnvFromApiKey,
 } from './lib/config.js';
 import { connectionAddCommand, connectionListCommand, connectionDeleteCommand } from './commands/connection.js';
+import { OneApi } from './lib/api.js';
 import { platformsCommand } from './commands/platforms.js';
 import { actionsSearchCommand, actionsKnowledgeCommand, actionsExecuteCommand, actionsExecuteParallelCommand } from './commands/actions.js';
 import {
@@ -60,6 +66,7 @@ program
     one add <platform>                    Connect a platform via OAuth (e.g. gmail, slack, shopify)
     one connection delete <key>           Remove a connection (alias: one connection rm)
     one config                            Configure access control (permissions, scoping)
+    one whoami                            Show current user, organization, and project
 
   Workflow (use these in order):
     1. one list                           List your connected platforms and connection keys
@@ -577,6 +584,65 @@ program
   .description('Update the One CLI to the latest version')
   .action(async () => {
     await updateCommand();
+  });
+
+program
+  .command('whoami')
+  .description('Show the user, organization, and project for the current API key')
+  .action(async () => {
+    const apiKey = getApiKey();
+    if (!apiKey) {
+      outputError('Not configured. Run `one init` first.');
+      return;
+    }
+
+    const api = new OneApi(apiKey, getApiBase());
+
+    let whoami;
+    try {
+      whoami = await api.whoami();
+      updateWhoAmI(whoami);
+    } catch (error) {
+      outputError(`Failed to fetch account info: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      return;
+    }
+
+    const env = getEnvFromApiKey(apiKey);
+    const resolved = resolveConfig();
+    const configScope = resolved.scope ?? 'global';
+    const apiBase = getApiBase();
+
+    if (isAgentMode()) {
+      outputJson({
+        user: whoami.user,
+        organization: whoami.organization,
+        project: whoami.project,
+        env,
+        configScope,
+        apiBase,
+      });
+      return;
+    }
+
+    const pc = (await import('picocolors')).default;
+    const contextParts: string[] = [];
+    if (whoami.organization) contextParts.push(whoami.organization.name);
+    if (whoami.project) contextParts.push(whoami.project.name);
+    const scopeDisplay = contextParts.length > 0 ? contextParts.join(' / ') : 'Personal';
+    const envLabel = env === 'test' ? pc.yellow('test') : pc.green('live');
+    const configLabel = configScope === 'project'
+      ? pc.cyan('project config')
+      : pc.magenta('global config');
+
+    console.log();
+    console.log(`  ${pc.bold(scopeDisplay)} ${pc.dim('·')} ${envLabel}`);
+    console.log(`  ${whoami.user.name} ${pc.dim(`(${whoami.user.email})`)}`);
+    if (whoami.organization) console.log(`  ${pc.dim('Org:')} ${whoami.organization.name} ${pc.dim(`(${whoami.organization.id})`)}`);
+    if (whoami.project) console.log(`  ${pc.dim('Project:')} ${whoami.project.name} ${pc.dim(`(${whoami.project.id})`)}`);
+    console.log();
+    console.log(`  ${pc.dim('Using')} ${configLabel}`);
+    console.log(`  ${pc.dim('API:')} ${apiBase}`);
+    console.log();
   });
 
 // Shortcuts

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   ExecutePassthroughResponse,
   SanitizedRequestConfig,
   ApiResponseWithMeta,
+  WhoAmIResponse,
 } from './types.js';
 
 export class ApiError extends Error {
@@ -83,10 +84,13 @@ export class OneApi {
     return JSON.parse(text) as T;
   }
 
-  async validateApiKey(): Promise<boolean> {
+  async whoami(): Promise<WhoAmIResponse> {
+    return this.request<WhoAmIResponse>('/users/whoami');
+  }
+
+  async validateApiKey(): Promise<WhoAmIResponse | false> {
     try {
-      await this.listConnections();
-      return true;
+      return await this.whoami();
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         return false;

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -2,16 +2,28 @@ import open from 'open';
 
 const ONE_APP_URL = 'https://app.withone.ai';
 
-export function getConnectionUrl(platform: string): string {
-  return `${ONE_APP_URL}/?#open=${platform}`;
+export interface ConnectionUrlParams {
+  orgId?: string;
+  projectId?: string;
+  env?: 'live' | 'test';
+}
+
+export function getConnectionUrl(platform: string, params?: ConnectionUrlParams): string {
+  const searchParams = new URLSearchParams();
+  if (params?.orgId) searchParams.set('orgId', params.orgId);
+  if (params?.projectId) searchParams.set('projectId', params.projectId);
+  if (params?.env) searchParams.set('env', params.env);
+
+  const qs = searchParams.toString();
+  return `${ONE_APP_URL}/${qs ? `?${qs}` : ''}#open=${platform}`;
 }
 
 export function getApiKeyUrl(): string {
   return `${ONE_APP_URL}/settings/api-keys`;
 }
 
-export async function openConnectionPage(platform: string): Promise<void> {
-  const url = getConnectionUrl(platform);
+export async function openConnectionPage(platform: string, params?: ConnectionUrlParams): Promise<void> {
+  const url = getConnectionUrl(platform, params);
   await open(url);
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import type { Config, AccessControlSettings, PermissionLevel } from './types.js';
+import type { Config, AccessControlSettings, PermissionLevel, WhoAmIResponse } from './types.js';
+import type { OneApi } from './api.js';
 
 const CONFIG_DIR = path.join(os.homedir(), '.one');
 const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
@@ -252,6 +253,9 @@ export function updateApiBase(url: string | null): void {
     delete config.apiBase;
   }
 
+  // Clear cached whoami — base URL changed, so it needs to be re-fetched
+  delete config.whoami;
+
   writeConfig(config);
 }
 
@@ -291,4 +295,34 @@ export function updateAccessControl(settings: AccessControlSettings): void {
   }
 
   writeConfig(config);
+}
+
+// ── WhoAmI helpers ──────────────────────────────────────────────────
+
+export function getWhoAmI(): WhoAmIResponse | null {
+  return readConfig()?.whoami ?? null;
+}
+
+export function updateWhoAmI(whoami: WhoAmIResponse): void {
+  const config = readConfig();
+  if (!config) return;
+  config.whoami = whoami;
+  writeConfig(config);
+}
+
+export async function ensureWhoAmI(api: OneApi): Promise<WhoAmIResponse | null> {
+  const cached = getWhoAmI();
+  if (cached) return cached;
+
+  try {
+    const whoami = await api.whoami();
+    updateWhoAmI(whoami);
+    return whoami;
+  } catch {
+    return null;
+  }
+}
+
+export function getEnvFromApiKey(apiKey: string): 'live' | 'test' {
+  return apiKey.startsWith('sk_test_') ? 'test' : 'live';
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,15 @@ export interface AccessControlSettings {
   knowledgeAgent?: boolean;
 }
 
+export interface WhoAmIUser { id: string; name: string; email: string }
+export interface WhoAmIOrg { id: string; name: string }
+export interface WhoAmIProject { id: string; name: string }
+export interface WhoAmIResponse {
+  user: WhoAmIUser;
+  organization: WhoAmIOrg | null;
+  project: WhoAmIProject | null;
+}
+
 export interface Config {
   apiKey: string;
   installedAgents: string[];
@@ -52,6 +61,7 @@ export interface Config {
   accessControl?: AccessControlSettings;
   cacheTtl?: number;
   apiBase?: string;
+  whoami?: WhoAmIResponse;
 }
 
 export interface ConnectionsResponse {


### PR DESCRIPTION
## Summary
- Add `one whoami` command — shows user, org, project, env, config scope, and API base URL
- Use `/v1/users/whoami` for API key validation (lighter than listConnections), cache result in config
- Pass `orgId`, `projectId`, `env` query params when opening connection URLs so the dashboard pre-selects the right scope
- Show account context (org/project/env) during `one init` and key update flows
- Lazy-fetch whoami for existing installs (retroactive) via `ensureWhoAmI`
- Clear cached whoami when API key or base URL changes
- Show tags column in `one connection list` when connections have tags
- Fix `one relay list/events/deliveries` crash — printTable was using old array signature

## Test plan
- [x] `one whoami` — shows user/org/project/env/config scope/API base
- [x] `one --agent whoami` — returns structured JSON
- [x] `one init` (fresh) — shows account context after key validation
- [x] `one init` → Update API key — refreshes whoami and shows new context
- [x] `one add gmail` — connection URL includes orgId/projectId/env params
- [x] `one list` — shows tags column when connections have tags
- [x] `one relay list` — no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)