### PR TITLE
feat: config reset + ancestor config resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.32.1",
+      "version": "1.33.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createRequire } from 'module';
+import path from 'node:path';
 import { Command } from 'commander';
 import { initCommand } from './commands/init.js';
 import { configCommand } from './commands/config.js';
@@ -259,6 +260,96 @@ configSkills
     console.log(`  installed: ${marker}`);
     console.log(`  current:   ${status.currentVersion}`);
     console.log(`  path:      ${status.canonicalPath}`);
+  });
+
+config
+  .command('reset')
+  .description('Remove the project config for the current directory (falls back to global)')
+  .option('--global', 'Remove the global config instead')
+  .action(async (opts: { global?: boolean }) => {
+    const resolved = resolveConfig();
+
+    if (opts.global) {
+      const globalPath = getGlobalConfigPath();
+      if (!globalConfigExists()) {
+        if (isAgentMode()) {
+          outputJson({ deleted: false, reason: 'No global config found' });
+        } else {
+          console.log('No global config found.');
+        }
+        return;
+      }
+      if (!isAgentMode()) {
+        const p = await import('@clack/prompts');
+        const confirmed = await p.confirm({
+          message: 'Delete the global config? This removes your API key for all projects without a project config.',
+          initialValue: false,
+        });
+        if (p.isCancel(confirmed) || !confirmed) {
+          console.log('Cancelled.');
+          return;
+        }
+      }
+      const fs = await import('node:fs');
+      fs.unlinkSync(globalPath);
+      if (isAgentMode()) {
+        outputJson({ deleted: true, scope: 'global' });
+      } else {
+        console.log('Global config removed.');
+      }
+      return;
+    }
+
+    // Project reset
+    if (resolved.scope !== 'project') {
+      if (isAgentMode()) {
+        outputJson({ deleted: false, reason: 'No project config found for this directory' });
+      } else {
+        console.log('No project config found for this directory.');
+        console.log(`Currently using: ${resolved.scope ?? 'none'}`);
+      }
+      return;
+    }
+
+    // Determine what config will be used after deletion
+    const fs = await import('node:fs');
+    // Temporarily remove the file to check what resolves next
+    const configContent = fs.readFileSync(resolved.path, 'utf-8');
+    fs.unlinkSync(resolved.path);
+    const next = resolveConfig();
+    // Restore it before confirming
+    fs.mkdirSync(path.dirname(resolved.path), { recursive: true });
+    fs.writeFileSync(resolved.path, configContent);
+
+    let fallbackLabel: string;
+    if (next.scope === 'project') {
+      fallbackLabel = `parent project config (${path.basename(next.projectRoot)})`;
+    } else if (next.scope === 'global') {
+      fallbackLabel = 'global config';
+    } else {
+      fallbackLabel = 'no config';
+    }
+
+    if (!isAgentMode()) {
+      const p = await import('@clack/prompts');
+      const confirmed = await p.confirm({
+        message: `Delete project config for ${path.basename(resolved.projectRoot)}? Will fall back to ${fallbackLabel}.`,
+        initialValue: false,
+      });
+      if (p.isCancel(confirmed) || !confirmed) {
+        console.log('Cancelled.');
+        return;
+      }
+    }
+
+    fs.unlinkSync(resolved.path);
+    try { fs.rmdirSync(path.dirname(resolved.path)); } catch { /* not empty, fine */ }
+
+    if (isAgentMode()) {
+      outputJson({ deleted: true, scope: 'project', projectRoot: resolved.projectRoot, fallback: next.scope });
+    } else {
+      console.log(`Project config removed. Now using ${fallbackLabel}.`);
+    }
   });
 
 const connection = program

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -72,10 +72,26 @@ export function resolveConfig(): ResolvedConfig {
   const projectSlug = getProjectSlug(projectRoot);
   const projectPath = getProjectConfigPath(projectRoot);
 
+  // Check detected project root first
   if (fs.existsSync(projectPath)) {
     const config = readConfigFile(projectPath);
     if (config) {
       return { config, scope: 'project', path: projectPath, projectRoot, projectSlug };
+    }
+  }
+
+  // Walk up from cwd checking each ancestor for a project config
+  const root = path.parse(process.cwd()).root;
+  let dir = path.resolve(process.cwd());
+  while (dir !== root) {
+    dir = path.dirname(dir);
+    const slug = getProjectSlug(dir);
+    const configPath = path.join(PROJECTS_DIR, slug, 'config.json');
+    if (fs.existsSync(configPath)) {
+      const config = readConfigFile(configPath);
+      if (config) {
+        return { config, scope: 'project', path: configPath, projectRoot: dir, projectSlug: slug };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `one config reset` — deletes project config with confirmation showing what it falls back to
- Add `one config reset --global` — deletes global config
- Walk up parent directories to find project configs, so `cd src/` within a project still uses the project's config
- Confirmation message shows fallback target before deletion (e.g. "Will fall back to global config")

## Test plan
- [x] `one config reset` from project dir — shows confirmation with fallback info, deletes on confirm
- [x] `one config reset` from subdir — resolves parent project config correctly
- [x] `one --agent config reset` — deletes without prompt, returns JSON
- [x] `one whoami` from project subdir — uses parent project config instead of falling back to global
- [x] `one config reset` with no project config — shows "No project config found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)