### PR TITLE
feat: support subdirectories in .one/flows/

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ one flow validate welcome-customer
 one flow execute welcome-customer -i email=jane@example.com
 ```
 
-Workflows live under `.one/flows/<key>/flow.json` with an optional `lib/` subfolder for `.mjs` code modules — create new flows in this folder layout. (The legacy single-file layout `.one/flows/<key>.flow.json` is deprecated but still loads for backward compatibility.) Flows support conditions, loops, while loops, parallel steps, transforms, sub-flows, pagination, bash steps, and external `.mjs` code modules. Run `one guide flows` for the full reference.
+Workflows live under `.one/flows/<key>/flow.json` with an optional `lib/` subfolder for `.mjs` code modules — create new flows in this folder layout. Flows can be organized into subdirectory groups: `.one/flows/<group>/<key>/flow.json`. Reference them as `group/key` or just the bare key if unique. (The legacy single-file layout `.one/flows/<key>.flow.json` is deprecated but still loads for backward compatibility.) Flows support conditions, loops, while loops, parallel steps, transforms, sub-flows, pagination, bash steps, and external `.mjs` code modules. Run `one guide flows` for the full reference.
 
 ## How it works
 
@@ -357,11 +357,14 @@ In agent mode (`--agent`), the JSON response includes the guide content and an `
 
 ### `one flow create [key]`
 
-Create a workflow from a JSON definition. New workflows are always saved to the folder layout at `.one/flows/<key>/flow.json` (with a `lib/` subfolder scaffolded for code modules). The legacy `.one/flows/<key>.flow.json` single-file layout is deprecated; existing legacy files continue to load and run unchanged for backward compatibility.
+Create a workflow from a JSON definition. New workflows are always saved to the folder layout at `.one/flows/<key>/flow.json` (with a `lib/` subfolder scaffolded for code modules). Use `group/key` to place flows in a subdirectory group (e.g. `.one/flows/research/company-research/flow.json`). The legacy `.one/flows/<key>.flow.json` single-file layout is deprecated; existing legacy files continue to load and run unchanged for backward compatibility.
 
 ```bash
 # From a --definition flag
 one flow create welcome-customer --definition '{"key":"welcome-customer","name":"Welcome","version":"1","inputs":{},"steps":[]}'
+
+# Create in a subdirectory group
+one flow create research/company-research --definition @flow.json
 
 # From stdin
 cat flow.json | one flow create

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.33.0",
+      "version": "1.34.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -121,9 +121,16 @@ export async function flowCreateCommand(
     output.error('Interactive workflow creation not yet supported. Use --definition <json> or pipe JSON via stdin.');
   }
 
-  // Override key if provided as arg
+  // Override key if provided as arg — extract group prefix if present (e.g. "research/company-research")
+  let group: string | undefined;
   if (key) {
-    flow!.key = key;
+    if (key.includes('/')) {
+      const parts = key.split('/');
+      flow!.key = parts.pop()!;
+      group = parts.join('/');
+    } else {
+      flow!.key = key;
+    }
   }
 
   // Validate
@@ -136,7 +143,7 @@ export async function flowCreateCommand(
     output.error(`Validation failed:\n${errors.map(e => `  ${e.path}: ${e.message}`).join('\n')}`);
   }
 
-  const flowPath = saveFlow(flow!, options.output);
+  const flowPath = saveFlow(flow!, options.output, group);
 
   if (output.isAgentMode()) {
     output.json({ created: true, key: flow!.key, path: flowPath });
@@ -336,7 +343,7 @@ export async function flowListCommand(): Promise<void> {
       { key: 'flags', label: 'Requires' },
     ],
     flows.map(f => ({
-      key: f.key,
+      key: f.group ? `${f.group}/${f.key}` : f.key,
       name: f.name,
       layout: f.layout,
       inputCount: String(f.inputCount),

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,8 +80,8 @@ program
 
   Workflows (multi-step):
     one flow list                         List saved workflows
-    one flow create [key]                 Create a workflow from JSON
-    one flow execute <key>                Execute a workflow
+    one flow create [key]                 Create a workflow from JSON (key can be group/key)
+    one flow execute <key>                Execute a workflow (key can be group/key)
     one flow validate <key>               Validate a flow
 
   Data Sync (run "one sync install" first, then "one guide sync" for full reference):

--- a/src/lib/flow-runner.ts
+++ b/src/lib/flow-runner.ts
@@ -281,22 +281,58 @@ export class FlowRunner {
 /**
  * Resolve a flow key or path to its file location.
  *
- * Resolution order for bare keys:
- *   1. `.one/flows/<key>/flow.json` (folder layout — preferred for new flows)
+ * Resolution order for bare keys (e.g. "my-flow"):
+ *   1. `.one/flows/<key>/flow.json` (folder layout — preferred)
  *   2. `.one/flows/<key>.flow.json` (legacy single-file layout)
  *
- * Returns the first existing path. If neither exists, returns the folder-layout
+ * Namespaced keys (e.g. "research/company-research"):
+ *   1. `.one/flows/<group>/<key>/flow.json`
+ *
+ * Bare keys also check subdirectories — if `my-flow` doesn't exist at the
+ * top level, the CLI scans group folders for a matching `<group>/my-flow/flow.json`.
+ *
+ * Returns the first existing path. If none exists, returns the folder-layout
  * path so error messages point at the modern convention.
  */
 export function resolveFlowPath(keyOrPath: string): string {
-  // Explicit path or .json filename → use as-is
-  if (keyOrPath.includes('/') || keyOrPath.includes('\\') || keyOrPath.endsWith('.json')) {
+  // Explicit .json filename → use as-is
+  if (keyOrPath.endsWith('.json')) {
     return path.resolve(keyOrPath);
   }
+
+  // Backslash paths are always literal filesystem paths
+  if (keyOrPath.includes('\\')) {
+    return path.resolve(keyOrPath);
+  }
+
+  // Namespaced key: "group/key" — check the nested folder layout
+  if (keyOrPath.includes('/')) {
+    const nestedFolder = path.resolve(FLOWS_DIR, keyOrPath, 'flow.json');
+    if (fs.existsSync(nestedFolder)) return nestedFolder;
+    // Could be a literal filesystem path — try resolving it
+    const literal = path.resolve(keyOrPath);
+    if (fs.existsSync(literal)) return literal;
+    // Fall through to return the nested folder path for error messages
+    return nestedFolder;
+  }
+
+  // Bare key: check top-level folder layout first, then legacy, then scan subdirectories
   const folderPath = path.resolve(FLOWS_DIR, keyOrPath, 'flow.json');
-  const legacyPath = path.resolve(FLOWS_DIR, `${keyOrPath}.flow.json`);
   if (fs.existsSync(folderPath)) return folderPath;
+
+  const legacyPath = path.resolve(FLOWS_DIR, `${keyOrPath}.flow.json`);
   if (fs.existsSync(legacyPath)) return legacyPath;
+
+  // Scan group subdirectories for a matching flow
+  const flowsDir = path.resolve(FLOWS_DIR);
+  if (fs.existsSync(flowsDir)) {
+    for (const entry of fs.readdirSync(flowsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      const nested = path.join(flowsDir, entry.name, keyOrPath, 'flow.json');
+      if (fs.existsSync(nested)) return nested;
+    }
+  }
+
   return folderPath;
 }
 
@@ -402,6 +438,8 @@ type FlowListEntry = {
   stepCount: number;
   path: string;
   layout: 'folder' | 'legacy';
+  /** Subdirectory group (e.g. "research") if the flow lives under `.one/flows/<group>/<key>/`. */
+  group?: string;
   stepTypes: FlowStepType[];
   requiresBash: boolean;
   usesCodeModules: boolean;
@@ -415,12 +453,14 @@ export function listFlows(): FlowListEntry[] {
   const flows: FlowListEntry[] = [];
   const seenKeys = new Set<string>();
 
-  const readFlowFile = (filePath: string): void => {
+  const readFlowFile = (filePath: string, group?: string): void => {
     try {
       const content = fs.readFileSync(filePath, 'utf-8');
       const flow = JSON.parse(content) as Flow;
-      if (seenKeys.has(flow.key)) return;
-      seenKeys.add(flow.key);
+      // Deduplicate by namespaced key (group/key or just key)
+      const nsKey = group ? `${group}/${flow.key}` : flow.key;
+      if (seenKeys.has(nsKey)) return;
+      seenKeys.add(nsKey);
       flows.push({
         key: flow.key,
         name: flow.name,
@@ -429,6 +469,7 @@ export function listFlows(): FlowListEntry[] {
         stepCount: flow.steps.length,
         path: filePath,
         layout: path.basename(filePath) === 'flow.json' ? 'folder' : 'legacy',
+        group,
         stepTypes: collectStepTypes(flow),
         requiresBash: flowRequiresBash(flow),
         usesCodeModules: flowUsesCodeModules(flow),
@@ -439,17 +480,29 @@ export function listFlows(): FlowListEntry[] {
     }
   };
 
-  for (const entry of fs.readdirSync(flowsDir, { withFileTypes: true })) {
-    if (entry.name.startsWith('.')) continue; // skip .runs, .logs, etc.
-    const full = path.join(flowsDir, entry.name);
-    if (entry.isDirectory()) {
-      const flowJson = path.join(full, 'flow.json');
-      if (fs.existsSync(flowJson)) readFlowFile(flowJson);
-    } else if (entry.isFile() && entry.name.endsWith('.flow.json')) {
-      readFlowFile(full);
+  /** Scan a directory for flows. `group` is the subdirectory prefix (e.g. "research"). */
+  const scanDir = (dir: string, group?: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith('.')) continue; // skip .runs, .logs, etc.
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const flowJson = path.join(full, 'flow.json');
+        if (fs.existsSync(flowJson)) {
+          // This is a flow folder (<key>/flow.json)
+          readFlowFile(flowJson, group);
+        } else {
+          // No flow.json here — treat as a group subdirectory and recurse one level
+          if (!group) {
+            scanDir(full, entry.name);
+          }
+        }
+      } else if (entry.isFile() && entry.name.endsWith('.flow.json')) {
+        readFlowFile(full, group);
+      }
     }
-  }
+  };
 
+  scanDir(flowsDir);
   return flows;
 }
 
@@ -457,16 +510,34 @@ export function listFlows(): FlowListEntry[] {
  * Save a flow. New flows default to the folder layout
  * (`.one/flows/<key>/flow.json`), creating `<key>/lib/` alongside. An explicit
  * `outputPath` is respected as-is for backward compatibility.
+ *
+ * The key can include a group prefix (e.g. "research/company-research") which
+ * places the flow at `.one/flows/research/company-research/flow.json`. The
+ * flow's `key` field is always the bare key (without group prefix).
  */
-export function saveFlow(flow: Flow, outputPath?: string): string {
+export function saveFlow(flow: Flow, outputPath?: string, group?: string): string {
   let flowPath: string;
   if (outputPath) {
     flowPath = path.resolve(outputPath);
   } else {
-    const legacyPath = path.resolve(FLOWS_DIR, `${flow.key}.flow.json`);
-    const folderPath = path.resolve(FLOWS_DIR, flow.key, 'flow.json');
-    // Preserve layout if a flow with this key already exists
-    if (fs.existsSync(legacyPath) && !fs.existsSync(folderPath)) {
+    // Determine group from the flow key if it contains a slash
+    let bareKey = flow.key;
+    let resolvedGroup = group;
+    if (flow.key.includes('/')) {
+      const parts = flow.key.split('/');
+      bareKey = parts.pop()!;
+      resolvedGroup = resolvedGroup || parts.join('/');
+      flow.key = bareKey; // Store only the bare key in the flow JSON
+    }
+
+    const basePath = resolvedGroup
+      ? path.resolve(FLOWS_DIR, resolvedGroup, bareKey)
+      : path.resolve(FLOWS_DIR, bareKey);
+
+    const legacyPath = path.resolve(FLOWS_DIR, `${bareKey}.flow.json`);
+    const folderPath = path.join(basePath, 'flow.json');
+    // Preserve layout if a flow with this key already exists at top level
+    if (!resolvedGroup && fs.existsSync(legacyPath) && !fs.existsSync(folderPath)) {
       flowPath = legacyPath;
     } else {
       flowPath = folderPath;

--- a/src/lib/flow-schema.ts
+++ b/src/lib/flow-schema.ts
@@ -328,7 +328,18 @@ Workflows live in \`.one/flows/\` (relative to your current working directory �
 - **Folder layout (REQUIRED for new flows)** — \`.one/flows/<key>/flow.json\`, with an optional \`lib/\` subfolder for JavaScript modules. This is like a skill: the folder groups the JSON spec with any JavaScript modules it needs, so the whole flow is shareable. **Always create new flows in this layout.**
 - **Single-file layout (DEPRECATED)** — \`.one/flows/<key>.flow.json\`. Still loads and runs for backward compatibility, but is deprecated. Do not create new flows in this layout. When editing an existing single-file flow, migrate it to the folder layout: move \`<key>.flow.json\` to \`<key>/flow.json\` and extract any non-trivial \`code.source\` blocks into \`<key>/lib/*.mjs\` modules.
 
-When resolving a flow by key, the CLI checks the folder layout first, then the deprecated legacy file. The \`loadFlow\` helper in agent integrations behaves the same.
+**Subdirectory groups** — Flows can be organized into subdirectories: \`.one/flows/<group>/<key>/flow.json\`. For example:
+\`\`\`
+.one/flows/
+  research/
+    company-research/flow.json
+    competitor-research/flow.json
+  deal-ops/
+    deal-log/flow.json
+\`\`\`
+Reference grouped flows with \`group/key\` (e.g. \`one flow execute research/company-research\`) or just the bare key if it's unique (e.g. \`one flow execute company-research\`). Create grouped flows with \`one flow create research/company-research --definition ...\`. \`flow list\` shows the group prefix.
+
+When resolving a flow by key, the CLI checks the folder layout first, then the deprecated legacy file, then scans group subdirectories. The \`loadFlow\` helper in agent integrations behaves the same.
 
 ## Before you execute a flow you did NOT author — READ THIS
 
@@ -353,19 +364,21 @@ A good description is one paragraph. If a flow's description doesn't tell you ho
 ## Commands
 
 \`\`\`bash
-one --agent flow create <key> --definition '<json>'   # Create (or --definition @file.json)
-one --agent flow create <key> --definition @flow.json  # Create from file
-one --agent flow list                                  # List
-one --agent flow validate <key>                        # Validate
-one --agent flow execute <key> -i name=value           # Execute
-one --agent flow execute <key> --dry-run --mock        # Test with mock data
-one --agent flow execute <key> --allow-bash            # Enable bash steps
-one --agent flow runs [flowKey]                        # List past runs
-one --agent flow resume <runId>                        # Resume failed run
-one --agent flow scaffold [template]                   # Generate a starter template
+one --agent flow create <key> --definition '<json>'              # Create (or --definition @file.json)
+one --agent flow create <key> --definition @flow.json            # Create from file
+one --agent flow create <group/key> --definition '<json>'        # Create in a subdirectory group
+one --agent flow list                                            # List (shows group prefixes)
+one --agent flow validate <key>                                  # Validate
+one --agent flow execute <key> -i name=value                     # Execute (bare key)
+one --agent flow execute <group/key> -i name=value               # Execute (namespaced key)
+one --agent flow execute <key> --dry-run --mock                  # Test with mock data
+one --agent flow execute <key> --allow-bash                      # Enable bash steps
+one --agent flow runs [flowKey]                                  # List past runs
+one --agent flow resume <runId>                                  # Resume failed run
+one --agent flow scaffold [template]                             # Generate a starter template
 \`\`\`
 
-You can also write the JSON file directly to \`.one/flows/<key>/flow.json\` — often easier than passing large JSON via --definition. (The legacy \`.one/flows/<key>.flow.json\` single-file location is deprecated; don't use it for new flows.)
+You can also write the JSON file directly to \`.one/flows/<key>/flow.json\` (or \`.one/flows/<group>/<key>/flow.json\` for grouped flows) — often easier than passing large JSON via --definition. (The legacy \`.one/flows/<key>.flow.json\` single-file location is deprecated; don't use it for new flows.)
 
 ## Code modules (flow \`lib/\` folder)
 

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -62,7 +62,7 @@ one --agent flow list                                 # List all workflows
 \`\`\`
 
 **Key concepts:**
-- Workflows live at \`.one/flows/<key>/flow.json\` (folder layout — REQUIRED for new flows). The legacy \`.one/flows/<key>.flow.json\` single-file layout is DEPRECATED but still loads for backward compatibility
+- Workflows live at \`.one/flows/<key>/flow.json\` (folder layout — REQUIRED for new flows). Flows can be organized into subdirectory groups: \`.one/flows/<group>/<key>/flow.json\`. Reference them as \`group/key\` or just the bare key. The legacy \`.one/flows/<key>.flow.json\` single-file layout is DEPRECATED but still loads for backward compatibility
 - Code steps can reference an external \`.mjs\` module under the flow's \`lib/\` folder (stdin JSON in, stdout JSON out) — keeps JS out of JSON strings and makes flows shareable
 - 12 step types: action, transform, code, condition, loop, parallel, file-read, file-write, while, flow, paginate, bash
 - Data wiring via selectors: \`$.input.param\`, \`$.steps.stepId.response\`, \`$.loop.item\`


### PR DESCRIPTION
## Summary
- Flows can now be organized into subdirectory groups: `.one/flows/<group>/<key>/flow.json`
- `flow list` shows group-prefixed keys (e.g. `research/company-research`)
- `flow execute` and `flow validate` resolve both namespaced keys (`research/company-research`) and bare keys (scans subdirs automatically)
- `flow create` accepts `group/key` format to place flows in subdirectories
- Fully backward compatible — ungrouped flows and legacy single-file layout work unchanged

Closes #96

## Test plan
- [x] `flow list` shows grouped and ungrouped flows correctly
- [x] `flow validate research/company-research` resolves namespaced key
- [x] `flow validate company-research` scans subdirs for bare key
- [x] `flow create infra/cache-clear --definition ...` saves to correct path
- [x] Ungrouped flows resolve as before
- [x] Build clean, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)