### PR TITLE
feat: support binary file downloads with --output flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ one actions execute stripe <actionId> <connectionKey> \
 | `--dry-run` | Show the request without executing it |
 | `--mock` | Return example response without making an API call |
 | `--skip-validation` | Skip input validation against the action schema |
+| `--output <path>` | Save response to a file (for binary downloads) |
 
 The CLI validates required parameters (path variables, query params, body fields) against the action schema before executing. Missing params return a clear error with the flag name and description. Pass `--skip-validation` to bypass.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -87,6 +87,7 @@ Options:
 - `--dry-run` — Preview the request without executing
 - `--mock` — Return example response without making an API call (useful for building UI)
 - `--skip-validation` — Skip input validation against the action schema
+- `--output <path>` — Save response to a file (for binary downloads like PDFs, images, documents)
 
 The CLI validates required parameters before executing. Missing params return a structured error with the flag name, parameter name, and description. Pass `--skip-validation` to bypass.
 

--- a/src/commands/actions.ts
+++ b/src/commands/actions.ts
@@ -348,6 +348,7 @@ export async function actionsExecuteCommand(
     dryRun?: boolean;
     mock?: boolean;
     skipValidation?: boolean;
+    output?: string;
   }
 ): Promise<void> {
   output.intro(pc.bgCyan(pc.black(' One ')));
@@ -468,6 +469,7 @@ export async function actionsExecuteCommand(
         isFormData: options.formData,
         isFormUrlEncoded: options.formUrlEncoded,
         dryRun: options.dryRun,
+        output: options.output,
       },
       actionDetails
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -450,6 +450,7 @@ actions
   .option('--dry-run', 'Show request that would be sent without executing')
   .option('--mock', 'Return example response without making an API call')
   .option('--skip-validation', 'Skip input validation against the action schema')
+  .option('--output <path>', 'Save binary response to a file (for non-JSON responses like file downloads)')
   .option('--parallel', 'Execute multiple actions concurrently (separate actions with --)')
   .option('--max-concurrency <n>', 'Max concurrent actions when using --parallel (default: 5)', '5')
   .action(async (platform: string | undefined, actionId: string | undefined, connectionKey: string | undefined, options: any) => {
@@ -470,6 +471,7 @@ actions
       dryRun: options.dryRun,
       mock: options.mock,
       skipValidation: options.skipValidation,
+      output: options.output,
     });
   });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,7 @@
-import { writeFileSync } from 'node:fs';
+import { createWriteStream } from 'node:fs';
 import { resolve } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
 import type {
   Connection,
   ConnectionsResponse,
@@ -424,46 +426,54 @@ export class OneApi {
       throw new ApiError(response.status, text || `HTTP ${response.status}`);
     }
 
-    // Try to parse as JSON first; if that fails, treat as binary
-    const responseBuffer = Buffer.from(await response.arrayBuffer());
     const responseContentType = response.headers.get('content-type') || '';
+    const isExplicitJson = responseContentType.includes('application/json') || responseContentType.includes('text/');
 
-    let responseData: unknown;
-    try {
-      const text = responseBuffer.toString('utf-8');
-      responseData = text ? JSON.parse(text) : {};
-    } catch {
-      // Not valid JSON — treat as binary response
-      if (args.output) {
-        const outputPath = resolve(args.output);
-        writeFileSync(outputPath, responseBuffer);
-        return {
-          requestConfig: sanitizedConfig,
-          responseData: {
-            saved: true,
-            path: outputPath,
-            size: responseBuffer.length,
-            contentType: responseContentType,
-          },
-        };
+    if (isExplicitJson || !responseContentType) {
+      // Explicit JSON/text content-type — fast path
+      const responseText = await response.text();
+      const responseData = responseText ? JSON.parse(responseText) : {};
+      return { requestConfig: sanitizedConfig, responseData };
+    }
+
+    // Ambiguous content-type (e.g. application/octet-stream from the API proxy).
+    // With --output: stream to disk (memory-safe for large binary files).
+    if (args.output) {
+      const outputPath = resolve(args.output);
+      const body = response.body;
+      if (!body) {
+        throw new ApiError(0, 'Response body is null — cannot save to file');
       }
+      const nodeReadable = Readable.fromWeb(body as any);
+      await pipeline(nodeReadable, createWriteStream(outputPath));
+      const contentLength = response.headers.get('content-length');
+      const size = contentLength ? parseInt(contentLength, 10) : undefined;
+      return {
+        requestConfig: sanitizedConfig,
+        responseData: { saved: true, path: outputPath, size, contentType: responseContentType },
+      };
+    }
 
-      // No --output flag — return metadata about the binary response
+    // Without --output: try JSON parse, fall back to binary metadata.
+    // The API proxy often returns application/octet-stream for JSON responses,
+    // so we must attempt parsing before assuming binary.
+    const responseText = await response.text();
+    try {
+      const responseData = responseText ? JSON.parse(responseText) : {};
+      return { requestConfig: sanitizedConfig, responseData };
+    } catch {
+      const contentLength = response.headers.get('content-length');
+      const size = contentLength ? parseInt(contentLength, 10) : responseText.length;
       return {
         requestConfig: sanitizedConfig,
         responseData: {
           binary: true,
-          size: responseBuffer.length,
+          size,
           contentType: responseContentType,
           message: 'Binary response received. Use --output <path> to save to a file.',
         },
       };
     }
-
-    return {
-      requestConfig: sanitizedConfig,
-      responseData,
-    };
   }
 
   // Webhook Relay methods

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type {
   Connection,
   ConnectionsResponse,
@@ -422,8 +424,41 @@ export class OneApi {
       throw new ApiError(response.status, text || `HTTP ${response.status}`);
     }
 
-    const responseText = await response.text();
-    const responseData = responseText ? JSON.parse(responseText) : {};
+    // Try to parse as JSON first; if that fails, treat as binary
+    const responseBuffer = Buffer.from(await response.arrayBuffer());
+    const responseContentType = response.headers.get('content-type') || '';
+
+    let responseData: unknown;
+    try {
+      const text = responseBuffer.toString('utf-8');
+      responseData = text ? JSON.parse(text) : {};
+    } catch {
+      // Not valid JSON — treat as binary response
+      if (args.output) {
+        const outputPath = resolve(args.output);
+        writeFileSync(outputPath, responseBuffer);
+        return {
+          requestConfig: sanitizedConfig,
+          responseData: {
+            saved: true,
+            path: outputPath,
+            size: responseBuffer.length,
+            contentType: responseContentType,
+          },
+        };
+      }
+
+      // No --output flag — return metadata about the binary response
+      return {
+        requestConfig: sanitizedConfig,
+        responseData: {
+          binary: true,
+          size: responseBuffer.length,
+          contentType: responseContentType,
+          message: 'Binary response received. Use --output <path> to save to a file.',
+        },
+      };
+    }
 
     return {
       requestConfig: sanitizedConfig,

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -47,6 +47,7 @@ one --agent actions execute <platform> <actionId> <key> -d '{}'  # Execute it
 - \`--dry-run\` — Preview request without executing
 - \`--mock\` — Return example response without making an API call (useful for building UI against a response shape)
 - \`--skip-validation\` — Skip input validation against the action schema
+- \`--output <path>\` — Save response to a file (for binary downloads like PDFs, images, documents)
 
 The CLI validates required parameters against the action schema before executing. If you're missing a required path variable, query param, or body field, you'll get a clear error listing what's missing and which flag to use. Pass \`--skip-validation\` to bypass.
 
@@ -171,6 +172,7 @@ one --agent actions execute <platform> <actionId> <connectionKey> [options]
 - \`--dry-run\` — Preview without executing
 - \`--mock\` — Return example response without making an API call
 - \`--skip-validation\` — Skip input validation against the action schema
+- \`--output <path>\` — Save response to a file (for binary downloads like PDFs, images, documents)
 
 **Do NOT** pass path or query parameters in \`-d\`. Use the correct flags.
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -122,6 +122,7 @@ export interface ExecuteActionArgs {
   isFormData?: boolean;
   isFormUrlEncoded?: boolean;
   dryRun?: boolean;
+  output?: string;
 }
 
 export interface SanitizedRequestConfig {


### PR DESCRIPTION
## Summary

Adds support for binary (non-JSON) responses from the API passthrough layer, fixing a crash that occurred when downloading files from Google Drive and other platforms that return binary data.

### The Problem

When using actions that return binary data (e.g., Google Drive `Get File` with `alt=media`, or `Export` for native Google Docs), the CLI crashed with:

```
Error: Unexpected token '%', "%PDF-1.4\n%"... is not valid JSON
```

This happened because `executePassthroughRequest` unconditionally called `JSON.parse()` on the response body, which fails for binary content like PDFs, images, and documents.

This blocked a very common workflow — downloading document files from Google Drive for local processing by AI agents.

### The Fix

**Binary response detection** (`src/lib/api.ts`)
- After receiving a response, check the `Content-Type` header
- If the response is not `application/json` or `text/*`, treat it as binary
- Without `--output`: return metadata (`size`, `contentType`, and a message prompting the user to use `--output`)
- With `--output <path>`: save the raw binary data to the specified file path

**New `--output` flag** (`src/index.ts`, `src/commands/actions.ts`, `src/lib/types.ts`)
- Added `--output <path>` option to `one actions execute`
- Passes through to the API layer for binary file saving

### Usage

```bash
# Download a PDF from Google Drive
one actions execute google-drive <get-file-action> <key> \
  --path-vars '{"fileId": "abc123"}' \
  --query-params '{"alt": "media"}' \
  --output ./file.pdf

# Export a native Google Doc as PDF
one actions execute google-drive <export-action> <key> \
  --path-vars '{"fileId": "abc123"}' \
  --query-params '{"mimeType": "application/pdf"}' \
  --output ./export.pdf

# Without --output, returns metadata instead of crashing
one actions execute google-drive <get-file-action> <key> \
  --path-vars '{"fileId": "abc123"}' \
  --query-params '{"alt": "media"}'
# → {"binary": true, "size": 415272, "contentType": "application/octet-stream", "message": "..."}
```

### Verified

| Test | Before | After |
|------|--------|-------|
| `alt=media` without `--output` | Crash: `not valid JSON` | Returns metadata (size, contentType) |
| `alt=media` with `--output` | N/A | Saves valid PDF to disk (415KB, `%PDF-1.4` header) |
| Export Google Doc as PDF | Crash: `not valid JSON` | Saves valid PDF to disk (24KB) |
| Export uploaded `.pdf` | `403: Export only supports Docs Editors files` | Same (expected — Google API limitation) |
| Normal JSON responses | Works | Unchanged — no regression |

### Files Changed

- `src/lib/api.ts` — Binary response detection and file saving logic
- `src/lib/types.ts` — Added `output` to `ExecuteActionArgs`
- `src/commands/actions.ts` — Pass `output` option through to API
- `src/index.ts` — Register `--output` CLI option

Closes withoneai/knowledge#46