### PR TITLE
feat: add --metadata flag to relay create + webhook-secret guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.36.0",
+      "version": "1.37.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/relay.md
+++ b/skills/one/references/relay.md
@@ -52,6 +52,25 @@ one --agent relay create \
 
 Always use `--create-webhook` — it registers the webhook URL with the source platform automatically.
 
+**Some source platforms require extra identifiers via `--metadata`:**
+
+| Platform | Required metadata keys |
+|---|---|
+| `github` | `GITHUB_OWNER`, `GITHUB_REPOSITORY` |
+| `typeform` | `TYPEFORM_FORM_ID` |
+| `stripe`, `airtable`, `attio`, `google-calendar` | (none) |
+
+Without metadata, `--create-webhook` silently fails for these platforms. Example for GitHub:
+
+```bash
+one --agent relay create \
+  --connection-key "live::github::default::<key>" \
+  --event-filters '["issues","pull_request"]' \
+  --metadata '{"GITHUB_OWNER":"my-org","GITHUB_REPOSITORY":"my-repo"}' \
+  --description "GitHub relay" \
+  --create-webhook
+```
+
 ### Step 6: Activate with a passthrough action
 
 ```bash
@@ -65,6 +84,8 @@ one --agent relay activate <relay-id> --actions '[{
   "eventFilters": ["event.type"]
 }]'
 ```
+
+**Do NOT pass `--webhook-secret` on activate** when you created the endpoint with `--create-webhook`. The correct secret is registered with the source platform and stored automatically. Supplying a wrong one does not error — events arrive but every delivery is dropped during signature verification (0 deliveries). If you don't have a reason to override the secret, omit the flag.
 
 ## Template Context
 
@@ -177,3 +198,5 @@ one --agent relay deliveries --event-id <id>
 - Event filters on both the endpoint and individual actions must match
 - Multiple actions can be attached to a single relay endpoint
 - Missing template variables resolve to empty strings — verify `{{payload.*}}` paths against the actual payload
+- GitHub and Typeform relays require `--metadata` on create; without it `--create-webhook` silently fails
+- Never pass `--webhook-secret` on activate when the endpoint was created with `--create-webhook` — the auto-stored secret is correct, and a wrong one causes signature verification to drop every event silently

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -68,6 +68,10 @@ export async function relayCreateCommand(options: {
     if (result.description) console.log(`  ${pc.dim('Description:')} ${result.description}`);
     if (result.eventFilters?.length) console.log(`  ${pc.dim('Events:')}      ${result.eventFilters.join(', ')}`);
     if (result.webhookPayload?.id) console.log(`  ${pc.dim('Webhook ID:')}  ${result.webhookPayload.id}`);
+    if (result.warning) {
+      console.log();
+      console.log(`  ${pc.yellow('⚠ Warning:')} ${result.warning}`);
+    }
     console.log();
   } catch (error) {
     spinner.stop('Failed to create relay endpoint');

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -30,6 +30,7 @@ export async function relayCreateCommand(options: {
   description?: string;
   eventFilters?: string;
   tags?: string;
+  metadata?: string;
   createWebhook?: boolean;
 }): Promise<void> {
   const { apiKey, connectionKeys } = getConfig();
@@ -49,6 +50,7 @@ export async function relayCreateCommand(options: {
     if (options.description) body.description = options.description;
     if (options.eventFilters) body.eventFilters = parseJsonArg(options.eventFilters, '--event-filters');
     if (options.tags) body.tags = parseJsonArg(options.tags, '--tags');
+    if (options.metadata) body.metadata = parseJsonArg(options.metadata, '--metadata');
     if (options.createWebhook) body.createWebhook = true;
 
     const result = await api.createRelayEndpoint(body as any);

--- a/src/index.ts
+++ b/src/index.ts
@@ -554,8 +554,9 @@ relay
   .option('--description <desc>', 'Description of the relay endpoint')
   .option('--event-filters <json>', 'JSON array of event types to filter (e.g. \'["customer.created"]\')')
   .option('--tags <json>', 'JSON array of tags')
+  .option('--metadata <json>', 'JSON object of platform-specific metadata required to register the webhook (e.g. GitHub: \'{"GITHUB_OWNER":"org","GITHUB_REPOSITORY":"repo"}\', Typeform: \'{"TYPEFORM_FORM_ID":"abc"}\')')
   .option('--create-webhook', 'Automatically register the webhook with the source platform')
-  .action(async (options: { connectionKey: string; description?: string; eventFilters?: string; tags?: string; createWebhook?: boolean }) => {
+  .action(async (options: { connectionKey: string; description?: string; eventFilters?: string; tags?: string; metadata?: string; createWebhook?: boolean }) => {
     await relayCreateCommand(options);
   });
 

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -246,8 +246,32 @@ one --agent relay deliveries --endpoint-id <id>    # Check delivery status
 2. **Get event types** — \`one --agent relay event-types <platform>\`
 3. **Get source knowledge** — understand the incoming webhook payload shape (\`{{payload.*}}\` paths)
 4. **Get destination knowledge** — understand the outgoing API body shape
-5. **Create endpoint** — with \`--create-webhook\` and \`--event-filters\`
-6. **Activate** — with passthrough action mapping source fields to destination fields
+5. **Create endpoint** — with \`--create-webhook\`, \`--event-filters\`, and \`--metadata\` if the source platform requires it
+6. **Activate** — with passthrough action mapping source fields to destination fields. **Do NOT pass \`--webhook-secret\`** when the endpoint was created with \`--create-webhook\` — the correct secret is auto-stored, and supplying a wrong one silently drops every delivery (events arrive, 0 deliveries).
+
+## Platform-Specific Metadata (\`--metadata\`)
+
+Some source platforms need extra identifiers to register a webhook. Pass these via \`--metadata '<json>'\` on \`relay create\`. Without them, \`--create-webhook\` silently fails:
+
+| Platform | Required metadata keys |
+|---|---|
+| \`github\` | \`GITHUB_OWNER\`, \`GITHUB_REPOSITORY\` |
+| \`typeform\` | \`TYPEFORM_FORM_ID\` |
+| \`stripe\` | (none) |
+| \`airtable\` | (none) |
+| \`attio\` | (none) |
+| \`google-calendar\` | (none) |
+
+Example (GitHub):
+
+\`\`\`bash
+one --agent relay create \\
+  --connection-key "live::github::default::<key>" \\
+  --event-filters '["issues","pull_request"]' \\
+  --metadata '{"GITHUB_OWNER":"my-org","GITHUB_REPOSITORY":"my-repo"}' \\
+  --description "GitHub relay" \\
+  --create-webhook
+\`\`\`
 
 ## Template Context
 
@@ -298,6 +322,8 @@ Any connected platform can be a destination via passthrough actions.
 2. \`relay events --platform <p>\` — check events are arriving
 3. \`relay deliveries --event-id <id>\` — check delivery status and errors
 4. \`relay event <id>\` — inspect full payload to verify template paths
+
+**If events arrive but 0 deliveries succeed**: you likely passed a wrong \`--webhook-secret\` on \`relay activate\`. When you created the endpoint with \`--create-webhook\`, the secret was registered with the source platform and stored automatically — do not pass it again on activate. Signature verification will fail silently and every event will be dropped.
 `;
 
 export const GUIDE_CACHE = `# One Cache — Reference


### PR DESCRIPTION
## Summary

- Wire `--metadata <json>` through `one relay create` — the API already accepted this field, but the CLI never surfaced it, so `--create-webhook` silently failed for platforms that need extra identifiers (GitHub, Typeform)
- Document required metadata keys per source platform in `GUIDE_RELAY` and `skills/one/references/relay.md`
- Document a signature-verification foot-gun: when an endpoint is created with `--create-webhook`, the correct secret is auto-stored. Passing `--webhook-secret` on `relay activate` overrides it with a wrong value, causing events to arrive but every delivery to be dropped silently (0 deliveries)
- Surface the API's `warning` field in human mode on `relay create` (previously only visible in agent JSON — users whose webhook registration failed saw "Relay endpoint created" with no indication)
- Bump version 1.36.0 → 1.37.0

## Example

```bash
one --agent relay create \
  --connection-key "live::github::default::<key>" \
  --event-filters '["issues","pull_request"]' \
  --metadata '{"GITHUB_OWNER":"my-org","GITHUB_REPOSITORY":"my-repo"}' \
  --description "GitHub relay" \
  --create-webhook
```

## Test results

| Case | Result |
|---|---|
| Stripe regression (no `--metadata`) | ✅ endpoint + webhook registered, `metadata: null` |
| GitHub with `--metadata` on `moekatib/awesome-one` | ✅ webhook registered (id 606645882), `ping` event delivered |
| Typeform with `--metadata` on form `SYQ7mnlZ` | ✅ webhook registered (id `01KPBXGAAR3YRVW9VY5GPDDR2V`) |
| Negative: GitHub without `--metadata` | ✅ API returns `warning: "... 404 Not Found"` — bug reproduced |
| `--metadata` plumbing (invalid JSON) | ✅ CLI errors with `Invalid JSON for --metadata: ...` |
| `node dist/index.js relay create --help` | ✅ new flag shown |
| `npm run build` | ✅ passes |

All test endpoints were deleted, and platform-side webhooks were cleaned up separately via the One CLI (`actions execute github delete-repository-webhook` / `actions execute typeform delete-form-webhook`) — verified 0 webhooks remaining on both platforms.

## Known follow-up (not in this PR)

`one relay delete` removes the endpoint from our API but leaves the platform-side webhook behind. Belongs on the server as a cascade in `DELETE /webhooks/relay/:id`. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
