### PR TITLE
fix: profile hooks run on enriched rows (Phase 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -551,6 +551,8 @@ The transform can be any command: \`jq\`, \`python3\`, a bash script, or \`one f
 
 **Pipeline order:** fetch → enrich → transform → **exclude** → create table → schema evolution → upsert → hooks
 
+Transform, exclude, identityKey, and hooks all fire in **both** phases. In Phase 1 they run on the raw list page; in Phase 2 they run again on the merged (list + enriched) record so that transforms can extract columns from fields that only appear after enrichment. Phase 2 fires \`onUpdate\`/\`onChange\` for every row it writes — \`onInsert\` is Phase-1-only because the row already exists in SQL by the time enrichment runs.
+
 ## Cross-Platform Identity
 
 Add \`identityKey\` to a sync profile to extract a stable cross-platform identifier (e.g. email) into a normalized \`_identity\` column:

--- a/src/lib/sync/enrich.ts
+++ b/src/lib/sync/enrich.ts
@@ -4,6 +4,8 @@ import { isAgentMode } from '../output.js';
 import type { EnrichConfig } from './types.js';
 import type { ActionDetails } from '../types.js';
 import type Database from 'better-sqlite3';
+import { transformRecords } from './transform.js';
+import { fireHooks, type ChangeEvent } from './hooks.js';
 
 /**
  * Phase 2 enrichment engine. Runs AFTER the list sync completes.
@@ -145,6 +147,27 @@ export interface EnrichResult {
 }
 
 /**
+ * Profile-level hooks/transforms that must be applied to each enriched row
+ * before it's written back to SQL. Mirrors the Phase 1 pipeline so that
+ * rows produced by enrichment end up with the same columns, identity, and
+ * event stream as rows written during list ingestion.
+ */
+export interface EnrichContext {
+  /** profile.transform — runs on the merged batch after enrich, before upsert. */
+  transform?: string;
+  /** profile.exclude — dot-paths stripped from each merged record. */
+  exclude?: string[];
+  /** profile.identityKey — recomputes `_identity` from the merged record. */
+  identityKey?: string;
+  /** profile.onInsert — not used here: enriched rows always existed, so they're updates. */
+  onInsert?: string;
+  /** profile.onUpdate — fired per row after a successful enrichment UPDATE. */
+  onUpdate?: string;
+  /** profile.onChange — fallback hook fired when onUpdate isn't set. */
+  onChange?: string;
+}
+
+/**
  * Phase 2: Enrich unenriched rows in the local DB.
  *
  * Queries all rows where the timestamp field IS NULL, calls the detail
@@ -158,6 +181,7 @@ export async function enrichPhase(
   idField: string,
   connectionKey: string,
   platform: string,
+  ctx: EnrichContext = {},
 ): Promise<EnrichResult> {
   const startTime = Date.now();
   const tsField = config.timestampField ?? '_enriched_at';
@@ -219,67 +243,111 @@ export async function enrichPhase(
     let batchHitRateLimit = false;
     const now = new Date().toISOString();
 
+    // Step 1: collect successfully-enriched rows as merged records (no writes yet).
+    // Accumulating the whole batch before writing lets us apply profile.transform
+    // across the batch as a single subprocess invocation, matching Phase 1 semantics.
+    type Pending = { merged: Record<string, unknown>; id: unknown };
+    const pending: Pending[] = [];
+
     for (let j = 0; j < results.length; j++) {
       const result = results[j];
       const row = batch[j];
       const id = row[idField];
 
       if (result.status === 'fulfilled' && result.value !== null) {
-        // Merge enriched data into the row
         let enrichedData = result.value;
-
-        // Apply fields filter
         if (config.fields && config.fields.length > 0) {
           enrichedData = pickFields(enrichedData, config.fields);
         }
-
-        // Apply exclude filter
         if (config.exclude && config.exclude.length > 0) {
           stripExcludedFields(enrichedData, config.exclude);
         }
-
-        // Merge
         const merged = config.merge !== false
           ? deepMerge(row, enrichedData)
           : { ...enrichedData, [idField]: id };
-
         merged[tsField] = now;
-
-        // Prepare values for SQL update — stringify objects
-        const setClauses: string[] = [];
-        const values: (string | number | null)[] = [];
-        for (const [key, val] of Object.entries(merged)) {
-          if (key === idField) continue; // don't update the id
-          setClauses.push(`"${key}" = ?`);
-          values.push(prepareValue(val));
-        }
-        values.push(prepareValue(id)); // for WHERE clause
-
-        if (setClauses.length > 0) {
-          // Ensure new columns exist
-          const existingCols = new Set((db.prepare(`PRAGMA table_info("${safeTable}")`).all() as Array<{ name: string }>).map(c => c.name));
-          for (const [key, val] of Object.entries(merged)) {
-            if (!existingCols.has(key)) {
-              const colType = detectColumnType(val);
-              db.exec(`ALTER TABLE "${safeTable}" ADD COLUMN "${key}" ${colType}`);
-              existingCols.add(key);
-            }
-          }
-
-          db.prepare(
-            `UPDATE "${safeTable}" SET ${setClauses.join(', ')} WHERE "${safeIdField}" = ?`
-          ).run(...values);
-        }
-
-        enriched++;
+        pending.push({ merged, id });
       } else if (result.status === 'fulfilled' && result.value === null) {
-        // null means rate-limited after all retries
         rateLimited++;
         skipped++;
         batchHitRateLimit = true;
       } else {
         skipped++;
       }
+    }
+
+    // Step 2: run profile.transform on the merged batch. The transform gets the
+    // post-merge shape (list fields + enriched fields) so it can extract columns
+    // from nested structures that only exist after enrichment (e.g. jq pulling
+    // `subject` out of `messages[0].payload.headers`).
+    let writes: Pending[] = pending;
+    if (ctx.transform && pending.length > 0) {
+      const transformed = await transformRecords(ctx.transform, pending.map(p => p.merged));
+      if (transformed) {
+        // Pair transformed records back to original ids by idField so the UPDATE
+        // hits the right row even if the transform reorders or filters.
+        const byId = new Map<unknown, Record<string, unknown>>();
+        for (const r of transformed) byId.set(r[idField], r);
+        writes = [];
+        for (const p of pending) {
+          const t = byId.get(p.id);
+          if (!t) continue; // transform dropped this record — skip update, row stays unenriched
+          // Re-assert tsField in case the transform omitted it; if we don't,
+          // the row's _enriched_at stays NULL and the next run re-enriches.
+          if (!t[tsField]) t[tsField] = now;
+          writes.push({ merged: t, id: p.id });
+        }
+      }
+    }
+
+    // Step 3: per-row profile-level exclude + identity, schema evolution, UPDATE.
+    const hookEvents: ChangeEvent[] = [];
+    for (const { merged, id } of writes) {
+      if (ctx.exclude && ctx.exclude.length > 0) {
+        stripExcludedFields(merged, ctx.exclude);
+      }
+      if (ctx.identityKey) {
+        const raw = getByDotPath(merged, ctx.identityKey);
+        if (raw !== null && raw !== undefined) {
+          merged._identity = String(raw).toLowerCase().trim();
+        }
+      }
+
+      const setClauses: string[] = [];
+      const values: (string | number | null)[] = [];
+      for (const [key, val] of Object.entries(merged)) {
+        if (key === idField) continue;
+        setClauses.push(`"${key}" = ?`);
+        values.push(prepareValue(val));
+      }
+      values.push(prepareValue(id));
+
+      if (setClauses.length > 0) {
+        const existingCols = new Set((db.prepare(`PRAGMA table_info("${safeTable}")`).all() as Array<{ name: string }>).map(c => c.name));
+        for (const [key, val] of Object.entries(merged)) {
+          if (!existingCols.has(key)) {
+            const colType = detectColumnType(val);
+            db.exec(`ALTER TABLE "${safeTable}" ADD COLUMN "${key}" ${colType}`);
+            existingCols.add(key);
+          }
+        }
+        db.prepare(
+          `UPDATE "${safeTable}" SET ${setClauses.join(', ')} WHERE "${safeIdField}" = ?`
+        ).run(...values);
+      }
+
+      enriched++;
+
+      // Enrichment writes are always "update" events — the row existed in SQL
+      // before this phase ran (Phase 1 inserted it with _enriched_at NULL).
+      if (ctx.onUpdate || ctx.onChange) {
+        hookEvents.push({ type: 'update', platform, model, record: merged, timestamp: now });
+      }
+    }
+
+    if (hookEvents.length > 0) {
+      const hook = ctx.onUpdate || ctx.onChange;
+      if (hook) await fireHooks(hook, hookEvents);
     }
 
     // Shared backoff: if ANY worker in this batch hit a rate limit,

--- a/src/lib/sync/runner.ts
+++ b/src/lib/sync/runner.ts
@@ -547,10 +547,24 @@ export async function syncModel(
       enrichResult = await enrichPhase(
         api, db, profile.enrich, model, profile.idField,
         profile.connectionKey, platform,
+        {
+          transform: profile.transform,
+          exclude: profile.exclude,
+          identityKey: profile.identityKey,
+          onInsert: profile.onInsert,
+          onUpdate: profile.onUpdate,
+          onChange: profile.onChange,
+        },
       );
       enrichedTotal = enrichResult.enriched;
       enrichSkipped = enrichResult.skipped;
       enrichRateLimited = enrichResult.rateLimited;
+
+      // Enrichment writes count as updates for hook metrics (the row already
+      // existed in SQL from Phase 1 — enrichment just fills in detail fields).
+      if (hasHooks && (profile.onUpdate || profile.onChange)) {
+        hooksUpdated += enrichResult.enriched;
+      }
 
       // Rebuild FTS after enrichment added new text content
       if (enrichResult.enriched > 0) {

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -60,8 +60,15 @@ export interface SyncProfile {
   exclude?: string[];
   /**
    * Transform records through a shell command or flow before storing.
-   * The command receives the page of records as a JSON array on stdin and
-   * must return a JSON array on stdout. Runs after enrich, before upsert.
+   * The command receives a JSON array on stdin and must return a JSON array
+   * on stdout. Runs in both phases: on each list page during Phase 1, and
+   * on each enrichment batch (after merge, before UPDATE) during Phase 2,
+   * so extracted columns stay consistent regardless of which phase produced
+   * the data.
+   *
+   * Performance note: the transform is spawned once per batch, so a slow
+   * transform combined with a low `enrich.delayMs` and high `enrich.concurrency`
+   * can become throughput-bound.
    *
    * Examples:
    *   "node ./scripts/flatten-properties.js"


### PR DESCRIPTION
## Summary

- `profile.transform`, `exclude`, `identityKey`, and `onUpdate`/`onChange` were silently skipped during Phase 2 enrichment — the enriched payload was merged and written straight to SQL with no hooks
- Plumb a ctx object through `enrichPhase` and apply the same pipeline as Phase 1 per concurrency-batch: **merge → transform → exclude → identity → schema evolve → UPDATE → hook**
- Enrichment writes fire `onUpdate`/`onChange` (the row existed in SQL before Phase 2 ran, so \`onInsert\` is Phase-1-only by design)
- Docs updated: `guide-content.ts` pipeline note, `types.ts` transform JSDoc

## Why

The documented pipeline order in `one guide sync` ("fetch → enrich → transform → …") wasn't true for any row whose data came from Phase 2. Transforms that pulled columns out of enriched structures (e.g. Gmail threads extracting \`subject\` from \`messages[0].payload.headers\`) would populate those columns on rows that happened to arrive in the list payload but leave them empty for every row that needed a detail call.

## Verification

Smoke test against an in-memory sqlite DB with a stubbed \`OneApi\`:

- seed 2 lightweight rows (no subject/from/date), enrich via mock detail endpoint that returns \`messages[].payload.headers[]\`
- profile has \`transform\` (jq), \`exclude\` (strip big blob), \`identityKey\`, \`onUpdate: "cat >> events.jsonl"\`
- assert: transform-extracted columns populated, \`_enriched_at\` set, excluded blob absent, \`_identity\` set, 2 update events written to the hook log

All assertions pass.

## Out of scope

- \`--full-refresh\` bypassing \`_enriched_at IS NULL\` so already-enriched rows can be re-processed after a transform is added (backfill UX)
- Performance: spawning the transform per concurrency-batch is fine for default \`concurrency: 5\`, but very low \`delayMs\` + high concurrency + slow transform will be transform-bound — called out in the JSDoc

## Test plan

- [x] typecheck clean for the changed files
- [x] build clean
- [x] smoke test with stubbed api (transform + exclude + identity + hook fired)
- [ ] real-world Gmail threads run (clear \`_enriched_at\` on a few rows, re-sync, confirm subject/from populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)