### PR TITLE
feat: sync support for root-array responses + primitive wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ one sync run stripe --full-refresh
 | `schedule add/list/status/remove/repair` | Cron-backed scheduled syncs with drift detection |
 | `remove <platform>` | Delete local data (`--dry-run` to preview) |
 
-Change hooks (`onInsert`, `onUpdate`, `onChange`) fire per-page during sync — pipe to a shell command, a flow, or an event log. Run `one guide sync` for the full reference.
+Change hooks (`onInsert`, `onUpdate`, `onChange`) fire per-page during sync — pipe to a shell command, a flow, or an event log. Root-array responses (e.g. Hacker News `/v0/topstories.json` → `[9129911, 9129199, ...]`) are supported by setting `resultsPath` to `""`, `"$"`, or `"."`; primitive elements are auto-wrapped as `{ [idField]: value }`. Run `one guide sync` for the full reference.
 
 ### `one guide [topic]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.37.3",
+  "version": "1.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.37.3",
+      "version": "1.38.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.37.3",
+  "version": "1.38.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [
@@ -16,7 +16,8 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "start": "node bin/cli.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@clack/prompts": "^0.9.1",

--- a/profiles/hacker-news/topStories.json
+++ b/profiles/hacker-news/topStories.json
@@ -1,0 +1,11 @@
+{
+  "description": "Hacker News top story IDs — up to 500 item IDs at /v0/topstories.json (root-array response, primitives wrapped as { id })",
+  "platform": "hacker-news",
+  "model": "topStories",
+  "connectionKey": "AUTO",
+  "actionId": "conn_mod_def::GJ3108Dwmm4::avAMAq7HQtW6PT8JhPg5vA",
+  "resultsPath": "",
+  "idField": "id",
+  "pagination": { "type": "none" },
+  "limitParam": ""
+}

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -478,7 +478,7 @@ one --agent sync sql stripe "SELECT count(*) FROM balanceTransactions"
 \`sync init\` without \`--config\` does all of this automatically:
 - **connectionKey** — auto-resolved when there's exactly one connection for the platform
 - **Pagination** — Stripe id-pagination, Notion body-cursor, HubSpot/Google token, offset, link. Inapplicable fields stripped (no nextPath for offset, no passAs for none)
-- **resultsPath** — generic keys (data, results, items) + platform-specific (model name stripped of platform prefix: attioCompanies → companies)
+- **resultsPath** — generic keys (data, results, items) + platform-specific (model name stripped of platform prefix: attioCompanies → companies). Use \`""\`, \`"$"\`, or \`"."\` for responses that return a bare array at the root (e.g. Hacker News \`/v0/topstories.json\`); primitive array elements are auto-wrapped as \`{ [idField]: value }\`.
 - **idField** — id, _id, uuid
 - **pathVars** — extracted from URL template with smart defaults (calendarId="primary", userId="me"). Internal keys (INTERNAL_SIGNING_KEY) and record-level IDs (record_id) are stripped automatically
 - **dateFilter** — updated_since, created_after, etc.
@@ -643,7 +643,7 @@ Fetches ALL records and deletes local rows whose IDs are no longer in the source
 |-------|----------|-------------|
 | connectionKey | yes | From \`one list\` |
 | actionId | yes | Auto-resolved by \`sync init\` |
-| resultsPath | yes | Auto-inferred or auto-discovered by \`sync test\` |
+| resultsPath | yes | Auto-inferred or auto-discovered by \`sync test\`. Use \`""\` / \`"$"\` / \`"."\` for root-array responses |
 | idField | yes | Auto-inferred or auto-discovered by \`sync test\` |
 | pagination | yes | Auto-inferred (cursor/token/offset/id/link/none) |
 | pathVars | no | Auto-extracted from URL template |

--- a/src/lib/sync/extract.test.ts
+++ b/src/lib/sync/extract.test.ts
@@ -1,0 +1,114 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractRecords, isRootPath } from './extract.js';
+
+test('isRootPath recognises all root sentinel values', () => {
+  assert.equal(isRootPath(''), true);
+  assert.equal(isRootPath('$'), true);
+  assert.equal(isRootPath('.'), true);
+  assert.equal(isRootPath(undefined), true);
+  assert.equal(isRootPath(null), true);
+  assert.equal(isRootPath('items'), false);
+  assert.equal(isRootPath('data.records'), false);
+});
+
+test('extractRecords: dotted path on an object response (unchanged behaviour)', () => {
+  const resp = { items: [{ id: 'a' }, { id: 'b' }] };
+  const out = extractRecords(resp, 'items', 'id', 'attio/attioCompanies');
+  assert.deepEqual(out.records, [{ id: 'a' }, { id: 'b' }]);
+  assert.equal(out.wrappedPrimitives, false);
+});
+
+test('extractRecords: root array of objects when resultsPath is empty', () => {
+  const resp = [{ id: 1 }, { id: 2 }];
+  const out = extractRecords(resp, '', 'id', 'foo/bar');
+  assert.deepEqual(out.records, [{ id: 1 }, { id: 2 }]);
+  assert.equal(out.wrappedPrimitives, false);
+});
+
+test('extractRecords: root array of objects when resultsPath is "$"', () => {
+  const resp = [{ id: 1 }, { id: 2 }];
+  const out = extractRecords(resp, '$', 'id', 'foo/bar');
+  assert.deepEqual(out.records, [{ id: 1 }, { id: 2 }]);
+});
+
+test('extractRecords: root array of objects when resultsPath is "."', () => {
+  const resp = [{ id: 1 }, { id: 2 }];
+  const out = extractRecords(resp, '.', 'id', 'foo/bar');
+  assert.deepEqual(out.records, [{ id: 1 }, { id: 2 }]);
+});
+
+test('extractRecords: primitive integers at the root are wrapped as { id: "<string>" }', () => {
+  const resp = [9129911, 9129199, 9127761];
+  const out = extractRecords(resp, '', 'id', 'hacker-news/topStories');
+  assert.deepEqual(out.records, [
+    { id: '9129911' },
+    { id: '9129199' },
+    { id: '9127761' },
+  ]);
+  assert.equal(out.wrappedPrimitives, true);
+});
+
+test('extractRecords: primitive strings at the root are wrapped and stringified', () => {
+  const resp = ['alpha', 'beta'];
+  const out = extractRecords(resp, '', 'slug', 'custom/tags');
+  assert.deepEqual(out.records, [{ slug: 'alpha' }, { slug: 'beta' }]);
+  assert.equal(out.wrappedPrimitives, true);
+});
+
+test('extractRecords: primitive booleans at the root are wrapped', () => {
+  const resp = [true, false, true];
+  const out = extractRecords(resp, '', 'v', 'flags/toggle');
+  assert.deepEqual(out.records, [{ v: 'true' }, { v: 'false' }, { v: 'true' }]);
+  assert.equal(out.wrappedPrimitives, true);
+});
+
+test('extractRecords: empty array returns empty records and wrappedPrimitives=false', () => {
+  const out = extractRecords([], '', 'id', 'foo/bar');
+  assert.deepEqual(out.records, []);
+  assert.equal(out.wrappedPrimitives, false);
+});
+
+test('extractRecords: path-resolved primitive array is also wrapped', () => {
+  // Some APIs return `{ ids: [1, 2, 3] }` — resultsPath = "ids" should
+  // still benefit from primitive wrapping.
+  const resp = { ids: [1, 2, 3] };
+  const out = extractRecords(resp, 'ids', 'id', 'foo/bar');
+  assert.deepEqual(out.records, [{ id: '1' }, { id: '2' }, { id: '3' }]);
+  assert.equal(out.wrappedPrimitives, true);
+});
+
+test('extractRecords: non-array response throws with profile label and top-level type', () => {
+  const resp = { message: 'nope', errors: [{ code: 42 }] };
+  assert.throws(
+    () => extractRecords(resp, 'items', 'id', 'foo/bar'),
+    (err: Error) => {
+      assert.match(err.message, /foo\/bar/);
+      assert.match(err.message, /'items'/);
+      assert.match(err.message, /object/);
+      assert.match(err.message, /Top-level keys: \[message, errors\]/);
+      return true;
+    },
+  );
+});
+
+test('extractRecords: root path on non-array response names <root>', () => {
+  const resp = { oops: 'not an array' };
+  assert.throws(
+    () => extractRecords(resp, '', 'id', 'foo/bar'),
+    (err: Error) => {
+      assert.match(err.message, /<root>/);
+      assert.match(err.message, /foo\/bar/);
+      return true;
+    },
+  );
+});
+
+test('extractRecords: primitive nulls inside an otherwise-primitive array are dropped', () => {
+  // Real-world fuzzy responses sometimes interleave nulls. Typeof null is
+  // 'object', so the first element dictates wrapping. If a primitive leads,
+  // nulls are skipped rather than wrapped as { id: "null" }.
+  const resp = [1, null, 2, null, 3];
+  const out = extractRecords(resp, '', 'id', 'foo/bar');
+  assert.deepEqual(out.records, [{ id: '1' }, { id: '2' }, { id: '3' }]);
+});

--- a/src/lib/sync/extract.ts
+++ b/src/lib/sync/extract.ts
@@ -1,0 +1,99 @@
+import { getByDotPath } from '../dot-path.js';
+
+/**
+ * A profile's `resultsPath` value that targets the root of the response
+ * (i.e. the response IS the records array). Any of these are treated as
+ * equivalent to "no path — use the whole response".
+ */
+const ROOT_PATH_TOKENS = new Set(['', '$', '.']);
+
+export function isRootPath(resultsPath: string | undefined | null): boolean {
+  return resultsPath === undefined || resultsPath === null || ROOT_PATH_TOKENS.has(resultsPath);
+}
+
+/** A primitive response element that must be wrapped as `{ id: <stringified> }`. */
+function isPrimitive(value: unknown): value is string | number | boolean {
+  const t = typeof value;
+  return t === 'string' || t === 'number' || t === 'boolean';
+}
+
+/**
+ * Describe the top-level type of a response for error messages.
+ * Used when the caller points resultsPath at something that doesn't exist.
+ */
+function describeType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+export interface ExtractResult {
+  records: Record<string, unknown>[];
+  /** Whether primitive elements were auto-wrapped as { id: <value> }. */
+  wrappedPrimitives: boolean;
+}
+
+/**
+ * Extract the records array from an API response for a sync profile.
+ *
+ * Supports three shapes:
+ *   1. Dotted path on an object response (existing behaviour, e.g. "items").
+ *   2. Root array: `resultsPath` is empty / "$" / "." AND response is an array.
+ *   3. Array of primitives (numbers/strings/bools) at the root or at a path.
+ *      Each primitive is wrapped as `{ [idField]: String(value) }` so the
+ *      downstream schema-inference and upsert code can treat it like any
+ *      other object record.
+ *
+ * Throws a descriptive Error when the configured path doesn't resolve to
+ * an array — the message names both the profile path and the actual
+ * top-level type so the agent can diagnose without re-running with -v.
+ */
+export function extractRecords(
+  responseData: unknown,
+  resultsPath: string | undefined | null,
+  idField: string,
+  profileLabel: string,
+): ExtractResult {
+  let candidate: unknown;
+
+  if (isRootPath(resultsPath)) {
+    candidate = responseData;
+  } else {
+    candidate = getByDotPath(responseData, resultsPath as string);
+  }
+
+  if (!Array.isArray(candidate)) {
+    const topKeys = typeof responseData === 'object' && responseData !== null && !Array.isArray(responseData)
+      ? Object.keys(responseData).slice(0, 10)
+      : [];
+    const pathLabel = isRootPath(resultsPath) ? '<root>' : `'${resultsPath}'`;
+    const typeLabel = describeType(responseData);
+    const keyHint = topKeys.length > 0 ? ` Top-level keys: [${topKeys.join(', ')}].` : '';
+    throw new Error(
+      `Could not find results at path ${pathLabel} for profile ${profileLabel}. ` +
+      `Response top-level type is ${typeLabel}.${keyHint} ` +
+      `Set resultsPath to the array field, or use "" / "$" / "." for root arrays.`
+    );
+  }
+
+  // Fast-path: empty array. Caller will handle "no records" signalling.
+  if (candidate.length === 0) {
+    return { records: [], wrappedPrimitives: false };
+  }
+
+  // If the first element is a primitive, assume the whole array is primitives.
+  // Mixed arrays (some primitives, some objects) are not a real-world shape
+  // we need to handle — wrapping the primitives and leaving the objects alone
+  // would give the schema inference two conflicting row shapes for the same
+  // model, which has no good answer.
+  if (isPrimitive(candidate[0])) {
+    const wrapped: Record<string, unknown>[] = [];
+    for (const value of candidate) {
+      if (!isPrimitive(value)) continue; // skip nulls / oddball entries
+      wrapped.push({ [idField]: String(value) });
+    }
+    return { records: wrapped, wrappedPrimitives: true };
+  }
+
+  return { records: candidate as Record<string, unknown>[], wrappedPrimitives: false };
+}

--- a/src/lib/sync/profile.ts
+++ b/src/lib/sync/profile.ts
@@ -20,11 +20,16 @@ export function readProfile(platform: string, model: string): SyncProfile | null
 }
 
 export function writeProfile(profile: SyncProfile): void {
-  const required: (keyof SyncProfile)[] = ['platform', 'model', 'connectionKey', 'actionId', 'resultsPath', 'idField', 'pagination'];
+  const required: (keyof SyncProfile)[] = ['platform', 'model', 'connectionKey', 'actionId', 'idField', 'pagination'];
   for (const field of required) {
     if (!profile[field]) {
       throw new Error(`Missing required field: ${field}`);
     }
+  }
+  // resultsPath is required but empty string / "$" / "." all mean "root array",
+  // so we only reject `undefined` (not explicitly set by the caller).
+  if (profile.resultsPath === undefined) {
+    throw new Error('Missing required field: resultsPath (use "" or "$" for root-array responses)');
   }
   if (!profile.pagination.type) {
     throw new Error('Missing required field: pagination.type');

--- a/src/lib/sync/runner.ts
+++ b/src/lib/sync/runner.ts
@@ -10,6 +10,7 @@ import { acquireSyncLock } from './lock.js';
 import { classifyRecords, fireHooks, type ChangeEvent } from './hooks.js';
 import { enrichPhase, type EnrichResult } from './enrich.js';
 import { transformRecords } from './transform.js';
+import { extractRecords } from './extract.js';
 import type Database from 'better-sqlite3';
 
 const MAX_RETRIES_PER_PAGE = 3;
@@ -341,18 +342,16 @@ export async function syncModel(
         }
       }
 
-      // Extract results
-      const records = getByDotPath(responseData, profile.resultsPath);
-      if (!Array.isArray(records)) {
-        // Try to help the user fix the profile
-        const topKeys = typeof responseData === 'object' && responseData !== null
-          ? Object.keys(responseData)
-          : [];
-        throw new Error(
-          `Could not find results at path '${profile.resultsPath}' in API response. ` +
-          `Check your sync profile. Response keys: [${topKeys.join(', ')}]`
-        );
-      }
+      // Extract results. extractRecords also handles root-array responses
+      // (e.g. the HN `topstories.json` endpoint returns a bare `[123, 456]`)
+      // and arrays of primitives (wraps each as `{ [idField]: String(value) }`).
+      const extraction = extractRecords(
+        responseData,
+        profile.resultsPath,
+        profile.idField,
+        `${platform}/${model}`,
+      );
+      const records = extraction.records;
 
       if (records.length === 0 && page === 0) {
         // Empty results on first page — not an error

--- a/src/lib/sync/test.ts
+++ b/src/lib/sync/test.ts
@@ -4,6 +4,7 @@ import type { ActionDetails } from '../types.js';
 import { getByDotPath } from '../dot-path.js';
 import { getNextPageParams } from './pagination.js';
 import type { SyncProfile } from './types.js';
+import { extractRecords, isRootPath } from './extract.js';
 
 export interface SyncTestCheck {
   name: string;
@@ -105,27 +106,46 @@ export async function testSyncProfile(api: OneApi, profile: SyncProfile): Promis
   // If the profile still has FILL_IN (or the path fails), auto-discover by
   // scanning top-level response keys for the first array — the agent shouldn't
   // have to guess this when we have the real response sitting right here.
+  // Root-array responses (e.g. HN topstories) are also supported: if the
+  // response itself is an array, treat resultsPath as root.
   let resolvedResultsPath = profile.resultsPath;
-  let records = getByDotPath(responseData, resolvedResultsPath);
+  const rawCandidate: unknown = isRootPath(resolvedResultsPath)
+    ? responseData
+    : getByDotPath(responseData, resolvedResultsPath);
+  let records: unknown[] | null = Array.isArray(rawCandidate) ? rawCandidate : null;
 
-  if (!Array.isArray(records) && typeof responseData === 'object' && responseData !== null) {
-    // Auto-discover: find the first top-level key whose value is an array
-    const topObj = responseData as Record<string, unknown>;
-    const arrayKey = Object.keys(topObj).find(k => Array.isArray(topObj[k]));
-    if (arrayKey) {
-      resolvedResultsPath = arrayKey;
-      records = topObj[arrayKey];
+  if (records === null) {
+    if (Array.isArray(responseData)) {
+      // Auto-discover root array — profile had a stale path but response is
+      // a bare array.
+      resolvedResultsPath = '';
+      records = responseData;
       report.autoFixed = report.autoFixed ?? {};
-      report.autoFixed.resultsPath = arrayKey;
+      report.autoFixed.resultsPath = '';
       checks.push({
-        name: `resultsPath auto-discovered → "${arrayKey}"`,
+        name: `resultsPath auto-discovered → <root>`,
         ok: true,
-        detail: `Profile had "${profile.resultsPath}" which didn't resolve; found "${arrayKey}" in response`,
+        detail: `Response is a root-level array — profile had "${profile.resultsPath}"`,
       });
+    } else if (typeof responseData === 'object' && responseData !== null) {
+      // Auto-discover: find the first top-level key whose value is an array
+      const topObj = responseData as Record<string, unknown>;
+      const arrayKey = Object.keys(topObj).find(k => Array.isArray(topObj[k]));
+      if (arrayKey) {
+        resolvedResultsPath = arrayKey;
+        records = topObj[arrayKey] as unknown[];
+        report.autoFixed = report.autoFixed ?? {};
+        report.autoFixed.resultsPath = arrayKey;
+        checks.push({
+          name: `resultsPath auto-discovered → "${arrayKey}"`,
+          ok: true,
+          detail: `Profile had "${profile.resultsPath}" which didn't resolve; found "${arrayKey}" in response`,
+        });
+      }
     }
   }
 
-  if (!Array.isArray(records)) {
+  if (records === null) {
     const topKeys =
       typeof responseData === 'object' && responseData !== null ? Object.keys(responseData as object) : [];
     checks.push({
@@ -135,10 +155,28 @@ export async function testSyncProfile(api: OneApi, profile: SyncProfile): Promis
     });
     return report;
   }
+
+  // Wrap primitive arrays (e.g. HN's array of integers) so the sample/column
+  // preview matches what the runner will actually insert.
+  let wrappedPrimitives = false;
+  if (records.length > 0 && typeof records[0] !== 'object') {
+    const idField = profile.idField || 'id';
+    const wrapped: Record<string, unknown>[] = [];
+    for (const v of records) {
+      if (typeof v === 'object') continue;
+      wrapped.push({ [idField]: String(v) });
+    }
+    records = wrapped;
+    wrappedPrimitives = true;
+  }
+
+  const pathLabel = isRootPath(resolvedResultsPath) ? '<root>' : `"${resolvedResultsPath}"`;
   checks.push({
-    name: `resultsPath "${resolvedResultsPath}" → array`,
+    name: `resultsPath ${pathLabel} → array`,
     ok: true,
-    detail: `${records.length} records`,
+    detail: wrappedPrimitives
+      ? `${(records as unknown[]).length} primitive records (wrapped as { ${profile.idField || 'id'}: value })`
+      : `${(records as unknown[]).length} records`,
   });
 
   if (records.length === 0) {

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -24,7 +24,13 @@ export interface SyncProfile {
   model: string;
   connectionKey: string;
   actionId: string;
-  /** Dot-path to the array of records in the API response */
+  /**
+   * Dot-path to the array of records in the API response. Use `""`, `"$"`,
+   * or `"."` when the response *is* the array (e.g. HN's `/v0/topstories.json`
+   * returns a bare `[123, 456, ...]`). Arrays of primitives are auto-wrapped
+   * as `{ [idField]: String(value) }` so they fit the same insert pipeline
+   * as object responses.
+   */
   resultsPath: string;
   /** Which field on each record is the unique ID */
   idField: string;


### PR DESCRIPTION
## Summary
- New `extractRecords` helper handles three response shapes: dotted path on an object (existing), root array when `resultsPath` is `""` / `"$"` / `"."`, and arrays of primitives (auto-wrapped as `{ [idField]: String(value) }`). Wired into `runner.ts` and `sync test`.
- Built-in profile `profiles/hacker-news/topStories.json` so `one sync init hacker-news topStories` just works.
- Profile validation now accepts empty `resultsPath` (only rejects `undefined`). Error message names both the profile (`platform/model`) and the actual top-level type when no array is found.

Root-array path was explicitly *not* added for `enrich.resultsPath` or for full JSONPath support — out of scope per the task.

## Test plan
- [x] `npm test` — 13/13 pass (new `extract.test.ts`).
- [x] `npm run build` — clean.
- [x] End-to-end on dev binary against a fresh project:
  - `one --agent sync init hacker-news topStories` → built-in profile loaded + `_test.ok: true` with `500 primitive records (wrapped as { id: value })`.
  - `one --agent sync run hacker-news --models topStories` → `{recordsSynced: 500, duration: "382ms", status: "complete"}`.
  - `one --agent sync query hacker-news/topStories --limit 5` → returns 5 rows, ids stringified as expected.
- [x] Negative path: patching profile to `"resultsPath":"wrongPath"` yields a clear error that names the profile, the path, the top-level type, and the remedy.
- [x] Smoke-tested existing `sync test` for `attio/attioCompanies`, `fathom/meetings`, `gmail/gmailThreads`, `google-calendar/events` — all pass unchanged (object-rooted behaviour untouched).

## Open question
Primitive wrapping is implicit (no profile flag). Keeps profiles minimal; happy to gate on a `wrapPrimitives` flag if you'd rather make it explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)