### PR TITLE
fix: hard-block custom actions in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ one sync init stripe balanceTransactions --config '{"onInsert":"one flow execute
 one sync run stripe --full-refresh
 ```
 
+> **Sync uses passthrough actions only.** Profiles referencing a custom/composer action are rejected at runtime. `sync models` already filters to passthrough-only; if a model has no passthrough list endpoint, compose a flow instead of syncing.
+
 | Subcommand | What it does |
 |------------|-------------|
 | `install` / `doctor` | Install + verify the SQLite engine |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -173,6 +173,8 @@ one --agent sync list stripe                     # progress + freshness
 one sync schedule add stripe --every 1h
 ```
 
+**Sync rejects custom actions** — profiles must use passthrough. `sync init` only surfaces passthrough models; `sync run` aborts if the list or enrich action is tagged `custom`. If no passthrough exists, compose a flow instead.
+
 **Advanced features** (enrich, transform, exclude, identityKey, hooks, --full-refresh, --where-sql delete, cursor resume): run `one guide sync` for the full reference.
 
 ## Beyond Single Actions

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -430,23 +430,29 @@ one --agent sync profiles stripe       # filter by platform
 
 When a built-in exists, \`sync init\` uses it automatically — no inference needed, no manual config. The agent just needs to match the user's intent to a profile description.
 
-## Action Resolution
+## Action Resolution — custom actions are hard-blocked
 
-Sync profiles MUST prefer passthrough actions over custom actions.
-Custom actions add server-side fan-out and transformation that causes timeouts
-and payload size failures at scale. The sync engine handles pagination, retries,
-rate limiting, and enrichment locally — a server-side middleware layer on top
-of that creates problems, not value.
+Sync refuses to run against custom/composer actions (tag \`custom\`). Both
+the list action and any enrich detail action in a profile MUST be passthrough.
+\`sync run\` loads the action's knowledge, checks for the \`custom\` tag, and
+aborts with a clear error pointing at the passthrough alternative.
 
-When resolving actions for sync profiles:
-1. Search with knowledge mode (not execute mode) to include passthrough actions
+Why the block:
+- Custom actions run on a small shared fleet that collapses under sync-scale load
+- Custom list endpoints often expect filters in the body and silently return
+  unfiltered or empty results (sync sends params as query/path only by design)
+- The sync engine already handles pagination, retry, rate limiting, and per-record
+  enrichment locally — server-side fan-out on top of that creates 5xx, not value
+
+How to build a profile:
+1. \`one actions search <platform> "<model>"\` surfaces passthrough actions.
+   \`sync init\`'s auto-infer also drops customs before offering choices.
 2. Prefer GET passthrough endpoints (e.g. /gmail/v1/users/{userId}/threads)
-   over POST custom endpoints (e.g. /gmail/get-threads)
-3. Use enrich config for per-record detail fetching instead of relying on
-   custom actions that fan out server-side
-4. Only fall back to custom actions when no passthrough equivalent exists
-
-This applies to sync models discovery, sync init, and enrich action selection.
+   over POST custom endpoints (e.g. /gmail/get-threads).
+3. If no passthrough list action exists for a model, that model can't be
+   synced. Compose a flow that chains passthrough calls instead. Custom
+   actions are for one-off agent use only — never sync, never flow.
+4. The enrich \`actionId\` is held to the same rule: must be passthrough.
 
 ## Workflow: init → run → query
 

--- a/src/lib/sync/enrich.ts
+++ b/src/lib/sync/enrich.ts
@@ -223,6 +223,15 @@ export async function enrichPhase(
     );
   }
 
+  // Hard block: enrich actions also must be passthrough. Custom actions
+  // collapse under the per-row fan-out that enrichment performs.
+  if (detailAction.tags?.includes('custom')) {
+    throw new Error(
+      `Enrich does not support custom actions. Action ${config.actionId} is tagged "custom". ` +
+      `Use a passthrough detail endpoint — run 'one actions search ${platform} "<model> get"' to find one.`
+    );
+  }
+
   let concurrency = config.concurrency ?? DEFAULT_CONCURRENCY;
   let enriched = 0;
   let skipped = 0;

--- a/src/lib/sync/models.ts
+++ b/src/lib/sync/models.ts
@@ -7,6 +7,7 @@ interface RawAvailableAction {
   modelName: string;
   method: string;
   path: string;
+  tags?: string[];
 }
 
 /**
@@ -17,6 +18,15 @@ function parseActionType(actionKey: string): string | null {
   const parts = actionKey.split('::');
   if (parts.length < 5) return null;
   return parts[4];
+}
+
+/**
+ * Custom/composer actions are one-off helpers backed by small, shared servers
+ * not designed for sync-scale load. Sync hard-blocks them — profiles must use
+ * passthrough actions and let the sync engine handle pagination/enrichment.
+ */
+function isCustomAction(tags: string[] | undefined): boolean {
+  return !!tags && tags.includes('custom');
 }
 
 /**
@@ -37,6 +47,7 @@ export async function discoverModels(api: OneApi, platform: string): Promise<Dis
     const actionType = parseActionType(action.key);
     if (!actionType) continue;
     if (!listActionTypes.has(actionType)) continue;
+    if (isCustomAction(action.tags)) continue;
 
     const modelName = action.modelName;
     if (!modelName) continue;
@@ -60,22 +71,34 @@ export async function discoverModels(api: OneApi, platform: string): Promise<Dis
   }
 
   // Resolve each discovered model's executable action ID in parallel.
+  // `searchActions` hits /available-actions/search which DOES return tags,
+  // so we can reject custom matches here (unlike the listAvailableActions
+  // result above, where tags aren't populated today).
   const models = Array.from(modelMap.values());
   await Promise.all(
     models.map(async model => {
       try {
         const searchResults = await api.searchActions(platform, model.displayName, 'execute');
         const resolved = searchResults.find(
-          a => a.path === model.listAction.path && a.method === model.listAction.method,
+          a =>
+            a.path === model.listAction.path &&
+            a.method === model.listAction.method &&
+            !isCustomAction(a.tags),
         );
         if (resolved?.systemId) {
           model.listAction.actionId = resolved.systemId;
         }
       } catch {
-        // Leave the api:: key if resolution fails — the user can still resolve manually
+        // Leave the api:: key if resolution fails — the filter below drops it.
       }
     }),
   );
 
-  return models.sort((a, b) => a.name.localeCompare(b.name));
+  // Drop any model that couldn't be resolved to an executable passthrough.
+  // Unresolved models either have no passthrough variant (the only match was
+  // custom and got filtered) or the search API failed. Either way, sync
+  // can't execute them — surfacing them in `sync init` only creates dead ends.
+  const syncable = models.filter(m => m.listAction.actionId.startsWith('conn_mod_def::'));
+
+  return syncable.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/lib/sync/runner.ts
+++ b/src/lib/sync/runner.ts
@@ -252,6 +252,19 @@ export async function syncModel(
 
     // Get preloaded action details for efficiency
     const actionDetails = await api.getActionDetails(profile.actionId);
+
+    // Hard block: sync never uses custom/composer actions. They run on a
+    // small shared fleet that collapses under sync-scale load and often
+    // expect filters in the body (see gmail get-threads). Passthrough +
+    // local enrichment scales instead.
+    if (actionDetails.tags?.includes('custom')) {
+      throw new Error(
+        `Sync does not support custom actions. Action ${profile.actionId} is tagged "custom". ` +
+        `Use a passthrough action — run 'one actions search ${platform} "${model}"' to find one, ` +
+        `or compose a flow that chains passthrough calls if the logic is complex.`
+      );
+    }
+
     const maxPages = options.maxPages ?? Infinity;
     let tableCreated = tableExists(db, model);
 


### PR DESCRIPTION
## Summary
- Sync rejects profiles referencing custom/composer actions (tag `custom`). Both the list action and any enrich action must be passthrough.
- `discoverModels` filters customs at resolution time and drops models with no passthrough variant — `sync models <platform>` only returns models that can actually be synced.
- `sync run` loads action knowledge, checks tags, and aborts with a pointer at `one actions search` and the flow alternative.

## Why
Custom actions run on a small shared fleet that collapses under sync-scale load and often expect filters in the request body — which sync doesn't send by design. The symptoms were empty results (withoneai/knowledge#65) and a feature request for body-param support (#116). Neither is the right fix; sync should never use custom actions in the first place. Custom actions are for one-off agent use — never sync, never flow.

Closes #116
Closes withoneai/knowledge#65

## Test plan
- [x] `npm run build` passes; no new tsc errors in changed files
- [x] `sync models gmail` returns 9 passthrough-only models (no `gmailThreads` custom)
- [x] `sync run` against a known custom actionId (`conn_mod_def::GGSNlnppgZ0::...`) aborts with: *"Sync does not support custom actions... run 'one actions search gmail "gmailThreads"' to find one, or compose a flow."*
- [x] Built-in profiles (`one --agent sync profiles`) still lists `gmail/gmailThreads`; built-in uses the passthrough `GJ3ok-Q0D40::...` (verified via `/knowledge` — tagged `hidden:agents`, not `custom`)
- [x] Version bumped to 1.39.0; package-lock refreshed

## Caveat
`sync models gmail` no longer surfaces `gmailThreads` (custom-only modelName); users see `threads` (passthrough) instead. The pre-tuned built-in `gmailThreads` profile remains reachable via `sync profiles` → `sync init gmail gmailThreads`. Two discovery paths, slight asymmetry — kept the built-in name to avoid breaking existing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)