### PR TITLE
fix: hard-block custom actions in sync test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.39.0",
+      "version": "1.39.1",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/lib/sync/test.ts
+++ b/src/lib/sync/test.ts
@@ -78,6 +78,21 @@ export async function testSyncProfile(api: OneApi, profile: SyncProfile): Promis
     return report;
   }
 
+  // Hard block: sync never uses custom/composer actions (see runner.ts).
+  // Catch it here too so `sync test` and `sync init` auto-validation fail
+  // fast with the same guidance, instead of letting the user reach `sync run`
+  // before discovering the profile is unsupported.
+  if (actionDetails.tags?.includes('custom')) {
+    checks.push({
+      name: 'action is passthrough (not custom)',
+      ok: false,
+      detail:
+        `Action ${profile.actionId} is tagged "custom". Sync only supports passthrough actions. ` +
+        `Run 'one actions search ${profile.platform} "${profile.model}"' to find one.`,
+    });
+    return report;
+  }
+
   // Check 2: single-page fetch succeeds
   let responseData: unknown;
   try {


### PR DESCRIPTION
## Summary
- Sync hard-blocks custom actions in `runner.ts` and `enrich.ts`, but `test.ts` (`sync test` + `sync init` auto-validation) was missing the same guard
- A profile pointing at a custom action would pass `sync test` and only fail later at `sync run` time
- Adds the same check at the top of `testSyncProfile` so the rejection fires consistently from every entry point — no docs change needed (the rule was already documented in #118)

Follow-up to #118.

## Test results — all green ✅

Verified against the dev binary using a real Gmail custom action (`POST /gmail/get-threads`, `conn_mod_def::GGSNlnppgZ0::...`, confirmed `custom`-tagged via the composer fleet).

- **`sync test` blocks custom action — PASS.** The new `action is passthrough (not custom)` check fails before any fetch attempt:
  ```
  "detail":"Action conn_mod_def::GGSNlnppgZ0::... is tagged \"custom\". Sync only supports
   passthrough actions. Run 'one actions search gmail \"gmailThreads\"' to find one."
  ```
- **`sync run` regression — PASS.** Existing runner.ts block intact: `"Sync does not support custom actions..."`
- **Passthrough regression — PASS.** `sync test gmail/labels` (passthrough action) returns `ok:true`, all 5 checks green, 84 records sampled. No false positive.

## Observation (separate from this PR)
The agent flagged that `sync init --config '<json>'` doesn't run auto-test today (only the no-config inference path does). Custom actions are still caught at `sync run` time, but a follow-up to also auto-test on the `--config` branch would close this gap. Tracking separately if useful — not blocking this fix.

## Test plan
- [x] `npm test` passes
- [x] `sync test` against custom action returns the new check failure (verified)
- [x] `sync run` against custom action still fails (regression verified)
- [x] `sync test` against passthrough action still succeeds (regression verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)