### PR TITLE
feat: late-bound connection refs in sync profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,9 +312,9 @@ one sync install && one sync doctor
 ```
 
 ```bash
-# Discover → init (one command: infer + auto-resolve key + auto-test) → run
+# Discover → init (one command: infer + late-bound connection + auto-test) → run
 one sync models stripe
-one sync init stripe balanceTransactions    # connectionKey auto-resolved, test auto-run
+one sync init stripe balanceTransactions    # connection: { platform } baked in, test auto-run
 one sync run stripe --since 90d
 
 # Query, search, SQL
@@ -331,6 +331,8 @@ one sync run stripe --full-refresh
 ```
 
 > **Sync uses passthrough actions only.** Profiles referencing a custom/composer action are rejected at runtime. `sync models` already filters to passthrough-only; if a model has no passthrough list endpoint, compose a flow instead of syncing.
+
+> **Connections are late-bound.** Profiles use `"connection": { "platform": "<name>", "tag"?: "..." }` instead of literal `connectionKey` strings. The key is resolved at sync time, so `one add <platform>` (re-auth) doesn't break the profile. `tag` only needed for multi-account platforms (e.g. two Gmail accounts).
 
 | Subcommand | What it does |
 |------------|-------------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.39.1",
+      "version": "1.40.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/profiles/attio/attioCompanies.json
+++ b/profiles/attio/attioCompanies.json
@@ -2,7 +2,7 @@
   "description": "Attio companies — CRM company records with domains, industry, and custom attributes",
   "platform": "attio",
   "model": "attioCompanies",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "attio" },
   "actionId": "conn_mod_def::GJt0lFZ6kpk::attio-companies-list",
   "resultsPath": "companies",
   "idField": "id",

--- a/profiles/attio/attioPeople.json
+++ b/profiles/attio/attioPeople.json
@@ -2,7 +2,7 @@
   "description": "Attio people — CRM contact records with emails, phone numbers, and custom attributes",
   "platform": "attio",
   "model": "attioPeople",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "attio" },
   "identityKey": "primary_email_address",
   "actionId": "conn_mod_def::GJt0lFZ6kpk::attio-people-list",
   "resultsPath": "people",

--- a/profiles/fathom/meetings.json
+++ b/profiles/fathom/meetings.json
@@ -2,7 +2,7 @@
   "description": "Fathom meetings — recorded meetings with transcripts, summaries, action items, and attendees",
   "platform": "fathom",
   "model": "meetings",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "fathom" },
   "actionId": "conn_mod_def::fathom::meetings-list",
   "resultsPath": "items",
   "idField": "recording_id",

--- a/profiles/gmail/gmailThreads.json
+++ b/profiles/gmail/gmailThreads.json
@@ -2,7 +2,7 @@
   "description": "Gmail email threads — primary inbox with full message bodies (no attachments)",
   "platform": "gmail",
   "model": "gmailThreads",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "gmail" },
   "actionId": "conn_mod_def::GJ3ok-Q0D40::oLWNlcx4QDORaL_18z-MsQ",
   "resultsPath": "threads",
   "idField": "id",

--- a/profiles/google-calendar/events.json
+++ b/profiles/google-calendar/events.json
@@ -2,7 +2,7 @@
   "description": "Google Calendar events — meetings, appointments, and all-day events with attendees and location",
   "platform": "google-calendar",
   "model": "events",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "google-calendar" },
   "actionId": "conn_mod_def::GJ5x5pOh2TU::gcal-events-list",
   "resultsPath": "items",
   "idField": "id",

--- a/profiles/hacker-news/topStories.json
+++ b/profiles/hacker-news/topStories.json
@@ -2,7 +2,7 @@
   "description": "Hacker News top story IDs — up to 500 item IDs at /v0/topstories.json (root-array response, primitives wrapped as { id })",
   "platform": "hacker-news",
   "model": "topStories",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "hacker-news" },
   "actionId": "conn_mod_def::GJ3108Dwmm4::avAMAq7HQtW6PT8JhPg5vA",
   "resultsPath": "",
   "idField": "id",

--- a/profiles/notion/search.json
+++ b/profiles/notion/search.json
@@ -2,7 +2,7 @@
   "description": "Notion pages and databases — full workspace search with titles, properties, and metadata",
   "platform": "notion",
   "model": "search",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "notion" },
   "actionId": "conn_mod_def::GJ5En67fz04::-CJAS419SVWm7L2l6brp6A",
   "resultsPath": "results",
   "idField": "id",

--- a/profiles/stripe/balanceTransactions.json
+++ b/profiles/stripe/balanceTransactions.json
@@ -2,7 +2,7 @@
   "description": "Stripe balance transactions — payments, refunds, payouts, and fees with amount, currency, and status",
   "platform": "stripe",
   "model": "balanceTransactions",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "stripe" },
   "actionId": "conn_mod_def::GGx6clhYjSQ::3kEaM3HQTA2JRfW3DzXC4g",
   "resultsPath": "data",
   "idField": "id",

--- a/profiles/stripe/customers.json
+++ b/profiles/stripe/customers.json
@@ -2,7 +2,7 @@
   "description": "Stripe customers — customer records with email, name, payment methods, and subscription status",
   "platform": "stripe",
   "model": "customers",
-  "connectionKey": "AUTO",
+  "connection": { "platform": "stripe" },
   "actionId": "conn_mod_def::GGx6clhYjSQ::customers-list",
   "resultsPath": "data",
   "idField": "id",

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -175,6 +175,8 @@ one sync schedule add stripe --every 1h
 
 **Sync rejects custom actions** — profiles must use passthrough. `sync init` only surfaces passthrough models; `sync run` aborts if the list or enrich action is tagged `custom`. If no passthrough exists, compose a flow instead.
 
+**Connections are late-bound** — profiles use `"connection": { "platform": "<name>" }`, not literal `connectionKey` strings. The key is resolved at sync time, so `one add <platform>` (re-auth) doesn't break the profile. For multi-account platforms, add `"tag": "<connection-tag>"` to disambiguate. Don't hardcode connection keys in profiles.
+
 **Advanced features** (enrich, transform, exclude, identityKey, hooks, --full-refresh, --where-sql delete, cursor resume): run `one guide sync` for the full reference.
 
 ## Beyond Single Actions

--- a/src/lib/api-resolve.test.ts
+++ b/src/lib/api-resolve.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { OneApi } from './api.js';
+import type { Connection } from './types.js';
+
+const conn = (key: string, platform: string, tags?: string[]): Connection => ({
+  id: key,
+  key,
+  platform,
+  state: 'operational',
+  tags,
+});
+
+describe('OneApi.resolveConnection', () => {
+  const api = new OneApi('test-key', 'http://unused');
+
+  it('resolves a single match by platform alone', async () => {
+    const cache = [conn('k1', 'gmail', ['work@example.com'])];
+    const result = await api.resolveConnection({ platform: 'gmail' }, cache);
+    assert.equal(result.key, 'k1');
+  });
+
+  it('resolves the right one when tag is supplied', async () => {
+    const cache = [
+      conn('k1', 'gmail', ['work@example.com']),
+      conn('k2', 'gmail', ['personal@example.com']),
+    ];
+    const result = await api.resolveConnection(
+      { platform: 'gmail', tag: 'personal@example.com' },
+      cache,
+    );
+    assert.equal(result.key, 'k2');
+  });
+
+  it('errors when no connection exists for the platform', async () => {
+    const cache = [conn('k1', 'gmail')];
+    await assert.rejects(
+      api.resolveConnection({ platform: 'slack' }, cache),
+      /No connection found for platform "slack"/,
+    );
+  });
+
+  it('errors when multiple connections match without a tag', async () => {
+    const cache = [
+      conn('k1', 'gmail', ['work@example.com']),
+      conn('k2', 'gmail', ['personal@example.com']),
+    ];
+    await assert.rejects(
+      api.resolveConnection({ platform: 'gmail' }, cache),
+      /Multiple "gmail" connections found .*Add a "tag" field/,
+    );
+  });
+
+  it('errors when the tag does not match any connection, listing available tags', async () => {
+    const cache = [
+      conn('k1', 'gmail', ['work@example.com']),
+      conn('k2', 'gmail', ['personal@example.com']),
+    ];
+    await assert.rejects(
+      api.resolveConnection({ platform: 'gmail', tag: 'missing@example.com' }, cache),
+      /No "gmail" connection has tag "missing@example\.com".*work@example\.com.*personal@example\.com/,
+    );
+  });
+
+  it('matches platform case-insensitively', async () => {
+    const cache = [conn('k1', 'Gmail')];
+    const result = await api.resolveConnection({ platform: 'gmail' }, cache);
+    assert.equal(result.key, 'k1');
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,7 @@ import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
 import type {
   Connection,
+  ConnectionRef,
   ConnectionsResponse,
   Platform,
   PlatformsResponse,
@@ -120,6 +121,55 @@ export class OneApi {
 
   async deleteConnection(id: string): Promise<void> {
     await this.requestFull({ path: `/vault/connections/${id}`, method: 'DELETE' });
+  }
+
+  /**
+   * Resolve a late-bound `ConnectionRef` to a current `Connection`. Pass
+   * `cache` (a pre-fetched connection list) when resolving many refs in a
+   * loop, so each resolve doesn't repeat the listConnections round-trip.
+   *
+   * Errors are deliberately verbose: a sync profile or flow that fails to
+   * resolve a connection should surface *why* (no match / wrong tag /
+   * ambiguous) so the agent can fix the ref without trial and error.
+   */
+  async resolveConnection(
+    ref: ConnectionRef,
+    cache?: Connection[]
+  ): Promise<Connection> {
+    const all = cache ?? await this.listConnections();
+    const platformLower = ref.platform.toLowerCase();
+    const candidates = all.filter(c => c.platform.toLowerCase() === platformLower);
+
+    if (candidates.length === 0) {
+      throw new Error(
+        `No connection found for platform "${ref.platform}". ` +
+        `Run 'one add ${ref.platform}' to connect.`
+      );
+    }
+
+    let matches = candidates;
+    if (ref.tag) {
+      matches = candidates.filter(c => c.tags?.includes(ref.tag!));
+      if (matches.length === 0) {
+        const availableTags = candidates.flatMap(c => c.tags ?? []);
+        throw new Error(
+          `No "${ref.platform}" connection has tag "${ref.tag}". ` +
+          `Available tags: ${availableTags.length > 0 ? availableTags.join(', ') : '(none)'}.`
+        );
+      }
+    }
+
+    if (matches.length > 1) {
+      const tagList = matches
+        .map(c => (c.tags?.length ? c.tags.join(',') : '(no tag)'))
+        .join('; ');
+      throw new Error(
+        `Multiple "${ref.platform}" connections found (tags: ${tagList}). ` +
+        `Add a "tag" field to the connection ref to disambiguate.`
+      );
+    }
+
+    return matches[0];
   }
 
   async listPlatforms(): Promise<Platform[]> {

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -463,12 +463,12 @@ one --agent sync models stripe
 # 2. Init — one command does everything:
 #    - resolves action ID
 #    - infers pagination, resultsPath, idField, pathVars from knowledge
-#    - auto-resolves connectionKey (when only one connection exists)
+#    - sets connection: { platform } so the profile survives re-auth
 #    - auto-runs sync test if profile is complete
 one --agent sync init stripe balanceTransactions
 # Response includes _complete:true and _test results when fully resolved.
-# If connectionKey wasn't auto-resolved (multiple connections), patch it:
-one --agent sync init stripe balanceTransactions --config '{"connectionKey":"<from one list>"}'
+# Multi-account platforms (e.g. two Gmail connections) need a tag:
+one --agent sync init gmail gmailThreads --config '{"connection":{"platform":"gmail","tag":"work@example.com"}}'
 
 # 3. Sync
 one --agent sync run stripe
@@ -479,10 +479,29 @@ one --agent sync search "refund" --platform stripe
 one --agent sync sql stripe "SELECT count(*) FROM balanceTransactions"
 \`\`\`
 
+## Connection Resolution — late-bound by default
+
+Sync profiles use a late-bound connection ref instead of a hardcoded key, so re-auth (which always mints a new key) doesn't break the profile:
+
+\`\`\`json
+// recommended — survives re-auth
+"connection": { "platform": "gmail" }
+
+// multi-account: disambiguate with the connection's tag
+"connection": { "platform": "gmail", "tag": "work@example.com" }
+
+// legacy — still works for backwards compat, but breaks on re-auth
+"connectionKey": "live::gmail::default::abc123..."
+\`\`\`
+
+The resolver runs at \`sync test\` and \`sync run\` time. Resolution errors (no connection, ambiguous tag, missing tag with multiple connections) surface as the first check in the test report, before any HTTP call.
+
+To migrate an existing profile: replace the \`connectionKey\` field with \`connection: { platform: "<platform>" }\`. Tags only needed when more than one connection exists for the platform.
+
 ## Auto-Inference
 
 \`sync init\` without \`--config\` does all of this automatically:
-- **connectionKey** — auto-resolved when there's exactly one connection for the platform
+- **connection** — defaults to \`{ platform: "<platform>" }\` (late-bound). When multiple connections exist, init surfaces the available tags so the agent can add one to the ref.
 - **Pagination** — Stripe id-pagination, Notion body-cursor, HubSpot/Google token, offset, link. Inapplicable fields stripped (no nextPath for offset, no passAs for none)
 - **resultsPath** — generic keys (data, results, items) + platform-specific (model name stripped of platform prefix: attioCompanies → companies). Use \`""\`, \`"$"\`, or \`"."\` for responses that return a bare array at the root (e.g. Hacker News \`/v0/topstories.json\`); primitive array elements are auto-wrapped as \`{ [idField]: value }\`.
 - **idField** — id, _id, uuid

--- a/src/lib/sync/index.ts
+++ b/src/lib/sync/index.ts
@@ -267,22 +267,29 @@ async function syncInitCommand(platform: string, model: string, options: { confi
         }
       }
 
-      // Auto-resolve connectionKey when there's exactly one connection for this platform
+      // Set up the connection ref. The template already defaults to
+      // `connection: { platform }` (late-bound, survives re-auth). When
+      // multiple connections exist, surface the tags so the agent knows
+      // to add a `tag` field — but don't pick one for them, since the
+      // tags express user intent (e.g. multi-account Gmail).
       try {
         const connections = await api.listConnections();
         const platformConns = connections.filter(
-          (c: { platform: string; key: string }) => c.platform === platform
+          (c: { platform: string; tags?: string[] }) => c.platform === platform
         );
         if (platformConns.length === 1) {
-          template.connectionKey = platformConns[0].key;
-          inferred?.reasoning.push(`connectionKey: auto-resolved (only one ${platform} connection)`);
+          inferred?.reasoning.push(`connection: { platform: "${platform}" } resolves to the single available connection`);
         } else if (platformConns.length > 1) {
+          const tags = platformConns
+            .map(c => c.tags?.join(',') ?? '(no tag)')
+            .join('; ');
           inferred?.reasoning.push(
-            `connectionKey: ${platformConns.length} connections found — pick one from \`one list\``
+            `connection: ${platformConns.length} ${platform} connections found (tags: ${tags}). ` +
+            `Add a \`tag\` field to the connection ref to disambiguate.`
           );
         }
       } catch {
-        // Best-effort — leave as FILL_IN
+        // Best-effort — leave the default `connection: { platform }`
       }
 
       // Persist as a draft
@@ -376,6 +383,16 @@ async function syncInitCommand(platform: string, model: string, options: { confi
       ...(patch.pagination ?? {}),
     },
   };
+
+  // Connection form is mutually exclusive: if the patch supplies one form,
+  // clear the other from the merged result. Otherwise a `connection` patch
+  // applied to a profile with a literal `connectionKey` would leave both set
+  // and writeProfile would reject the merged profile.
+  if (patch.connection && !patch.connectionKey) {
+    delete profile.connectionKey;
+  } else if (patch.connectionKey && !patch.connection) {
+    delete profile.connection;
+  }
 
   try {
     writeProfile(profile);

--- a/src/lib/sync/profile.test.ts
+++ b/src/lib/sync/profile.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { writeProfile } from './profile.js';
+import type { SyncProfile } from './types.js';
+
+let tmpDir: string;
+let cwd: string;
+
+before(() => {
+  cwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-sync-profile-test-'));
+  process.chdir(tmpDir);
+});
+
+after(() => {
+  process.chdir(cwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const baseProfile: SyncProfile = {
+  platform: 'gmail',
+  model: 'threads',
+  actionId: 'conn_mod_def::abc',
+  resultsPath: 'threads',
+  idField: 'id',
+  pagination: { type: 'none' },
+};
+
+describe('writeProfile connection validation', () => {
+  it('accepts a profile with `connection` ref alone', () => {
+    const profile: SyncProfile = {
+      ...baseProfile,
+      model: 'threads-conn',
+      connection: { platform: 'gmail' },
+    };
+    assert.doesNotThrow(() => writeProfile(profile));
+  });
+
+  it('accepts a profile with legacy `connectionKey` alone', () => {
+    const profile: SyncProfile = {
+      ...baseProfile,
+      model: 'threads-key',
+      connectionKey: 'live::gmail::default::abc',
+    };
+    assert.doesNotThrow(() => writeProfile(profile));
+  });
+
+  it('rejects a profile with both `connectionKey` and `connection`', () => {
+    const profile: SyncProfile = {
+      ...baseProfile,
+      model: 'threads-both',
+      connectionKey: 'live::gmail::default::abc',
+      connection: { platform: 'gmail' },
+    };
+    assert.throws(() => writeProfile(profile), /both `connectionKey` and `connection`/);
+  });
+
+  it('rejects a profile with neither `connectionKey` nor `connection`', () => {
+    const profile: SyncProfile = {
+      ...baseProfile,
+      model: 'threads-neither',
+    };
+    assert.throws(() => writeProfile(profile), /Missing connection/);
+  });
+
+  it('accepts a `connection` ref with a tag', () => {
+    const profile: SyncProfile = {
+      ...baseProfile,
+      model: 'threads-tag',
+      connection: { platform: 'gmail', tag: 'work@example.com' },
+    };
+    assert.doesNotThrow(() => writeProfile(profile));
+  });
+});

--- a/src/lib/sync/profile.ts
+++ b/src/lib/sync/profile.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import type { Connection } from '../types.js';
+import type { OneApi } from '../api.js';
 import type { SyncProfile } from './types.js';
 
 const PROFILES_DIR = path.join('.one', 'sync', 'profiles');
@@ -20,11 +22,29 @@ export function readProfile(platform: string, model: string): SyncProfile | null
 }
 
 export function writeProfile(profile: SyncProfile): void {
-  const required: (keyof SyncProfile)[] = ['platform', 'model', 'connectionKey', 'actionId', 'idField', 'pagination'];
+  const required: (keyof SyncProfile)[] = ['platform', 'model', 'actionId', 'idField', 'pagination'];
   for (const field of required) {
     if (!profile[field]) {
       throw new Error(`Missing required field: ${field}`);
     }
+  }
+  // Either `connectionKey` (legacy literal) or `connection` (late-bound ref)
+  // must be set — never both, never neither. The two forms are mutually
+  // exclusive at write time so a profile has one source of truth for which
+  // connection it targets.
+  const hasKey = !!profile.connectionKey;
+  const hasRef = !!profile.connection?.platform;
+  if (hasKey && hasRef) {
+    throw new Error(
+      'Profile has both `connectionKey` and `connection` — set exactly one. ' +
+      'Prefer `connection: { platform, tag? }` so re-auth doesn\'t break the profile.'
+    );
+  }
+  if (!hasKey && !hasRef) {
+    throw new Error(
+      'Missing connection: set `connection: { platform: "<name>" }` ' +
+      '(or legacy `connectionKey: "<key>"`).'
+    );
   }
   // resultsPath is required but empty string / "$" / "." all mean "root array",
   // so we only reject `undefined` (not explicitly set by the caller).
@@ -38,6 +58,30 @@ export function writeProfile(profile: SyncProfile): void {
   fs.mkdirSync(PROFILES_DIR, { recursive: true });
   const filePath = profilePath(profile.platform, profile.model);
   fs.writeFileSync(filePath, JSON.stringify(profile, null, 2));
+}
+
+/**
+ * Resolve a profile's connection to a literal key. Returns the existing
+ * `connectionKey` if set, otherwise resolves the `connection` ref via the
+ * API. Pass `cache` (a pre-fetched connection list) when resolving many
+ * profiles in a row to avoid duplicate listConnections calls.
+ *
+ * Throws with a descriptive message if neither field is set or the ref
+ * doesn't resolve to a single connection.
+ */
+export async function resolveProfileConnectionKey(
+  api: OneApi,
+  profile: SyncProfile,
+  cache?: Connection[]
+): Promise<string> {
+  if (profile.connectionKey) return profile.connectionKey;
+  if (!profile.connection?.platform) {
+    throw new Error(
+      `Profile ${profile.platform}/${profile.model} has no connectionKey or connection ref.`
+    );
+  }
+  const conn = await api.resolveConnection(profile.connection, cache);
+  return conn.key;
 }
 
 /**
@@ -82,7 +126,9 @@ export function generateTemplate(platform: string, model: string, actionId?: str
   return {
     platform,
     model,
-    connectionKey: 'FILL_IN',
+    // Late-bound ref — survives re-auth. Use { platform, tag } when the
+    // platform has multiple connections (e.g. multiple Gmail accounts).
+    connection: { platform },
     actionId: actionId ?? 'FILL_IN',
     resultsPath: 'FILL_IN',
     idField: 'FILL_IN',

--- a/src/lib/sync/runner.ts
+++ b/src/lib/sync/runner.ts
@@ -11,6 +11,7 @@ import { classifyRecords, fireHooks, type ChangeEvent } from './hooks.js';
 import { enrichPhase, type EnrichResult } from './enrich.js';
 import { transformRecords } from './transform.js';
 import { extractRecords } from './extract.js';
+import { resolveProfileConnectionKey } from './profile.js';
 import type Database from 'better-sqlite3';
 
 const MAX_RETRIES_PER_PAGE = 3;
@@ -127,6 +128,12 @@ export async function syncModel(
       '--full-refresh and --since cannot be used together. --full-refresh always fetches the whole collection.'
     );
   }
+
+  // Resolve the connection key once up front. Profiles using the new
+  // `connection: { platform, tag? }` form get a fresh lookup; profiles using
+  // legacy `connectionKey` pass through unchanged. Done before the lock so a
+  // missing/ambiguous connection fails fast without leaving stale state.
+  const connectionKey = await resolveProfileConnectionKey(api, profile);
 
   // Acquire a cross-process lock so two concurrent syncs (e.g. cron tick +
   // manual run) don't race on the same table. Dry-run skips the lock since
@@ -311,7 +318,7 @@ export async function syncModel(
           const result = await api.executePassthroughRequest({
             platform,
             actionId: profile.actionId,
-            connectionKey: profile.connectionKey,
+            connectionKey,
             pathVariables: profile.pathVars,
             queryParams: currentPageQueryParams,
             headers: currentPageHeaders,
@@ -575,7 +582,7 @@ export async function syncModel(
     if (profile.enrich && tableCreated && !options.dryRun) {
       enrichResult = await enrichPhase(
         api, db, profile.enrich, model, profile.idField,
-        profile.connectionKey, platform,
+        connectionKey, platform,
         {
           transform: profile.transform,
           exclude: profile.exclude,

--- a/src/lib/sync/test.ts
+++ b/src/lib/sync/test.ts
@@ -5,6 +5,7 @@ import { getByDotPath } from '../dot-path.js';
 import { getNextPageParams } from './pagination.js';
 import type { SyncProfile } from './types.js';
 import { extractRecords, isRootPath } from './extract.js';
+import { resolveProfileConnectionKey } from './profile.js';
 
 export interface SyncTestCheck {
   name: string;
@@ -64,6 +65,22 @@ export async function testSyncProfile(api: OneApi, profile: SyncProfile): Promis
     else queryParams[limitParam] = pageSize;
   }
 
+  // Check 0: the connection ref resolves to a current connection key.
+  // Done before the action check so a missing/ambiguous connection surfaces
+  // as a clear ref problem rather than a downstream HTTP error.
+  let connectionKey: string;
+  try {
+    connectionKey = await resolveProfileConnectionKey(api, profile);
+    checks.push({ name: 'connection resolves', ok: true });
+  } catch (err) {
+    checks.push({
+      name: 'connection resolves',
+      ok: false,
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return report;
+  }
+
   // Check 1: the action resolves
   let actionDetails: ActionDetails | undefined;
   try {
@@ -99,7 +116,7 @@ export async function testSyncProfile(api: OneApi, profile: SyncProfile): Promis
     const result = await api.executePassthroughRequest({
       platform: profile.platform,
       actionId: profile.actionId,
-      connectionKey: profile.connectionKey,
+      connectionKey,
       pathVariables: profile.pathVars,
       queryParams,
       data: Object.keys(bodyParams).length > 0 ? bodyParams : undefined,

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -19,10 +19,28 @@ export interface DateFilterConfig {
   format: 'iso8601' | 'unix' | 'date';
 }
 
+import type { ConnectionRef } from '../types.js';
+
 export interface SyncProfile {
   platform: string;
   model: string;
-  connectionKey: string;
+  /**
+   * Literal connection key (e.g. "live::gmail::default::abc..."). Legacy form.
+   * Prefer `connection: { platform, tag? }` so re-auth doesn't break the
+   * profile — re-auth always mints a new key, and the literal form requires
+   * a manual edit every time.
+   *
+   * Exactly one of `connectionKey` or `connection` must be set.
+   */
+  connectionKey?: string;
+  /**
+   * Late-bound connection reference, resolved at sync run/test/init time.
+   * Survives re-auth: `one add gmail` mints a new key, and the next sync
+   * picks it up automatically.
+   *
+   * Exactly one of `connectionKey` or `connection` must be set.
+   */
+  connection?: ConnectionRef;
   actionId: string;
   /**
    * Dot-path to the array of records in the API response. Use `""`, `"$"`,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,21 @@ export interface Connection {
   createdAt?: string;
 }
 
+/**
+ * Late-bound connection reference. Resolved at execution time so re-auth
+ * (which mints a new connection key) doesn't break stored configs. Used in
+ * sync profiles and flow steps as the recommended alternative to literal
+ * `connectionKey` strings.
+ *
+ * `tag` disambiguates when a platform has multiple connections (e.g. two
+ * Gmail accounts tagged with their email addresses). Omit `tag` when there's
+ * only one connection for the platform — resolution will error if ambiguous.
+ */
+export interface ConnectionRef {
+  platform: string;
+  tag?: string;
+}
+
 export interface Platform {
   id: number;
   name: string;


### PR DESCRIPTION
Closes #114. Partial fix for #113 (closed) — addresses the underlying \"stale key after re-auth\" problem.

## Summary

Sync profiles now accept a late-bound connection ref instead of a literal connection key:

\`\`\`json
"connection": { "platform": "gmail" }                          // single account
"connection": { "platform": "gmail", "tag": "work@example.com" } // multi-account
\`\`\`

Resolution runs at sync test/run time via a shared \`OneApi.resolveConnection\` method. After \`one add gmail\` (re-auth), the next sync picks up the fresh key automatically — no manual edits across profiles.

The legacy \`\"connectionKey\": \"<literal>\"\` form still works (backwards compat), but \`writeProfile\` now requires exactly one of the two forms. Built-in profiles migrated from \`\"connectionKey\": \"AUTO\"\` to the new \`connection\` form.

## Why this matters

Issue #114 reported that re-auth silently breaks sync profiles because they hardcode the connection key. The user had 7 sync profiles + 95+ flows + 20+ Python scripts that all needed manual updates after each Gmail re-auth. The late-bound ref is the structural fix: the profile names *what* it wants (a Gmail connection, optionally with a specific account tag), not *which exact key*.

Same pattern will land for flows in a follow-up PR.

## Resolver semantics

| Scenario | Result |
|---|---|
| Single connection for the platform | resolves silently |
| Multiple connections, no tag | error: \`Multiple \"gmail\" connections found (tags: ...). Add a \"tag\" field to the connection ref to disambiguate.\` |
| Tag matches exactly one | resolves silently |
| Tag matches none | error: \`No \"gmail\" connection has tag \"X\". Available tags: ...\` |
| No connection for platform | error: \`No connection found for platform \"X\". Run 'one add X' to connect.\` |

Resolution is the first check in \`sync test\`, before \`action resolves\` — so a misconfigured ref is diagnosed cleanly rather than as a downstream auth error.

## Test results — all green ✅

Verified end-to-end against real connections via subagent:

- **Single-connection (google-calendar):** profile ships with \`connection: { platform }\`, resolver finds the one connection, full sync test passes.
- **Multi-connection without tag (gmail):** \`_test.ok:false\`, fails on the new \`connection resolves\` check with the disambiguation message. Action check correctly short-circuits.
- **Multi-connection with tag (gmail, tag: moe@picaos.com):** resolves to the right account, full fetch + pagination succeed.
- **Backwards compat (legacy \`connectionKey\`):** still works, full Notion sync succeeds.
- **Bad platform name:** clear error with remediation hint (\`Run 'one add doesnotexist'\`).
- **Both forms set at write time:** \`writeProfile\` rejects with explicit guidance.

24 unit tests pass (13 existing + 6 resolver + 5 profile validation).

## Files changed

- \`src/lib/types.ts\` — new \`ConnectionRef\` interface
- \`src/lib/api.ts\` — \`OneApi.resolveConnection({ platform, tag? }, cache?)\`
- \`src/lib/sync/types.ts\` — \`SyncProfile.connection\` (new) + \`connectionKey\` (now optional)
- \`src/lib/sync/profile.ts\` — \`resolveProfileConnectionKey\` helper, mutual-exclusion validation in \`writeProfile\`, template defaults to \`connection: { platform }\`
- \`src/lib/sync/runner.ts\`, \`src/lib/sync/test.ts\` — resolve once up front, pass through to passthrough calls
- \`src/lib/sync/index.ts\` — \`sync init\` surfaces available tags for multi-connection platforms; mutual-exclusion handled in \`--config\` patch
- \`profiles/**/*.json\` — 9 built-in profiles migrated from \`\"connectionKey\": \"AUTO\"\` to \`\"connection\": { \"platform\": \"...\" }\`
- README.md, SKILL.md, guide-content.ts — document the pattern as the recommended way; tag guidance for multi-account
- Tests: \`src/lib/api-resolve.test.ts\`, \`src/lib/sync/profile.test.ts\`

## Test plan
- [x] \`npm test\` passes (24/24)
- [x] \`npm run typecheck\` clean (no new errors; pre-existing unrelated errors unchanged)
- [x] \`sync test\` against single-connection platform passes
- [x] \`sync test\` against multi-connection platform without tag fails with disambiguation message
- [x] \`sync test\` against multi-connection platform with tag succeeds
- [x] Legacy \`connectionKey\` profiles still work
- [x] \`writeProfile\` rejects both-forms-set profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)