### PR TITLE
feat: late-bound connection refs in flow action steps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -282,11 +282,18 @@ The `if`, `unless`, `condition.expression`, `while.condition`, `transform.expres
   "action": {
     "platform": "stripe",
     "actionId": "conn_mod_def::xxx::yyy",
-    "connectionKey": "$.input.stripeConnectionKey",
+    "connection": { "platform": "stripe" },
     "data": { "query": "email:'{{$.input.customerEmail}}'" }
   }
 }
 ```
+
+**Connection forms.** Each action step sets exactly one of:
+
+- **`connection: { platform: "<name>", "tag"?: "<tag>" }`** (preferred) — late-bound, resolved at flow-execute time. Survives re-auth (which always mints a new key). Use `tag` to disambiguate when a platform has multiple connections (e.g. multi-account Gmail). Both `platform` and `tag` accept `$.input.x` selectors so flows can be parameterised per-execution.
+- **`connectionKey: "<literal-or-selector>"`** (legacy) — passes the key string straight through. Still supported for backwards compat, but breaks on re-auth and forces manual edits across every flow that references the stale key. Migrate to `connection` when convenient.
+
+The validator rejects an action that sets both forms (or neither) at `flow validate` and `flow execute` time.
 
 ### `transform` — JS expression (implicit return)
 

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -539,14 +539,7 @@ const SCAFFOLD_TEMPLATES: Record<string, () => Record<string, unknown>> = {
     name: 'My Workflow',
     description: 'A basic workflow with a single action step',
     version: '1',
-    inputs: {
-      connectionKey: {
-        type: 'string',
-        required: true,
-        description: 'Connection key for the platform',
-        connection: { platform: 'PLATFORM_NAME' },
-      },
-    },
+    inputs: {},
     steps: [
       {
         id: 'step1',
@@ -555,7 +548,7 @@ const SCAFFOLD_TEMPLATES: Record<string, () => Record<string, unknown>> = {
         action: {
           platform: 'PLATFORM_NAME',
           actionId: 'ACTION_ID_FROM_SEARCH',
-          connectionKey: '$.input.connectionKey',
+          connection: { platform: 'PLATFORM_NAME' },
           data: {},
         },
       },
@@ -566,14 +559,7 @@ const SCAFFOLD_TEMPLATES: Record<string, () => Record<string, unknown>> = {
     name: 'Conditional Workflow',
     description: 'Fetch data, then branch based on results',
     version: '1',
-    inputs: {
-      connectionKey: {
-        type: 'string',
-        required: true,
-        description: 'Connection key',
-        connection: { platform: 'PLATFORM_NAME' },
-      },
-    },
+    inputs: {},
     steps: [
       {
         id: 'fetch',
@@ -582,7 +568,7 @@ const SCAFFOLD_TEMPLATES: Record<string, () => Record<string, unknown>> = {
         action: {
           platform: 'PLATFORM_NAME',
           actionId: 'ACTION_ID_FROM_SEARCH',
-          connectionKey: '$.input.connectionKey',
+          connection: { platform: 'PLATFORM_NAME' },
         },
       },
       {
@@ -616,14 +602,7 @@ const SCAFFOLD_TEMPLATES: Record<string, () => Record<string, unknown>> = {
     name: 'Loop Workflow',
     description: 'Fetch a list, then process each item',
     version: '1',
-    inputs: {
-      connectionKey: {
-        type: 'string',
-        required: true,
-        description: 'Connection key',
-        connection: { platform: 'PLATFORM_NAME' },
-      },
-    },
+    inputs: {},
     steps: [
       {
         id: 'fetchList',
@@ -632,7 +611,7 @@ const SCAFFOLD_TEMPLATES: Record<string, () => Record<string, unknown>> = {
         action: {
           platform: 'PLATFORM_NAME',
           actionId: 'ACTION_ID_FROM_SEARCH',
-          connectionKey: '$.input.connectionKey',
+          connection: { platform: 'PLATFORM_NAME' },
         },
       },
       {
@@ -665,14 +644,7 @@ const SCAFFOLD_TEMPLATES: Record<string, () => Record<string, unknown>> = {
     name: 'AI Analysis Workflow',
     description: 'Fetch data, analyze with Claude, and send results',
     version: '1',
-    inputs: {
-      connectionKey: {
-        type: 'string',
-        required: true,
-        description: 'Connection key for data source',
-        connection: { platform: 'PLATFORM_NAME' },
-      },
-    },
+    inputs: {},
     steps: [
       {
         id: 'fetchData',
@@ -681,7 +653,7 @@ const SCAFFOLD_TEMPLATES: Record<string, () => Record<string, unknown>> = {
         action: {
           platform: 'PLATFORM_NAME',
           actionId: 'ACTION_ID_FROM_SEARCH',
-          connectionKey: '$.input.connectionKey',
+          connection: { platform: 'PLATFORM_NAME' },
         },
       },
       {

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -319,7 +319,40 @@ async function executeActionStep(
   const action = step.action!;
   const platform = resolveValue(action.platform, context) as string;
   const actionId = resolveValue(action.actionId, context) as string;
-  const connectionKey = resolveValue(action.connectionKey, context) as string;
+
+  // Resolve the connection key from either the legacy literal form or the
+  // late-bound { platform, tag? } ref. Mutual exclusion is enforced by the
+  // validator at flow-create/validate time, but re-checked here in case a
+  // hand-edited or programmatically-built step bypasses validation.
+  const hasKey = action.connectionKey !== undefined && action.connectionKey !== null && action.connectionKey !== '';
+  const hasRef = !!action.connection?.platform;
+  if (hasKey && hasRef) {
+    throw new Error(
+      `Action step "${step.id}" has both "connectionKey" and "connection" — set exactly one. ` +
+      `Prefer "connection: { platform, tag? }" so re-auth doesn't break the flow.`
+    );
+  }
+  if (!hasKey && !hasRef) {
+    throw new Error(
+      `Action step "${step.id}" must set "connection: { platform: <name> }" ` +
+      `(or legacy "connectionKey: <key>").`
+    );
+  }
+  let connectionKey: string;
+  if (hasKey) {
+    connectionKey = resolveValue(action.connectionKey, context) as string;
+  } else {
+    // Resolve selectors inside the ref first (e.g. tag: "$.input.userEmail"),
+    // then look up the matching connection. Cache the connection list on the
+    // context so a many-step flow does ONE listConnections per run.
+    const ref = resolveValue(action.connection, context) as { platform: string; tag?: string };
+    if (!context._connections) {
+      context._connections = await api.listConnections();
+    }
+    const conn = await api.resolveConnection(ref, context._connections);
+    connectionKey = conn.key;
+  }
+
   const data = action.data ? resolveValue(action.data, context) as Record<string, unknown> : undefined;
   const pathVars = action.pathVars ? resolveValue(action.pathVars, context) as Record<string, string | number | boolean> : undefined;
   const queryParams = action.queryParams ? resolveValue(action.queryParams, context) as Record<string, any> : undefined;

--- a/src/lib/flow-schema.ts
+++ b/src/lib/flow-schema.ts
@@ -82,7 +82,8 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
       fields: {
         platform:      { type: 'string', required: true, description: 'Platform name (kebab-case)' },
         actionId:      { type: 'string', required: true, description: 'Action ID from `actions search`' },
-        connectionKey: { type: 'string', required: true, description: 'Connection key (use $.input selector)' },
+        connection:    { type: 'object', required: false, description: 'Late-bound connection ref { platform, tag? } — survives re-auth. Exactly one of `connection` or `connectionKey` must be set.' },
+        connectionKey: { type: 'string', required: false, description: 'Literal connection key (or $.input selector). Legacy form — prefer `connection: { platform, tag? }`. Exactly one of `connection` or `connectionKey` must be set.' },
         data:          { type: 'object', required: false, description: 'Request body (POST/PUT/PATCH)' },
         pathVars:      { type: 'object', required: false, description: 'URL path variables' },
         queryParams:   { type: 'object', required: false, description: 'Query parameters' },
@@ -93,7 +94,7 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
         action: {
           platform: 'stripe',
           actionId: 'conn_mod_def::xxx::yyy',
-          connectionKey: '$.input.stripeConnectionKey',
+          connection: { platform: 'stripe' },
           data: { query: "email:'{{$.input.customerEmail}}'" },
         },
       },
@@ -136,7 +137,7 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
         id: 'checkFound', name: 'Check if customer exists', type: 'condition',
         condition: {
           expression: '$.steps.search.response.data.length > 0',
-          then: [{ id: 'notify', name: 'Send notification', type: 'action', action: { platform: 'slack', actionId: '...', connectionKey: '$.input.slackKey', data: { text: 'Found!' } } }],
+          then: [{ id: 'notify', name: 'Send notification', type: 'action', action: { platform: 'slack', actionId: '...', connection: { platform: 'slack' }, data: { text: 'Found!' } } }],
           else: [{ id: 'logMiss', name: 'Log not found', type: 'transform', transform: { expression: "'Not found'" } }],
         },
       },
@@ -157,7 +158,7 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
         id: 'processOrders', name: 'Process each order', type: 'loop',
         loop: {
           over: '$.steps.listOrders.response.data', as: 'order',
-          steps: [{ id: 'createInvoice', name: 'Create invoice', type: 'action', action: { platform: 'stripe', actionId: '...', connectionKey: '$.input.stripeKey', data: { amount: '$.loop.order.total' } } }],
+          steps: [{ id: 'createInvoice', name: 'Create invoice', type: 'action', action: { platform: 'stripe', actionId: '...', connection: { platform: 'stripe' }, data: { amount: '$.loop.order.total' } } }],
         },
       },
     },
@@ -173,8 +174,8 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
         id: 'lookups', name: 'Parallel data lookups', type: 'parallel',
         parallel: {
           steps: [
-            { id: 'getStripe', name: 'Get Stripe data', type: 'action', action: { platform: 'stripe', actionId: '...', connectionKey: '$.input.stripeKey' } },
-            { id: 'getSlack', name: 'Get Slack data', type: 'action', action: { platform: 'slack', actionId: '...', connectionKey: '$.input.slackKey' } },
+            { id: 'getStripe', name: 'Get Stripe data', type: 'action', action: { platform: 'stripe', actionId: '...', connection: { platform: 'stripe' } } },
+            { id: 'getSlack', name: 'Get Slack data', type: 'action', action: { platform: 'slack', actionId: '...', connection: { platform: 'slack' } } },
           ],
         },
       },
@@ -220,7 +221,7 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
         while: {
           condition: '$.steps.paginate.output.lastResult.nextPageToken != null',
           maxIterations: 50,
-          steps: [{ id: 'fetchPage', name: 'Fetch next page', type: 'action', action: { platform: 'gmail', actionId: '...', connectionKey: '$.input.gmailKey' } }],
+          steps: [{ id: 'fetchPage', name: 'Fetch next page', type: 'action', action: { platform: 'gmail', actionId: '...', connection: { platform: 'gmail' } } }],
         },
       },
     },
@@ -242,7 +243,7 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
       configKey: 'paginate',
       description: 'Auto-paginate API results into a single array',
       fields: {
-        action:          { type: 'object', required: true, description: 'Action config (same shape as action step: platform, actionId, connectionKey)' },
+        action:          { type: 'object', required: true, description: 'Action config (same shape as action step: platform, actionId, plus exactly one of `connection` or `connectionKey`)' },
         pageTokenField:  { type: 'string', required: true, description: 'Dot-path in response to next page token' },
         resultsField:    { type: 'string', required: true, description: 'Dot-path in response to results array' },
         inputTokenParam: { type: 'string', required: true, description: 'Dot-path in action config where page token is injected' },
@@ -251,7 +252,7 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
       example: {
         id: 'allMessages', name: 'Fetch all Gmail messages', type: 'paginate',
         paginate: {
-          action: { platform: 'gmail', actionId: '...', connectionKey: '$.input.gmailKey', queryParams: { maxResults: 100 } },
+          action: { platform: 'gmail', actionId: '...', connection: { platform: 'gmail' }, queryParams: { maxResults: 100 } },
           pageTokenField: 'nextPageToken', resultsField: 'messages', inputTokenParam: 'queryParams.pageToken', maxPages: 10,
         },
       },
@@ -461,12 +462,6 @@ The only differences: (1) prepend the stdin-read line, (2) replace \`return X\` 
   "description": "What this flow does",
   "version": "1",
   "inputs": {
-    "connectionKey": {
-      "type": "string",
-      "required": true,
-      "description": "Platform connection key",
-      "connection": { "platform": "stripe" }
-    },
     "param": {
       "type": "string",
       "required": true,
@@ -481,7 +476,7 @@ The only differences: (1) prepend the stdin-read line, (2) replace \`return X\` 
       "action": {
         "platform": "stripe",
         "actionId": "conn_mod_def::xxx::yyy",
-        "connectionKey": "$.input.connectionKey",
+        "connection": { "platform": "stripe" },
         "data": { "query": "{{$.input.param}}" }
       }
     }
@@ -587,13 +582,13 @@ Pipes can be applied to any value (objects/arrays are JSON-stringified first for
 
 ### When to use bare selectors vs \`{{...}}\` interpolation
 
-- **Bare selectors** (\`$.input.x\`): Use for fields the engine resolves directly — \`connectionKey\`, \`over\`, \`path\`, \`expression\`, \`condition\`, and any field where the entire value is a single selector. The resolved value keeps its original type (object, array, number).
+- **Bare selectors** (\`$.input.x\`): Use for fields the engine resolves directly — \`connectionKey\`, the \`tag\` (or \`platform\`) inside \`connection\`, \`over\`, \`path\`, \`expression\`, \`condition\`, and any field where the entire value is a single selector. The resolved value keeps its original type (object, array, number).
 - **Interpolation** (\`{{$.input.x}}\`): Use inside string values where the selector is embedded in text — e.g., \`"Hello {{$.steps.getUser.response.name}}"\`. The resolved value is always stringified. Use this in \`data\`, \`pathVars\`, and \`queryParams\` when mixing selectors with literal text.
 - **Rule of thumb**: If the value is purely a selector, use bare. If it's a string containing a selector, use \`{{...}}\`.
 
 ### Selectors vs expressions
 
-Selectors in data fields (\`data\`, \`queryParams\`, \`pathVars\`, \`connectionKey\`) are **dot-path lookups only** — they do not support JavaScript operators like \`||\` or \`&&\`. For default values, use the \`default\` field on the input definition:
+Selectors in data fields (\`data\`, \`queryParams\`, \`pathVars\`, \`connectionKey\`, \`connection.tag\`) are **dot-path lookups only** — they do not support JavaScript operators like \`||\` or \`&&\`. For default values, use the \`default\` field on the input definition:
 
 \`\`\`json
 { "inputs": { "maxResults": { "type": "number", "default": 10 } } }
@@ -713,9 +708,30 @@ A \`flow\` step's \`flow.key\` accepts selectors and Handlebars interpolations, 
 
 Conditional execution: \`"if": "$.steps.prev.response.data.length > 0"\`
 
-## Input Connection Auto-Resolution
+## Connection Resolution — late-bound by default
 
-When an input has \`"connection": { "platform": "stripe" }\`, the flow engine can automatically resolve the connection key at execution time. If the user has exactly one connection for that platform, the engine fills in the key without requiring \`-i connectionKey=...\`. If multiple connections exist, the user must specify which one. This is metadata for tooling — it does not affect the flow JSON structure, but it makes execution more convenient.
+Action steps reference a platform connection in one of two forms:
+
+\`\`\`json
+// preferred — late-bound, survives re-auth
+"connection": { "platform": "gmail" }
+
+// multi-account: disambiguate with the connection's tag
+"connection": { "platform": "gmail", "tag": "work@example.com" }
+
+// legacy — works for backwards compat, breaks on re-auth
+"connectionKey": "live::gmail::default::abc123..."
+\`\`\`
+
+The engine resolves the \`connection\` ref once per flow run (cached for the run's lifetime) by calling \`listConnections\` and matching on platform + optional tag. Resolution errors fail the step with a clear message — \`No connection found for platform "X"\`, \`Multiple "X" connections found (tags: ...). Add a "tag" field\`, or \`No "X" connection has tag "Y"\`.
+
+Both \`platform\` and \`tag\` accept \`$.input.x\` selectors so a flow can be parameterised per-execution (e.g. multi-tenant orchestrators that pass the user's email as the tag).
+
+The validator rejects any action that sets both forms or neither, at \`flow validate\` and \`flow execute\` time.
+
+### Optional input metadata: connection-key auto-resolve (legacy)
+
+For flows that still use literal \`connectionKey\` strings via inputs, an input declaration can carry a \`"connection": { "platform": "..." }\` hint so \`flow execute\` auto-fills a single matching connection's key. New flows don't need this — switch the action's connection form to \`{ platform, tag? }\` and skip the input entirely.
 
 ## Complete Example: Fetch Data, Transform, Notify
 
@@ -726,18 +742,6 @@ When an input has \`"connection": { "platform": "stripe" }\`, the flow engine ca
   "description": "Fetch recent contacts from CRM, build a summary, post to Slack",
   "version": "1",
   "inputs": {
-    "crmConnectionKey": {
-      "type": "string",
-      "required": true,
-      "description": "CRM platform connection key",
-      "connection": { "platform": "attio" }
-    },
-    "slackConnectionKey": {
-      "type": "string",
-      "required": true,
-      "description": "Slack connection key",
-      "connection": { "platform": "slack" }
-    },
     "slackChannel": {
       "type": "string",
       "required": true,
@@ -752,7 +756,7 @@ When an input has \`"connection": { "platform": "stripe" }\`, the flow engine ca
       "action": {
         "platform": "attio",
         "actionId": "ATTIO_LIST_PEOPLE_ACTION_ID",
-        "connectionKey": "$.input.crmConnectionKey",
+        "connection": { "platform": "attio" },
         "queryParams": { "limit": "10" }
       }
     },
@@ -771,7 +775,7 @@ When an input has \`"connection": { "platform": "stripe" }\`, the flow engine ca
       "action": {
         "platform": "slack",
         "actionId": "SLACK_SEND_MESSAGE_ACTION_ID",
-        "connectionKey": "$.input.slackConnectionKey",
+        "connection": { "platform": "slack" },
         "data": {
           "channel": "$.input.slackChannel",
           "text": "{{$.steps.buildSummary.output.summary}}"

--- a/src/lib/flow-types.ts
+++ b/src/lib/flow-types.ts
@@ -15,7 +15,25 @@ export interface FlowInputDeclaration {
 export interface FlowActionConfig {
   platform: string;
   actionId: string;
-  connectionKey: string;
+  /**
+   * Literal connection key (or `$.input.x` selector resolving to one). Legacy
+   * form. Prefer `connection: { platform, tag? }` so re-auth doesn't break
+   * the flow — re-auth always mints a new key, and the literal form forces a
+   * manual edit (or external resolver script) every time.
+   *
+   * Exactly one of `connectionKey` or `connection` must be set per action.
+   */
+  connectionKey?: string;
+  /**
+   * Late-bound connection reference, resolved at flow-execute time. Survives
+   * re-auth: the next run picks up the fresh key automatically. Use `tag` to
+   * disambiguate when a platform has multiple connections (e.g. multiple
+   * Gmail accounts). Both fields support `$.input.x` selectors so flows can
+   * accept the tag (or the whole platform) as runtime input.
+   *
+   * Exactly one of `connectionKey` or `connection` must be set per action.
+   */
+  connection?: { platform: string; tag?: string };
   data?: Record<string, unknown>;
   pathVars?: Record<string, unknown>;
   queryParams?: Record<string, unknown>;
@@ -219,6 +237,14 @@ export interface FlowContext {
     i?: number;
     [key: string]: unknown;
   };
+  /**
+   * Lazy-loaded connection cache — populated the first time an action step
+   * resolves a `connection: { platform, tag? }` ref, then reused for the
+   * rest of the run. Keeps a many-step flow from doing a `listConnections`
+   * round-trip per step. Connections don't change mid-run, so caching for
+   * the run's lifetime is safe.
+   */
+  _connections?: import('./types.js').Connection[];
 }
 
 export interface FlowRunState {

--- a/src/lib/flow-validator.test.ts
+++ b/src/lib/flow-validator.test.ts
@@ -1,0 +1,143 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateFlowSchema } from './flow-validator.js';
+import type { Flow } from './flow-types.js';
+
+const baseAction = {
+  id: 'doIt',
+  name: 'Do it',
+  type: 'action' as const,
+};
+
+function makeFlow(actionPatch: Record<string, unknown>): Flow {
+  return {
+    key: 'test-flow',
+    name: 'Test',
+    inputs: {},
+    steps: [{ ...baseAction, action: actionPatch as any } as any],
+  } as Flow;
+}
+
+const errorPathContains = (errors: { path: string; message: string }[], path: string): boolean =>
+  errors.some(e => e.path === path);
+
+const errorMessageContains = (
+  errors: { path: string; message: string }[],
+  needle: string,
+): boolean => errors.some(e => e.message.includes(needle));
+
+describe('validateFlowSchema action connection form', () => {
+  it('accepts an action step with `connection: { platform }`', () => {
+    const flow = makeFlow({
+      platform: 'gmail',
+      actionId: 'conn_mod_def::abc',
+      connection: { platform: 'gmail' },
+    });
+    const errors = validateFlowSchema(flow);
+    assert.equal(
+      errors.length,
+      0,
+      `expected no errors, got: ${JSON.stringify(errors)}`,
+    );
+  });
+
+  it('accepts an action step with `connection: { platform, tag }`', () => {
+    const flow = makeFlow({
+      platform: 'gmail',
+      actionId: 'conn_mod_def::abc',
+      connection: { platform: 'gmail', tag: 'work@example.com' },
+    });
+    const errors = validateFlowSchema(flow);
+    assert.equal(errors.length, 0);
+  });
+
+  it('accepts a legacy `connectionKey` string', () => {
+    const flow = makeFlow({
+      platform: 'gmail',
+      actionId: 'conn_mod_def::abc',
+      connectionKey: 'live::gmail::default::abc',
+    });
+    const errors = validateFlowSchema(flow);
+    assert.equal(errors.length, 0);
+  });
+
+  it('rejects when both `connectionKey` and `connection` are set', () => {
+    const flow = makeFlow({
+      platform: 'gmail',
+      actionId: 'conn_mod_def::abc',
+      connectionKey: 'live::gmail::default::abc',
+      connection: { platform: 'gmail' },
+    });
+    const errors = validateFlowSchema(flow);
+    assert.ok(errorMessageContains(errors, 'set exactly one'));
+  });
+
+  it('rejects when neither is set', () => {
+    const flow = makeFlow({
+      platform: 'gmail',
+      actionId: 'conn_mod_def::abc',
+    });
+    const errors = validateFlowSchema(flow);
+    assert.ok(errorMessageContains(errors, 'must set "connection'));
+  });
+
+  it('rejects an unknown field inside the connection ref (catches typos like `tags` plural)', () => {
+    const flow = makeFlow({
+      platform: 'gmail',
+      actionId: 'conn_mod_def::abc',
+      connection: { platform: 'gmail', tags: 'work@example.com' },
+    });
+    const errors = validateFlowSchema(flow);
+    assert.ok(errorPathContains(errors, 'steps[0].action.connection.tags'));
+    assert.ok(errorMessageContains(errors, 'Unknown field "tags"'));
+  });
+
+  it('rejects a non-string `tag`', () => {
+    const flow = makeFlow({
+      platform: 'gmail',
+      actionId: 'conn_mod_def::abc',
+      connection: { platform: 'gmail', tag: 123 },
+    });
+    const errors = validateFlowSchema(flow);
+    assert.ok(errorPathContains(errors, 'steps[0].action.connection.tag'));
+  });
+
+  it('treats an empty-string `connectionKey` as not-set (so `connection` must be present)', () => {
+    const flow = makeFlow({
+      platform: 'gmail',
+      actionId: 'conn_mod_def::abc',
+      connectionKey: '',
+    });
+    const errors = validateFlowSchema(flow);
+    assert.ok(errorMessageContains(errors, 'must set "connection'));
+  });
+
+  it('applies the same rules to a paginate step\'s inner action', () => {
+    const flow: Flow = {
+      key: 'test-flow',
+      name: 'Test',
+      inputs: {},
+      steps: [
+        {
+          id: 'page',
+          name: 'Page through',
+          type: 'paginate',
+          paginate: {
+            action: {
+              platform: 'gmail',
+              actionId: 'conn_mod_def::abc',
+              // both forms set — should be rejected
+              connectionKey: 'live::gmail::default::abc',
+              connection: { platform: 'gmail' },
+            } as any,
+            pageTokenField: 'nextPageToken',
+            resultsField: 'items',
+            inputTokenParam: 'pageToken',
+          },
+        } as any,
+      ],
+    } as Flow;
+    const errors = validateFlowSchema(flow);
+    assert.ok(errorMessageContains(errors, 'set exactly one'));
+  });
+});

--- a/src/lib/flow-validator.ts
+++ b/src/lib/flow-validator.ts
@@ -193,9 +193,17 @@ function validateStepsArray(steps: unknown[], pathPrefix: string, errors: Valida
           const a = value as Record<string, unknown>;
           if (!a.platform) errors.push({ path: `${fieldPath}.platform`, message: 'Action must have "platform"' });
           if (!a.actionId) errors.push({ path: `${fieldPath}.actionId`, message: 'Action must have "actionId"' });
-          if (!a.connectionKey) errors.push({ path: `${fieldPath}.connectionKey`, message: 'Action must have "connectionKey"' });
+          validateConnectionForm(a, fieldPath, errors);
         }
       }
+    }
+
+    // Special: action step — exactly one of `connection` or `connectionKey`.
+    // Done as custom logic because the descriptor's required:false leaves the
+    // field as conditionally required (one of two), which the descriptor loop
+    // can't express on its own.
+    if (descriptor.type === 'action') {
+      validateConnectionForm(config, `${path}.${configKey}`, errors);
     }
 
     // Special: code step — require exactly one of source/module and validate module path
@@ -224,6 +232,65 @@ function validateStepsArray(steps: unknown[], pathPrefix: string, errors: Valida
         if (syntaxError) {
           errors.push({ path: `${path}.${configKey}.source`, message: `Syntax error in code step: ${syntaxError}` });
         }
+      }
+    }
+  }
+}
+
+// ── Action connection-form validation ──
+
+/**
+ * Action steps (and the inner action of a paginate step) must set exactly
+ * one of `connectionKey` (legacy literal) or `connection: { platform, tag? }`
+ * (late-bound ref). Pushes errors into `errors` for missing-both, set-both,
+ * or a malformed `connection` ref.
+ */
+function validateConnectionForm(
+  config: Record<string, unknown>,
+  pathPrefix: string,
+  errors: ValidationError[],
+): void {
+  const hasKey = config.connectionKey !== undefined && config.connectionKey !== null && config.connectionKey !== '';
+  const conn = config.connection;
+  const hasRef =
+    !!conn &&
+    typeof conn === 'object' &&
+    !Array.isArray(conn) &&
+    typeof (conn as Record<string, unknown>).platform === 'string' &&
+    (conn as Record<string, string>).platform.length > 0;
+
+  if (hasKey && hasRef) {
+    errors.push({
+      path: pathPrefix,
+      message: 'Action has both "connectionKey" and "connection" — set exactly one. Prefer "connection: { platform, tag? }" so re-auth doesn\'t break the flow.',
+    });
+    return;
+  }
+  if (!hasKey && !hasRef) {
+    errors.push({
+      path: pathPrefix,
+      message: 'Action must set "connection: { platform: <name> }" (or legacy "connectionKey: <key>").',
+    });
+    return;
+  }
+
+  // Validate the shape of `connection` when it's the form in use.
+  if (hasRef) {
+    const c = conn as Record<string, unknown>;
+    if (c.tag !== undefined && typeof c.tag !== 'string') {
+      errors.push({
+        path: `${pathPrefix}.connection.tag`,
+        message: '"connection.tag" must be a string when set',
+      });
+    }
+    // Reject typos / unknown keys to catch e.g. `tags` (plural) silently being ignored.
+    const allowed = new Set(['platform', 'tag']);
+    for (const k of Object.keys(c)) {
+      if (!allowed.has(k)) {
+        errors.push({
+          path: `${pathPrefix}.connection.${k}`,
+          message: `Unknown field "${k}" in connection ref. Allowed: platform, tag.`,
+        });
       }
     }
   }


### PR DESCRIPTION
Companion to #120. Brings the same late-bound connection pattern to flow action steps so re-auth no longer breaks flows that reference a stale literal key.

## Summary

Flow action steps accept either form:

\`\`\`json
"connection": { "platform": "gmail" }                          // single account
"connection": { "platform": "gmail", "tag": "work@x.com" }     // multi-account
"connectionKey": "live::gmail::default::abc..."                // legacy literal
\`\`\`

Resolution runs at flow-execute time via the shared \`OneApi.resolveConnection\` helper introduced for sync (v1.40.0). The connection list is fetched once per flow run and cached on \`FlowContext._connections\`, so a many-step flow does ONE \`listConnections\` round-trip regardless of step count.

Selectors work inside the ref's \`tag\` (and \`platform\`) fields — \`resolveValue\` walks the object before the resolver is called. Lets multi-tenant orchestrators disambiguate per-execution:

\`\`\`json
"connection": { "platform": "gmail", "tag": "$.input.user_email" }
\`\`\`

## Validator

The schema validator (run at \`flow create\`, \`flow validate\`, and \`flow execute\`) enforces:

- Action steps must set **exactly one** of \`connection\` or \`connectionKey\`.
- The same rule applies to a paginate step's inner action.
- Unknown fields inside the ref (e.g. typo \`tags\` plural) are rejected explicitly with a list of allowed fields.
- Non-string \`tag\` values are rejected.

## Backwards compatible

Legacy \`connectionKey\` strings (literal or \`\$.input.x\` selectors) keep working with zero changes. Scaffold templates and schema docs updated to use the new form by default.

## Test results — all 8 cases green ✅

Subagent verified end-to-end against real Gmail, Attio, and Notion connections:

| Case | Result |
|---|---|
| Single-conn platform with \`connection: { platform }\` | ✅ resolves to the only connection, action runs |
| Multi-conn (gmail) without tag | ✅ fails with \`Multiple \"gmail\" connections found (tags: ...). Add a \"tag\" field...\` |
| Multi-conn with \`tag\` literal | ✅ resolves to the right account |
| Multi-conn with \`tag: \"\$.input.userEmail\"\` (selector) | ✅ resolves at runtime; bad input gives \`No \"gmail\" connection has tag ...\` |
| Both \`connectionKey\` and \`connection\` set | ✅ flow create rejects with mutual-exclusion error |
| Neither set | ✅ flow create rejects with \`Action must set \"connection: { platform: <name> }\"\` |
| Legacy literal \`connectionKey\` | ✅ no regression, still works |
| Typo \`tags\` (plural) inside the ref | ✅ \`Unknown field \"tags\" in connection ref. Allowed: platform, tag.\` |

Caching verified by source inspection (\`flow-engine.ts:349-352\`): \`if (!context._connections) { context._connections = await api.listConnections(); }\`.

33 unit tests pass (24 from main + 9 new flow-validator tests).

## Files changed

- \`src/lib/flow-types.ts\` — \`FlowActionConfig.connection?: { platform, tag? }\`, \`FlowContext._connections?: Connection[]\` cache
- \`src/lib/flow-engine.ts\` — \`executeActionStep\` resolves either form, lazy-loads cache once per run
- \`src/lib/flow-validator.ts\` — new \`validateConnectionForm\` helper, enforces mutual exclusion + shape on action steps and paginate.action
- \`src/lib/flow-schema.ts\` — descriptor accepts both fields as optional, all examples migrated to the \`connection\` form, generated guide updated
- \`src/commands/flow.ts\` — scaffold templates use \`connection: { platform }\` by default
- \`skills/one/references/flows.md\` — Connection forms section explaining when to use each
- \`src/lib/flow-validator.test.ts\` — 9 new tests covering both/neither, selectors, typos, paginate.action

## Side-finding (not a regression — pre-existing)

The agent flagged that \`validateActionInput\` (\`src/lib/validate.ts\`) treats action \`inputSchema.body.required\` literally and demands a \`connectionKey\` field in the user's \`data\` payload — even when the connection is supplied via the action-level \`connection\` ref or \`connectionKey\` field. Same behavior with the legacy form (Case 7), so it's not introduced by this PR. Workaround today: \`--skip-validation\`. Worth a follow-up to filter \`connectionKey\` (and other action-property-supplied fields) out of the body-required check.

## Test plan
- [x] \`npm test\` — 33/33
- [x] \`npm run typecheck\` — no new errors
- [x] Validator: both, neither, typo, non-string tag, paginate.action — all caught
- [x] Resolver: single-conn, multi-conn ambiguity, tag disambiguation, selector tag — all behave correctly
- [x] Backwards compat: literal \`connectionKey\` still resolves and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)