### PR TITLE
feat: one relay platforms — discover relay-capable platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,22 @@ one sync run stripe --full-refresh
 
 Change hooks (`onInsert`, `onUpdate`, `onChange`) fire per-page during sync — pipe to a shell command, a flow, or an event log. Root-array responses (e.g. Hacker News `/v0/topstories.json` → `[9129911, 9129199, ...]`) are supported by setting `resultsPath` to `""`, `"$"`, or `"."`; primitive elements are auto-wrapped as `{ [idField]: value }`. Run `one guide sync` for the full reference.
 
+### `one relay`
+
+Receive webhooks from platforms and forward them to any connected platform via passthrough actions.
+
+```bash
+one relay platforms                        # List relay-capable platforms + event type counts
+one relay event-types <platform>           # List supported event types for a platform
+one relay create --connection-key <key> --create-webhook --event-filters '["event.type"]'
+one relay activate <id> --actions '<json>' # Attach passthrough forwarding actions
+one relay list                             # List existing relay endpoints
+one relay events --platform <p>            # Inspect received events
+one relay deliveries --endpoint-id <id>    # Check delivery status
+```
+
+Start with `one relay platforms` to discover which platforms support relay at all, then drill into `event-types <platform>` for the specific events. Run `one guide relay` for the full reference including `--metadata` requirements per platform.
+
 ### `one guide [topic]`
 
 Get the full CLI usage guide, designed for AI agents that only have the binary (no MCP, no IDE skills).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.41.0",
+      "version": "1.42.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",
@@ -1210,6 +1210,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1593,6 +1594,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2144,6 +2146,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/relay.md
+++ b/skills/one/references/relay.md
@@ -16,6 +16,14 @@ one --agent connection list
 
 Identify source (sends webhooks) and destination (receives forwarded data). Note both connection keys.
 
+If you're unsure whether the source platform supports relay at all, list relay-capable platforms first:
+
+```bash
+one --agent relay platforms
+```
+
+This returns `[{ "platform": "<name>", "eventTypeCount": <n> }, ...]` for every platform that One can receive webhooks from. If your source isn't in the list, relay won't work for it.
+
 ### Step 2: Get event types
 
 ```bash
@@ -171,6 +179,13 @@ one --agent relay activate <relay-id> --actions '[{
   },
   "eventFilters": ["customer.created"]
 }]'
+```
+
+## Discovery Commands
+
+```bash
+one --agent relay platforms                        # All relay-capable platforms + event type counts
+one --agent relay event-types <platform>           # Event types for a specific platform
 ```
 
 ## Management Commands

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -422,6 +422,47 @@ export async function relayDeliveriesCommand(options: {
   }
 }
 
+export async function relayPlatformsCommand(): Promise<void> {
+  const { apiKey } = getConfig();
+  const api = new OneApi(apiKey, getApiBase());
+  const spinner = output.createSpinner();
+  spinner.start('Loading relay-capable platforms...');
+
+  try {
+    const platforms = await api.listRelayPlatforms();
+
+    if (output.isAgentMode()) {
+      output.json({ platforms });
+      return;
+    }
+
+    spinner.stop(`${platforms.length} relay-capable platform${platforms.length === 1 ? '' : 's'} found`);
+
+    if (platforms.length === 0) {
+      console.log('\n  No relay-capable platforms available.\n');
+      return;
+    }
+
+    console.log();
+    printTable(
+      [
+        { key: 'platform', label: 'Platform' },
+        { key: 'eventTypeCount', label: 'Event types', color: pc.dim },
+      ],
+      platforms.map(p => ({ platform: p.platform, eventTypeCount: String(p.eventTypeCount) }))
+    );
+    console.log();
+    console.log(
+      pc.dim(
+        `  Run ${pc.cyan('one relay event-types <platform>')} to see the full event list for a platform.\n`
+      )
+    );
+  } catch (error) {
+    spinner.stop('Failed to load relay platforms');
+    output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
 export async function relayEventTypesCommand(platform: string): Promise<void> {
   const { apiKey } = getConfig();
   const api = new OneApi(apiKey, getApiBase());

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
   relayEventGetCommand,
   relayDeliveriesCommand,
   relayEventTypesCommand,
+  relayPlatformsCommand,
 } from './commands/relay.js';
 
 import { registerSyncCommands } from './lib/sync/index.js';
@@ -103,6 +104,7 @@ program
     one cache update-all                  Re-fetch fresh data for all cached entries
 
   Webhook Relay:
+    one relay platforms                   List platforms that support relay + event type counts
     one relay create                      Create a relay endpoint for a connection
     one relay list                        List relay endpoints
     one relay activate <id>               Activate with passthrough actions
@@ -640,6 +642,13 @@ relay
   .description('List supported webhook event types for a platform')
   .action(async (platform: string) => {
     await relayEventTypesCommand(platform);
+  });
+
+relay
+  .command('platforms')
+  .description('List all platforms that support webhook relay, with their event type counts')
+  .action(async () => {
+    await relayPlatformsCommand();
   });
 
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -579,6 +579,10 @@ export class OneApi {
     return this.requestFull({ path: '/webhooks/relay/event-types', queryParams: { platform } });
   }
 
+  async listRelayPlatforms(): Promise<Array<{ platform: string; eventTypeCount: number }>> {
+    return this.requestFull({ path: '/webhooks/relay/platforms' });
+  }
+
 
   async waitForConnection(
     platform: string,

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -78,6 +78,7 @@ Receive webhooks from platforms (Stripe, GitHub, Airtable, Attio, Google Calenda
 
 **Quick start:**
 \`\`\`bash
+one --agent relay platforms                                     # See relay-capable platforms
 one --agent relay event-types <platform>                        # See available events
 one --agent relay create --connection-key <key> --create-webhook --event-filters '["event.type"]'
 one --agent relay activate <id> --actions '[{"type":"passthrough","actionId":"...","connectionKey":"...","body":{...}}]'
@@ -228,6 +229,7 @@ Webhook relay receives events from platforms (Stripe, GitHub, Airtable, Attio, G
 ## Commands
 
 \`\`\`bash
+one --agent relay platforms                        # List relay-capable platforms + event type counts
 one --agent relay event-types <platform>          # List available events
 one --agent relay create --connection-key <key> --create-webhook --event-filters '["event.type"]'
 one --agent relay activate <id> --actions '<json>' # Add forwarding actions
@@ -242,7 +244,7 @@ one --agent relay deliveries --endpoint-id <id>    # Check delivery status
 
 ## Building a Relay
 
-1. **Discover connections** — identify source and destination platforms
+1. **Discover connections** — identify source and destination platforms. Use \`one --agent relay platforms\` to see which platforms support relay at all before digging into a specific one.
 2. **Get event types** — \`one --agent relay event-types <platform>\`
 3. **Get source knowledge** — understand the incoming webhook payload shape (\`{{payload.*}}\` paths)
 4. **Get destination knowledge** — understand the outgoing API body shape

--- a/src/lib/sync/index.ts
+++ b/src/lib/sync/index.ts
@@ -1,7 +1,7 @@
 import type { Command } from 'commander';
 import * as output from '../output.js';
 import { OneApi } from '../api.js';
-import { getApiKey, getAccessControlFromAllSources } from '../config.js';
+import { getApiKey, getApiBase, getAccessControlFromAllSources } from '../config.js';
 import { discoverModels } from './models.js';
 import { readProfile, writeProfile, writeDraftProfile, listProfiles, generateTemplate } from './profile.js';
 import { syncModel } from './runner.js';
@@ -122,7 +122,7 @@ function getApi(): OneApi {
   if (!apiKey) {
     output.error('No API key configured. Run "one init" first.');
   }
-  return new OneApi(apiKey);
+  return new OneApi(apiKey!, getApiBase());
 }
 
 // ── sync profiles (built-in) ──


### PR DESCRIPTION
## Summary

Adds a new `one relay platforms` subcommand that lists every platform supporting webhook relay, with the number of event types each exposes. Previously users had to guess a platform and try `relay event-types <platform>` to find out whether relay was supported at all.

Also includes a small pre-existing fix: `sync/index.ts` was constructing `new OneApi(apiKey)` without passing `apiBase`, causing sync to always hit prod even when the CLI was configured for dev.

Closes withoneai/cli#123

## Changes

### New command

```bash
# Agent mode
$ one --agent relay platforms
{"platforms":[{"platform":"airtable","eventTypeCount":3},{"platform":"attio","eventTypeCount":27}, ...]}

# Human mode
$ one relay platforms
  Platform         Event types
  ───────────────  ───────────
  airtable         3
  attio            27
  autodesk         20
  brevo            17
  ...
  stripe           224
  typeform         2
  webflow          14

  Run `one relay event-types <platform>` to see the full event list for a platform.
```

Calls `GET /webhooks/relay/platforms` (no auth required).

### Files changed

- `src/lib/api.ts` — added `listRelayPlatforms()`
- `src/commands/relay.ts` — added `relayPlatformsCommand` with agent + human output
- `src/index.ts` — registered `one relay platforms` and added it to the top-level help text
- `src/lib/guide-content.ts` — surfaced in overview + relay topic
- `skills/one/references/relay.md` — added to Step 1 discovery flow + new "Discovery Commands" section
- `README.md` — added a `one relay` section (was previously undocumented)
- `src/lib/sync/index.ts` — pass `getApiBase()` to sync's `OneApi` instance
- `package.json` — 1.41.0 → 1.42.0

## Test plan

- [x] `npx tsup` builds cleanly
- [x] `one relay platforms --agent` returns the platforms array
- [x] `one relay platforms` renders the table in human mode
- [x] `one relay event-types airtable` still works (no regression)
- [x] `one relay --help` lists the new `platforms` subcommand
- [ ] Reviewer to verify docs read well in rendered GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)