### PR TITLE
fix(cli): close memory backend in postAction (~10s → ~300ms)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.43.2",
+  "version": "1.43.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.43.2",
+      "version": "1.43.3",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.43.2",
+  "version": "1.43.3",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import { onboardCommand } from './commands/onboard.js';
 import { loginCommand } from './commands/login.js';
 import { logoutCommand } from './commands/logout.js';
 import { updateCommand, checkLatestVersionCached, getCurrentVersion, isNewerVersion, autoUpdate } from './commands/update.js';
+import { closeBackendIfCached } from './lib/memory/runtime.js';
 import { setAgentMode, isAgentMode, json as outputJson, error as outputError } from './lib/output.js';
 import { syncSkillsIfStale, forceSyncSkills, getSkillStatus } from './lib/skill-sync.js';
 
@@ -161,6 +162,12 @@ program.hook('preAction', (thisCommand) => {
 });
 
 program.hook('postAction', async () => {
+  // Close the memory backend (if one was instantiated) so the process
+  // doesn't sit on node-pg's default 10s idleTimeoutMillis after the
+  // command's work is done. Without this, `mem search` prints its JSON
+  // immediately but the process hangs for ~10s before exiting.
+  await closeBackendIfCached();
+
   if (!updateCheckPromise) return;
   const info = await updateCheckPromise;
   if (!info) return;

--- a/src/lib/memory/runtime.ts
+++ b/src/lib/memory/runtime.ts
@@ -74,6 +74,30 @@ export function resetBackendSingleton(): void {
   cached = null;
 }
 
+/**
+ * Best-effort backend shutdown. Called from the program's postAction
+ * hook so a one-shot CLI command exits cleanly after the work is done.
+ *
+ * Why: node-pg's Pool defaults to `idleTimeoutMillis: 10000`. After
+ * every CLI command, the still-idle pooled connection keeps the event
+ * loop alive for that full 10s before the process can exit. End users
+ * see `mem search` block for ~10s after the JSON has already printed.
+ *
+ * No-op when no backend was ever instantiated (no `mem`/`sync` command
+ * ran, or the lookup failed before getBackend resolved). Errors are
+ * swallowed — we're shutting down anyway, complaining isn't useful.
+ */
+export async function closeBackendIfCached(): Promise<void> {
+  if (!cached) return;
+  try {
+    const backend = await cached;
+    await backend.close();
+  } catch {
+    /* shutdown is best-effort */
+  }
+  cached = null;
+}
+
 // ─── Embedding-aware helpers ───────────────────────────────────────────────
 
 export interface AddOptions {


### PR DESCRIPTION
## Summary

`one --agent mem search` was hanging for ~10s after the JSON response had already been printed. Root cause: node-pg's `Pool` defaults to `idleTimeoutMillis: 10000`, so the still-idle pooled connection kept the event loop alive for the full 10 seconds before the process could exit.

The original report from a CEO-data investigation:
> Postgres `mem_hybrid_search` SQL: 37ms (psql direct)
> Direct OpenAI embedding API: 200ms (curl direct)
> Expected total: ~500ms
> Actual `one --agent mem search` total: ~10.5s every invocation
> Process sampling shows the main thread blocked in kevent for ~9.5 seconds

## Diagnosis trail

Worth recording, because the surface symptom (kevent wait + one TLS connection) looked like a network problem but wasn't.

1. `time one --version` → 70ms. Module load + dispatch is fine.
2. Stage timers inside `memSearchCommand` → `requireMemoryInit + getBackend + embed + backend.search` totals ~700ms. The work itself is fast.
3. Print before/after the program's `postAction` hook → both fire promptly. The hook completes too.
4. Total wall-clock still ~10.5s. So whatever holds the loop is at module-import scope, after both hooks finish.
5. node-pg `Pool` is exactly that: a long-lived pool whose idle connection keeps the event loop alive for `idleTimeoutMillis` (default 10s) before idle-reaping itself.

## Fix

`closeBackendIfCached()` helper in `runtime.ts` awaits the cached backend promise (if any) and calls `backend.close()`. Wired into the `postAction` hook so every command that touched memory drains its pool before the process exits.

- No-op when no `mem`/`sync` command instantiated a backend.
- Errors swallowed (we're shutting down anyway).
- Idle-timeout stays at the node-pg default during the command so sequential queries reuse one pool connection (correct for `sync run`, `mem migrate`, etc.).

## Verified end-to-end against ~/CEO

| Run | Before | After |
|---|---|---|
| Cold (`mem search "test"`) | 10.4s | 2.0s |
| Warm × 5 (different queries) | ~10.4s each | 300-420ms each |

98/98 tests pass; 5 pre-existing TS errors unchanged.

## Test plan

- [ ] `one --agent mem search "<query>"` returns and exits in <1s on a warm pool
- [ ] `one --agent mem add note '{"content":"x"}'` exits cleanly
- [ ] `one --agent sync run <platform>` still completes (multiple sequential queries should reuse the connection during the run, then close at end)
- [ ] `one --agent mem doctor` still passes 7/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)