### PR TITLE
fix(cli): honor --limit on connection list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.43.3",
+  "version": "1.43.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.43.3",
+      "version": "1.43.4",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.43.3",
+  "version": "1.43.4",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -169,8 +169,10 @@ export async function connectionListCommand(options?: { search?: string; limit?:
       ? accessFiltered.filter(conn => conn.platform.toLowerCase().includes(searchQuery))
       : accessFiltered;
 
+    const limitArg = options?.limit ? parseInt(options.limit, 10) : undefined;
+
     if (output.isAgentMode()) {
-      const limit = options?.limit ? parseInt(options.limit, 10) : 20;
+      const limit = limitArg ?? 20;
       const limited = filtered.slice(0, limit);
 
       output.json({
@@ -190,6 +192,8 @@ export async function connectionListCommand(options?: { search?: string; limit?:
       });
       return;
     }
+
+    const displayed = limitArg !== undefined ? filtered.slice(0, limitArg) : filtered;
 
     spinner.stop(`${filtered.length} connection${filtered.length === 1 ? '' : 's'} found`);
 
@@ -212,7 +216,7 @@ export async function connectionListCommand(options?: { search?: string; limit?:
 
     console.log();
 
-    const rows = filtered.map(conn => ({
+    const rows = displayed.map(conn => ({
       status: getStatusIndicator(conn.state),
       platform: conn.platform,
       state: conn.state,
@@ -234,7 +238,14 @@ export async function connectionListCommand(options?: { search?: string; limit?:
     );
 
     console.log();
-    p.note(`Add more with: ${pc.cyan('one connection add <platform>')}`, 'Tip');
+    if (displayed.length < filtered.length) {
+      p.note(
+        `Showing ${displayed.length} of ${filtered.length}. Increase --limit or run without it to see all.`,
+        'Limited'
+      );
+    } else {
+      p.note(`Add more with: ${pc.cyan('one connection add <platform>')}`, 'Tip');
+    }
   } catch (error) {
     spinner.stop('Failed to load connections');
     output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -799,8 +799,10 @@ program
   .command('list')
   .alias('ls')
   .description('Shortcut for: connection list')
-  .action(async () => {
-    await connectionListCommand();
+  .option('-s, --search <query>', 'Filter connections by platform name')
+  .option('-l, --limit <n>', 'Max connections to return (agent mode default: 20)')
+  .action(async (options) => {
+    await connectionListCommand(options);
   });
 
 program.parse();


### PR DESCRIPTION
## Summary
- Apply \`--limit\` before rendering the human table on \`one connection list\` (was only honored in \`--agent\` mode).
- Forward \`--limit\` and \`--search\` through the top-level \`one list\` shortcut so \`one --agent list --limit 25\` works.
- Bump to 1.43.4.

Closes #134

## Test plan
- [x] \`one --agent list --limit 25\` → \`showing: 25\`
- [x] \`one --agent list --limit 2\` → \`showing: 2\`
- [x] \`one connection list --limit 2\` → table shows 2 rows + "Limited" note
- [x] \`one list --limit 1\` (top-level shortcut) → 1 row
- [x] \`--search\` still works through the top-level shortcut