### PR TITLE
fix: support nested project configs in monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Supports Claude Code, Claude Desktop, Cursor, Windsurf, Codex, and Kiro.
 
 When you run `one` in a project, it uses the project config if one exists and falls back to the global config otherwise. Use `one config path` to see which config is active and the full resolution order.
 
+In a monorepo, the project root is the nearest ancestor with `.one/`, `.git`, or `package.json` — checked in that order. Run `mkdir .one` in a nested subproject to make it its own project root (so the config is keyed by the nested dir's slug instead of the monorepo's).
+
 If you've already set up, `one init` shows your current status for the active scope and lets you update your key, install to more agents, or reconfigure.
 
 | Flag | What it does |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.43.6",
+  "version": "1.43.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.43.6",
+      "version": "1.43.7",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.43.6",
+  "version": "1.43.7",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -22,7 +22,7 @@ description: |
 
 You have access to the One CLI which lets you interact with 250+ third-party platforms through their APIs. Always include the `--agent` flag right after `one` for structured JSON output.
 
-If the user wants a separate API key / connections for a specific project (vs. their default), walk them through running `one init` from that project folder and picking the "project" scope — see `references/scoping.md`.
+If the user wants a separate API key / connections for a specific project (vs. their default), walk them through running `one init` from that project folder and picking the "project" scope — see `references/scoping.md`. For monorepo subprojects (where a parent already has `.git`/`package.json`), have them `mkdir .one` in the subproject first so the config is keyed to that dir, not the monorepo root.
 
 ## Authentication
 

--- a/skills/one/references/scoping.md
+++ b/skills/one/references/scoping.md
@@ -5,7 +5,9 @@ The One CLI can be configured at two scopes:
 - **Global** — `~/.one/config.json`. Applies everywhere the user runs `one`.
 - **Project** — `~/.one/projects/<slug>/config.json`, where `<slug>` is the project root path with slashes replaced by dashes (e.g. `/Users/jane/acme` → `-Users-jane-acme`). Only applies when running `one` from inside that project folder.
 
-**Resolution order:** env vars → `.onerc` in cwd → project config → global config. Project config wins when present; otherwise the CLI falls back to the global config.
+**Detecting the project root.** The CLI walks up from cwd looking for `.one`, `.git`, or `package.json` and treats the nearest hit as the project root — `.one` is checked first so a monorepo subproject can opt into being its own root with `mkdir .one`. Without a `.one` opt-in, every cwd under a parent `.git`/`package.json` shares one project config keyed by that parent.
+
+**Resolution order:** env vars → `.onerc` in cwd → project config → global config. The project lookup walks from cwd up — the nearest ancestor that has a config under `~/.one/projects/<slug>/config.json` wins, so cwd's own slug is checked before any parent's.
 
 ## When to suggest project scope
 
@@ -25,6 +27,8 @@ one init
 ```
 
 When `init` asks "Where should this setup live?", pick **"This project only"**. Init will write the config to `~/.one/projects/<slug>/config.json` and everything else (skill install, MCP) stays untouched.
+
+**Monorepo / nested project.** If the target dir is *inside* another repo (i.e. a parent already has `.git` or `package.json`), the slug used by `init` would otherwise resolve to that parent. To scope a config to the nested dir specifically, run `mkdir .one` in that dir before `one init` — the empty `.one/` directory marks it as its own project root, and the config will be keyed by the nested dir's slug.
 
 To see which config is currently active and the full fallback chain:
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getProjectRoot, resolveConfig } from './config.js';
+
+// All tests sandbox $HOME to a temp dir so they read/write under
+// `<tmp>/.one/...` instead of the developer's real `~/.one/`. The config
+// module deliberately resolves home-rooted paths lazily on every call
+// (see the comment at the top of config.ts), so flipping HOME here is
+// sufficient — no module reload required.
+
+function withSandbox(): {
+  tmpDir: string;
+  homeDir: string;
+  writeProjectConfig: (absDir: string, content: object) => void;
+  writeGlobalConfig: (content: object) => void;
+} {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-cli-config-test-'));
+  const homeDir = path.join(tmpDir, 'home');
+  fs.mkdirSync(homeDir, { recursive: true });
+  process.env.HOME = homeDir;
+
+  const projectsDir = path.join(homeDir, '.one', 'projects');
+
+  return {
+    tmpDir,
+    homeDir,
+    writeProjectConfig(absDir, content) {
+      const slug = absDir.replace(/[\\/]/g, '-');
+      const dir = path.join(projectsDir, slug);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify(content));
+    },
+    writeGlobalConfig(content) {
+      fs.mkdirSync(path.join(homeDir, '.one'), { recursive: true });
+      fs.writeFileSync(path.join(homeDir, '.one', 'config.json'), JSON.stringify(content));
+    },
+  };
+}
+
+describe('getProjectRoot', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    originalCwd = process.cwd();
+    ({ tmpDir } = withSandbox());
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns the nearest ancestor that contains .git', () => {
+    const repo = path.join(tmpDir, 'repo');
+    const leaf = path.join(repo, 'sub', 'leaf');
+    fs.mkdirSync(leaf, { recursive: true });
+    fs.mkdirSync(path.join(repo, '.git'));
+    assert.equal(getProjectRoot(leaf), repo);
+  });
+
+  it('returns the nearest ancestor that contains package.json', () => {
+    const repo = path.join(tmpDir, 'repo');
+    const leaf = path.join(repo, 'sub');
+    fs.mkdirSync(leaf, { recursive: true });
+    fs.writeFileSync(path.join(repo, 'package.json'), '{}');
+    assert.equal(getProjectRoot(leaf), repo);
+  });
+
+  it('treats .one as a project marker', () => {
+    const dir = path.join(tmpDir, 'project');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(path.join(dir, '.one'));
+    assert.equal(getProjectRoot(dir), dir);
+  });
+
+  it('nested .one wins over a parent .git (lets monorepo subprojects opt in)', () => {
+    const repo = path.join(tmpDir, 'monorepo');
+    const nested = path.join(repo, 'services', 'frontend');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.mkdirSync(path.join(repo, '.git'));
+    fs.mkdirSync(path.join(nested, '.one'));
+    assert.equal(
+      getProjectRoot(nested),
+      nested,
+      'walking up from nested should stop at nested because of its .one',
+    );
+  });
+
+  it('falls back to cwd when no marker exists in any ancestor', () => {
+    const dir = path.join(tmpDir, 'orphan', 'sub');
+    fs.mkdirSync(dir, { recursive: true });
+    assert.equal(getProjectRoot(dir), dir);
+  });
+});
+
+describe('resolveConfig', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalCwd: string;
+  let writeProjectConfig: (absDir: string, content: object) => void;
+  let writeGlobalConfig: (content: object) => void;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    originalCwd = process.cwd();
+    ({ tmpDir, writeProjectConfig, writeGlobalConfig } = withSandbox());
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads cwd-slug config even when cwd has no marker (orphan-config fix)', () => {
+    // Pre-existing bug: parent has .git, so getProjectRoot returns the
+    // parent, and the old resolver only checked the parent slug + walked
+    // strictly above cwd — never checking cwd's own slug. A config keyed
+    // to cwd was invisible.
+    const repo = path.join(tmpDir, 'workspace');
+    const nested = path.join(repo, 'sub', 'leaf');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.mkdirSync(path.join(repo, '.git'));
+    writeProjectConfig(nested, { apiKey: 'sk_nested' });
+    process.chdir(nested);
+
+    const resolved = resolveConfig();
+    assert.equal(resolved.scope, 'project');
+    assert.equal(resolved.projectRoot, nested);
+    assert.equal(resolved.config?.apiKey, 'sk_nested');
+  });
+
+  it('picks the nested-slug config when nested dir has .one and configs exist at both levels', () => {
+    const repo = path.join(tmpDir, 'monorepo');
+    const nested = path.join(repo, 'services', 'frontend');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.mkdirSync(path.join(repo, '.git'));
+    fs.mkdirSync(path.join(nested, '.one'));
+    writeProjectConfig(nested, { apiKey: 'sk_nested' });
+    writeProjectConfig(repo, { apiKey: 'sk_parent' });
+    process.chdir(nested);
+
+    const resolved = resolveConfig();
+    assert.equal(resolved.scope, 'project');
+    assert.equal(resolved.projectRoot, nested);
+    assert.equal(resolved.config?.apiKey, 'sk_nested');
+  });
+
+  it('preserves existing behavior: parent-only config still resolves for a nested cwd', () => {
+    const repo = path.join(tmpDir, 'repo');
+    const nested = path.join(repo, 'sub');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.mkdirSync(path.join(repo, '.git'));
+    writeProjectConfig(repo, { apiKey: 'sk_parent' });
+    process.chdir(nested);
+
+    const resolved = resolveConfig();
+    assert.equal(resolved.scope, 'project');
+    assert.equal(resolved.projectRoot, repo);
+    assert.equal(resolved.config?.apiKey, 'sk_parent');
+  });
+
+  it('cwd-slug config wins over parent-slug config (closer is more specific)', () => {
+    const repo = path.join(tmpDir, 'repo');
+    const nested = path.join(repo, 'sub');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.mkdirSync(path.join(repo, '.git'));
+    writeProjectConfig(nested, { apiKey: 'sk_nested' });
+    writeProjectConfig(repo, { apiKey: 'sk_parent' });
+    process.chdir(nested);
+
+    const resolved = resolveConfig();
+    assert.equal(resolved.scope, 'project');
+    assert.equal(resolved.projectRoot, nested);
+    assert.equal(resolved.config?.apiKey, 'sk_nested');
+  });
+
+  it('falls back to global, but reports the marker-detected root for diagnostics', () => {
+    const repo = path.join(tmpDir, 'repo');
+    const nested = path.join(repo, 'sub');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.mkdirSync(path.join(repo, '.git'));
+    writeGlobalConfig({ apiKey: 'sk_global' });
+    process.chdir(nested);
+
+    const resolved = resolveConfig();
+    assert.equal(resolved.scope, 'global');
+    assert.equal(
+      resolved.projectRoot,
+      repo,
+      'global fallback should still report where a project config *would* live',
+    );
+    assert.equal(resolved.config?.apiKey, 'sk_global');
+  });
+
+  it('returns null scope when no config exists anywhere', () => {
+    const repo = path.join(tmpDir, 'repo');
+    const nested = path.join(repo, 'sub');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.mkdirSync(path.join(repo, '.git'));
+    process.chdir(nested);
+
+    const resolved = resolveConfig();
+    assert.equal(resolved.scope, null);
+    assert.equal(resolved.config, null);
+    assert.equal(resolved.projectRoot, repo);
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -28,14 +28,20 @@ export interface ResolvedConfig {
 // ── Project detection ────────────────────────────────────────────────
 
 /**
- * Walk up from cwd looking for a project marker (.git, package.json).
+ * Walk up from cwd looking for a project marker (.one, .git, package.json).
  * Falls back to cwd if nothing is found.
+ *
+ * `.one` is listed first so a monorepo subproject can opt into being its
+ * own project root with `mkdir .one`, even when a parent already has .git
+ * or package.json. Without this opt-in, every cwd under a parent marker
+ * shares one project config keyed by the parent's slug.
  */
 export function getProjectRoot(cwd: string = process.cwd()): string {
   let dir = path.resolve(cwd);
   const root = path.parse(dir).root;
   while (dir !== root) {
     if (
+      fs.existsSync(path.join(dir, '.one')) ||
       fs.existsSync(path.join(dir, '.git')) ||
       fs.existsSync(path.join(dir, 'package.json'))
     ) {
@@ -75,23 +81,18 @@ export function getGlobalConfigPath(): string {
  * should use this; convenience wrappers below preserve the legacy API.
  */
 export function resolveConfig(): ResolvedConfig {
-  const projectRoot = getProjectRoot();
-  const projectSlug = getProjectSlug(projectRoot);
-  const projectPath = getProjectConfigPath(projectRoot);
+  const detectedRoot = getProjectRoot();
+  const detectedSlug = getProjectSlug(detectedRoot);
 
-  // Check detected project root first
-  if (fs.existsSync(projectPath)) {
-    const config = readConfigFile(projectPath);
-    if (config) {
-      return { config, scope: 'project', path: projectPath, projectRoot, projectSlug };
-    }
-  }
-
-  // Walk up from cwd checking each ancestor for a project config
+  // Walk from cwd up, checking each level's slug for a project config.
+  // First match wins — closer to cwd is more specific (mirrors how
+  // .gitignore / .envrc / .editorconfig resolve). This also catches the
+  // "orphan config" case where a project config exists under cwd's slug
+  // but cwd has no marker, so the marker walk above would otherwise
+  // skip over it and fall through to global.
   const root = path.parse(process.cwd()).root;
   let dir = path.resolve(process.cwd());
-  while (dir !== root) {
-    dir = path.dirname(dir);
+  while (true) {
     const slug = getProjectSlug(dir);
     const configPath = path.join(projectsDir(), slug, 'config.json');
     if (fs.existsSync(configPath)) {
@@ -100,16 +101,21 @@ export function resolveConfig(): ResolvedConfig {
         return { config, scope: 'project', path: configPath, projectRoot: dir, projectSlug: slug };
       }
     }
+    if (dir === root) break;
+    dir = path.dirname(dir);
   }
 
+  // No project config anywhere; check global. Report the marker-detected
+  // root in projectRoot so `one config path` still shows where a future
+  // project config *would* live.
   if (fs.existsSync(configFile())) {
     const config = readConfigFile(configFile());
     if (config) {
-      return { config, scope: 'global', path: configFile(), projectRoot, projectSlug };
+      return { config, scope: 'global', path: configFile(), projectRoot: detectedRoot, projectSlug: detectedSlug };
     }
   }
 
-  return { config: null, scope: null, path: configFile(), projectRoot, projectSlug };
+  return { config: null, scope: null, path: configFile(), projectRoot: detectedRoot, projectSlug: detectedSlug };
 }
 
 function readConfigFile(filePath: string): Config | null {


### PR DESCRIPTION
## Summary

A client report surfaced a real bug: in a monorepo where only the *parent* has `.git` / `package.json`, a `~/.one/projects/<nested-slug>/config.json` keyed to the nested dir was never picked up — every run from inside the nested dir silently fell back to global. The only workaround was dropping a `.git` or `package.json` into the nested dir.

Reproduced end-to-end with a synthetic monorepo (parent `.git`, no markers in nested), placed a nested-slug config, ran `one --agent config path` from the nested dir — got `"scope":"global"` despite the config sitting right there. Confirmed the cause in `src/lib/config.ts`.

## Fix

Two changes in `src/lib/config.ts`:

1. **`.one/` is now a project marker** (checked before `.git` / `package.json` in `getProjectRoot`). `mkdir .one` in a subproject makes it its own project root — no need to drop stray `.git`s. `one flow create` already writes `.one/flows/...`, so projects that use flows naturally already have this directory; behavior change there is intentional and aligned.

2. **Project-config lookup walks from cwd up** (`resolveConfig` rewritten). The old resolver checked the marker-detected root first and then walked ancestors *above* cwd — cwd's own slug was never checked, so any config keyed to it was orphaned. The new resolver walks outward from cwd and returns the first slug with a config (mirrors `.gitignore` / `.envrc` / `.editorconfig` resolution).

### Behavior change to flag

When both a nested-slug *and* a parent-slug config exist, the **nested (closer) one now wins** instead of the parent. This is the intended monorepo behavior but is technically a change for any existing setup that relied on parent-wins. Single-project repos (only `C[parent]` exists) are unaffected.

## Test plan

- [x] 11 new tests in `src/lib/config.test.ts` covering marker detection (`.git`, `package.json`, `.one/`), `.one/` precedence over a parent marker, the orphan-config fix, full monorepo end-to-end (nested `.one/` + nested slug config wins), existing parent-only resolution preserved, global fallback still reports the marker-detected root for diagnostics, and the no-config-anywhere case
- [x] Full suite: 109/109 pass (was 98)
- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds
- [x] Live re-run of the original repro now resolves to the nested project config instead of falling back to global
- [x] Docs updated per docs-first rule (`skills/one/references/scoping.md`, `skills/one/SKILL.md`, `README.md`)
- [x] Version bumped 1.43.6 → 1.43.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)