### PR TITLE
feat(cache): harden action-details preflight cache (INT-3104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ one actions execute stripe <actionId> <connectionKey> \
 | `--mock` | Return example response without making an API call |
 | `--skip-validation` | Skip input validation against the action schema |
 | `--output <path>` | Save response to a file (for binary downloads) |
-| `--no-cache` | Fetch action details fresh instead of from the local cache (execution itself is never cached) |
+| `--no-cache` | Bypass the cached action details and re-fetch them; the fresh details still refresh the cache (execution itself is never cached) |
 
 The CLI validates required parameters (path variables, query params, body fields) against the action schema before executing. Missing params return a clear error with the flag name and description. Pass `--skip-validation` to bypass.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.45.0",
+      "version": "1.45.1",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -90,7 +90,7 @@ Options:
 - `--mock` — Return example response without making an API call (useful for building UI)
 - `--skip-validation` — Skip input validation against the action schema
 - `--output <path>` — Save response to a file (for binary downloads like PDFs, images, documents)
-- `--no-cache` — Fetch action details fresh instead of from the local cache (execution itself is never cached)
+- `--no-cache` — Bypass the cached action details and re-fetch them; the fresh details still refresh the cache (execution itself is never cached)
 
 The CLI validates required parameters before executing. Missing params return a structured error with the flag name, parameter name, and description. Pass `--skip-validation` to bypass.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -440,7 +440,7 @@ actions
   .command('search <platform> <query>')
   .description('Search for actions on a platform (e.g. one actions search gmail "send email")')
   .option('-t, --type <type>', 'execute (to run it) or knowledge (to learn about it). Default: knowledge')
-  .option('--no-cache', 'Skip cache, fetch fresh from API')
+  .option('--no-cache', 'Bypass the cache and re-fetch from the API (the fresh response still refreshes the cache)')
   .action(async (platform: string, query: string, options: { type?: string; cache?: boolean }) => {
     await actionsSearchCommand(platform, query, options);
   });
@@ -449,7 +449,7 @@ actions
   .command('knowledge <platform> <actionId>')
   .alias('k')
   .description('Get full docs for an action — MUST call before execute to know required params')
-  .option('--no-cache', 'Skip cache, fetch fresh from API')
+  .option('--no-cache', 'Bypass the cache and re-fetch from the API (the fresh response still refreshes the cache)')
   .option('--cache-status', 'Print cache metadata without fetching')
   .action(async (platform: string, actionId: string, options: { cache?: boolean; cacheStatus?: boolean }) => {
     await actionsKnowledgeCommand(platform, actionId, options);
@@ -470,7 +470,7 @@ actions
   .option('--dry-run', 'Show request that would be sent without executing')
   .option('--mock', 'Return example response without making an API call')
   .option('--skip-validation', 'Skip input validation against the action schema')
-  .option('--no-cache', 'Fetch action details fresh instead of using the local cache (execution itself is never cached)')
+  .option('--no-cache', 'Bypass the cached action details and re-fetch them (the fresh details still refresh the cache; execution itself is never cached)')
   .option('--output <path>', 'Save binary response to a file (for non-JSON responses like file downloads)')
   .option('--parallel', 'Execute multiple actions concurrently (separate actions with --)')
   .option('--max-concurrency <n>', 'Max concurrent actions when using --parallel (default: 5)', '5')

--- a/src/commands/actions.preflight.test.ts
+++ b/src/commands/actions.preflight.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { actionsExecuteCommand, actionsExecuteParallelCommand } from './actions.js';
+
+// Contract lock for the execute "_preflight" field: agent-mode execute and
+// execute --parallel must report whether the action-details preflight was
+// served from cache. These run the real command functions in-process against
+// a throwaway HTTP server, with $HOME sandboxed so the cache lives in a temp dir.
+
+const ACTION_ID = 'conn_mod_def::TEST::send';
+
+const ACTION = {
+  _id: ACTION_ID,
+  title: 'Send',
+  tags: [] as string[],
+  knowledge: '# Send',
+  path: '/v1/things/send',
+  method: 'POST',
+  ioSchema: { inputSchema: { properties: {} }, ioExample: { output: { ok: true } } },
+};
+
+interface Harness {
+  server: http.Server;
+  port: number;
+  counts: { knowledge: number; passthrough: number };
+}
+
+function startServer(): Promise<Harness> {
+  const counts = { knowledge: 0, passthrough: 0 };
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    if (url.pathname === '/v1/knowledge') {
+      counts.knowledge++;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('etag', '"send-v1"');
+      res.end(JSON.stringify({ rows: [ACTION] }));
+      return;
+    }
+    if (url.pathname.startsWith('/v1/passthrough/')) {
+      counts.passthrough++;
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ ok: true }));
+      });
+      return;
+    }
+    res.statusCode = 404;
+    res.end('{}');
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, port, counts });
+    });
+  });
+}
+
+describe('execute _preflight contract (agent mode)', () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let originalAgent: string | undefined;
+  let originalArgv: string[];
+  let originalWrite: typeof process.stdout.write;
+  let originalExit: typeof process.exit;
+  let lines: string[];
+  let harness: Harness;
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME;
+    originalAgent = process.env.ONE_AGENT;
+    originalArgv = process.argv;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'one-cli-preflight-test-'));
+    process.env.HOME = tmpHome;
+    process.env.ONE_AGENT = '1';
+
+    harness = await startServer();
+    fs.mkdirSync(path.join(tmpHome, '.one'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, '.one', 'config.json'),
+      JSON.stringify({ apiKey: 'sk_test', apiBase: `http://localhost:${harness.port}` })
+    );
+
+    // Capture agent-mode JSON (output.json writes one line to stdout). Forward
+    // everything through so the test reporter — which shares this stdout — still
+    // prints; only stash JSON-object lines for assertions.
+    lines = [];
+    originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: any, ...rest: any[]) => {
+      const s = typeof chunk === 'string' ? chunk : String(chunk);
+      // Capture (and swallow) agent-mode JSON; forward everything else so the
+      // test reporter, which shares this stdout, still prints normally.
+      if (s.trim().startsWith('{')) { lines.push(s); return true; }
+      return (originalWrite as any)(chunk, ...rest);
+    }) as typeof process.stdout.write;
+
+    // Any process.exit during a success path is a bug — surface it as a throw.
+    originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      throw new Error(`unexpected process.exit(${code})`);
+    }) as typeof process.exit;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+    process.exit = originalExit;
+    process.argv = originalArgv;
+    if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+    if (originalAgent === undefined) delete process.env.ONE_AGENT; else process.env.ONE_AGENT = originalAgent;
+    harness.server.close();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function lastJson(): any {
+    const jsonLines = lines.filter((l) => l.trim().startsWith('{'));
+    return JSON.parse(jsonLines[jsonLines.length - 1]);
+  }
+
+  it('reports cache:miss on the first execute and cache:hit on the second', async () => {
+    await actionsExecuteCommand('plat', ACTION_ID, 'plat::key', { skipValidation: true });
+    const first = lastJson();
+    assert.deepEqual(first._preflight, { cache: 'miss' });
+    assert.equal(harness.counts.knowledge, 1);
+
+    lines = [];
+    await actionsExecuteCommand('plat', ACTION_ID, 'plat::key', { skipValidation: true });
+    const second = lastJson();
+    assert.deepEqual(second._preflight, { cache: 'hit' });
+    // No extra /knowledge round trip on the warm execute.
+    assert.equal(harness.counts.knowledge, 1);
+  });
+
+  it('reports cache:miss in --mock execute output too', async () => {
+    await actionsExecuteCommand('plat', ACTION_ID, 'plat::key', { skipValidation: true, mock: true });
+    const out = lastJson();
+    assert.equal(out.mock, true);
+    assert.deepEqual(out._preflight, { cache: 'miss' });
+  });
+
+  it('--parallel reports _preflight per segment: same action twice → [miss, hit]', async () => {
+    // The preflight loop runs segments sequentially, so segment 1 warms the
+    // cache and segment 2 hits it — one call exercises both states.
+    process.argv = [
+      'node', 'one', 'actions', 'execute', '--parallel', '--skip-validation',
+      'plat', ACTION_ID, 'plat::key1', '-d', '{}',
+      '--', 'plat', ACTION_ID, 'plat::key2', '-d', '{}',
+    ];
+
+    await actionsExecuteParallelCommand();
+
+    const out = lastJson();
+    assert.equal(out.parallel, true);
+    assert.equal(out.results.length, 2);
+    assert.deepEqual(out.results[0]._preflight, { cache: 'miss' });
+    assert.deepEqual(out.results[1]._preflight, { cache: 'hit' });
+    assert.equal(harness.counts.knowledge, 1);
+  });
+});

--- a/src/commands/actions.ts
+++ b/src/commands/actions.ts
@@ -10,7 +10,7 @@ import {
 } from '../lib/api.js';
 import { printTable } from '../lib/table.js';
 import * as output from '../lib/output.js';
-import type { PermissionLevel, ActionKnowledgeResponse, ActionDetails } from '../lib/types.js';
+import type { PermissionLevel, ActionKnowledgeResponse, ActionDetails, SearchCacheData, SearchCacheAction } from '../lib/types.js';
 import { validateActionInput } from '../lib/validate.js';
 import { resolveActionDetails } from '../lib/action-details.js';
 import {
@@ -68,10 +68,11 @@ export async function actionsSearchCommand(
       : (options.type as 'execute' | 'knowledge' | undefined) || 'execute';
 
     const useCache = options.cache !== false;
-    const cachePath = searchCachePath(platform, query, agentType || 'knowledge');
-    const cached = useCache ? readCache<{ actions: Array<{ actionId: string; title: string; method: string; path: string }> }>(cachePath) : null;
+    const searchType = agentType || 'knowledge';
+    const cachePath = searchCachePath(platform, query, searchType);
+    const cached = useCache ? readCache<SearchCacheData>(cachePath) : null;
 
-    let cleanedActions: Array<{ actionId: string; title: string; method: string; path: string }>;
+    let cleanedActions: SearchCacheAction[];
     let cacheHit = false;
 
     if (cached && isFresh(cached)) {
@@ -103,10 +104,11 @@ export async function actionsSearchCommand(
             path: action.path,
           }));
 
-          // Write to cache
+          // Write to cache, recording the request params so `cache update`
+          // can re-run this exact search later.
           writeCache(cachePath, makeCacheEntry(
-            `${platform}_${query}_${agentType || 'knowledge'}`,
-            { actions: cleanedActions },
+            `${platform}_${query}_${searchType}`,
+            { actions: cleanedActions, platform, query, searchType },
             result.etag
           ));
         }
@@ -343,7 +345,7 @@ export async function actionsExecuteCommand(
   const api = new OneApi(apiKey, getApiBase());
 
   const spinner = output.createSpinner();
-  spinner.start('Loading action details...');
+  spinner.start('Resolving action details...');
 
   try {
     // Served from the knowledge cache when fresh — in the standard
@@ -359,7 +361,10 @@ export async function actionsExecuteCommand(
       );
     }
 
-    spinner.stop(`Action: ${actionDetails.title} [${actionDetails.method}]`);
+    spinner.stop(
+      `Action: ${actionDetails.title} [${actionDetails.method}]` +
+        (preflightCacheHit ? pc.dim(' (cached)') : '')
+    );
 
     // Parse optional JSON arguments
     const data = options.data ? parseJsonArg(options.data, '--data') : undefined;
@@ -640,6 +645,10 @@ export async function actionsExecuteParallelCommand(): Promise<void> {
   const prepared: PreparedAction[] = [];
   const errors: { segment: number; label: string; messages: string[] }[] = [];
 
+  // Dedupe the resolver's stale-fallback warning: when several segments share
+  // one stale action (network down), warn once for that action, not per segment.
+  const staleWarned = new Set<string>();
+
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i];
     const label = `${seg.platform}/${seg.actionId}`;
@@ -657,7 +666,14 @@ export async function actionsExecuteParallelCommand(): Promise<void> {
     let actionDetails: ActionDetails | undefined;
     let preflightCacheHit = false;
     try {
-      const resolved = await resolveActionDetails(api, seg.actionId, { useCache: flags.useCache });
+      const resolved = await resolveActionDetails(api, seg.actionId, {
+        useCache: flags.useCache,
+        warn: (msg) => {
+          if (staleWarned.has(seg.actionId)) return;
+          staleWarned.add(seg.actionId);
+          process.stderr.write(msg);
+        },
+      });
       actionDetails = resolved.details;
       preflightCacheHit = resolved.cacheHit;
     } catch (err) {

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -1,6 +1,7 @@
 import pc from 'picocolors';
-import { getApiKey, getApiBase } from '../lib/config.js';
-import { OneApi } from '../lib/api.js';
+import { getApiKey, getApiBase, getAccessControlFromAllSources } from '../lib/config.js';
+import { OneApi, filterByPermissions, isActionAllowed } from '../lib/api.js';
+import type { PermissionLevel, SearchCacheData } from '../lib/types.js';
 import { printTable } from '../lib/table.js';
 import * as output from '../lib/output.js';
 import {
@@ -91,6 +92,9 @@ export async function cacheUpdateAllCommand(): Promise<void> {
   }
 
   const api = new OneApi(apiKey, getApiBase());
+  const ac = getAccessControlFromAllSources();
+  const permissions: PermissionLevel = ac.permissions || 'admin';
+  const actionIds: string[] = ac.actionIds || ['*'];
   const entries = listCacheEntries();
 
   if (entries.length === 0) {
@@ -117,12 +121,38 @@ export async function cacheUpdateAllCommand(): Promise<void> {
         writeCache(e.filePath, newEntry);
         updated++;
       } else {
-        // Search entries: re-fetch based on the cached key parts
-        // Key format: platform_query_type
-        // We can't perfectly reconstruct the original query, so just refresh TTL
-        // by marking as freshly cached with existing data
-        const refreshed = { ...e.entry, cachedAt: new Date().toISOString() };
-        writeCache(e.filePath, refreshed);
+        // Search entries record the request params (platform/query/searchType)
+        // so we can re-run the exact search. Entries written before that change
+        // lack them — fall back to a timestamp bump for those.
+        const data = e.entry.data as SearchCacheData;
+        if (data?.platform && data?.query) {
+          const searchType = data.searchType ?? 'knowledge';
+          const result = await api.searchActionsWithMeta(
+            data.platform, data.query, searchType, e.entry.etag ?? undefined
+          );
+          if (result.status === 304) {
+            // Unchanged — just refresh the timestamp.
+            writeCache(e.filePath, { ...e.entry, cachedAt: new Date().toISOString() });
+          } else {
+            let actions = result.data;
+            actions = filterByPermissions(actions, permissions);
+            actions = actions.filter((a) => isActionAllowed(a.systemId, actionIds));
+            const cleaned = actions.map((a) => ({
+              actionId: a.systemId,
+              title: a.title,
+              method: a.method,
+              path: a.path,
+            }));
+            writeCache(e.filePath, makeCacheEntry(
+              e.entry.key,
+              { actions: cleaned, platform: data.platform, query: data.query, searchType },
+              result.etag
+            ));
+          }
+        } else {
+          // Legacy entry without request params — can't re-fetch; bump TTL only.
+          writeCache(e.filePath, { ...e.entry, cachedAt: new Date().toISOString() });
+        }
         updated++;
       }
     } catch (err) {

--- a/src/lib/action-details.test.ts
+++ b/src/lib/action-details.test.ts
@@ -125,7 +125,43 @@ describe('resolveActionDetails', () => {
     const result = await resolveActionDetails(api, ACTION_ID);
 
     assert.equal(result.cacheHit, true);
+    assert.equal(result.stale, true);
     assert.deepEqual(result.details, FULL_DETAILS);
+  });
+
+  it('routes the stale-fallback warning to a custom warn sink instead of stderr', async () => {
+    writeEntry(makeEntry(FULL_DETAILS, { ageSeconds: 7200, ttl: 3600 }));
+    const api = stubApi(() => { throw new Error('network down'); });
+    const warnings: string[] = [];
+
+    const result = await resolveActionDetails(api, ACTION_ID, { warn: (m) => warnings.push(m) });
+
+    assert.equal(result.stale, true);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /network unavailable/);
+  });
+
+  it('reports stale:false on every non-fallback path (fresh hit, 304, fresh fetch)', async () => {
+    // fresh hit
+    writeEntry(makeEntry(FULL_DETAILS));
+    let r = await resolveActionDetails(stubApi(() => { throw new Error('no'); }), ACTION_ID);
+    assert.equal(r.stale, false);
+
+    // 304 revalidation
+    writeEntry(makeEntry(FULL_DETAILS, { ageSeconds: 7200, ttl: 3600 }));
+    r = await resolveActionDetails(
+      stubApi(() => ({ data: null as unknown as ActionDetails, etag: 'etag-1', status: 304 })),
+      ACTION_ID
+    );
+    assert.equal(r.stale, false);
+
+    // fresh fetch (miss)
+    fs.rmSync(knowledgeCachePath(ACTION_ID), { force: true });
+    r = await resolveActionDetails(
+      stubApi(() => ({ data: FULL_DETAILS, etag: 'etag-9', status: 200 })),
+      ACTION_ID
+    );
+    assert.equal(r.stale, false);
   });
 
   it('fetches fresh with useCache:false but still writes the cache', async () => {

--- a/src/lib/action-details.ts
+++ b/src/lib/action-details.ts
@@ -32,6 +32,8 @@ export interface ResolvedActionDetails {
   details: ActionDetails;
   /** True when the details came from disk (fresh hit, 304, or stale fallback). */
   cacheHit: boolean;
+  /** True only when a (stale) cache entry was served because the network failed. */
+  stale: boolean;
   entry: CacheEntry<ActionDetails> | null;
 }
 
@@ -55,15 +57,19 @@ export function isActionDetailsEntry(
 export async function resolveActionDetails(
   api: Pick<OneApi, 'getActionDetailsWithMeta'>,
   actionId: string,
-  opts: { useCache?: boolean } = {}
+  opts: { useCache?: boolean; warn?: (msg: string) => void } = {}
 ): Promise<ResolvedActionDetails> {
   const useCache = opts.useCache !== false;
+  // Default warning sink is stderr; callers that resolve many actions (e.g.
+  // `execute --parallel`) pass a deduping sink so a shared stale action only
+  // warns once instead of once per segment.
+  const warn = opts.warn ?? ((m: string) => { process.stderr.write(m); });
   const cachePath = knowledgeCachePath(actionId);
   const raw = useCache ? readCache<unknown>(cachePath) : null;
   const cached = isActionDetailsEntry(raw) ? raw : null;
 
   if (cached && isFresh(cached)) {
-    return { details: cached.data, cacheHit: true, entry: cached };
+    return { details: cached.data, cacheHit: true, stale: false, entry: cached };
   }
 
   try {
@@ -72,18 +78,18 @@ export async function resolveActionDetails(
     if (result.status === 304 && cached) {
       cached.cachedAt = new Date().toISOString();
       writeCache(cachePath, cached);
-      return { details: cached.data, cacheHit: true, entry: cached };
+      return { details: cached.data, cacheHit: true, stale: false, entry: cached };
     }
 
     const entry = makeCacheEntry(actionId, result.data, result.etag);
     writeCache(cachePath, entry);
-    return { details: result.data, cacheHit: false, entry };
+    return { details: result.data, cacheHit: false, stale: false, entry };
   } catch (fetchError) {
     if (cached) {
-      process.stderr.write(
+      warn(
         `Warning: serving cached action details (network unavailable, cached ${formatAge(getAge(cached))} ago)\n`
       );
-      return { details: cached.data, cacheHit: true, entry: cached };
+      return { details: cached.data, cacheHit: true, stale: true, entry: cached };
     }
     throw fetchError;
   }

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -59,7 +59,7 @@ one --agent actions execute <platform> <actionId> <key> -d '{}'  # Execute it
 - \`--mock\` — Return example response without making an API call (useful for building UI against a response shape)
 - \`--skip-validation\` — Skip input validation against the action schema
 - \`--output <path>\` — Save response to a file (for binary downloads like PDFs, images, documents)
-- \`--no-cache\` — Fetch action details fresh instead of from the local cache (execution itself is never cached)
+- \`--no-cache\` — Bypass the cached action details and re-fetch them; the fresh details still refresh the cache (execution itself is never cached)
 
 The CLI validates required parameters against the action schema before executing. If you're missing a required path variable, query param, or body field, you'll get a clear error listing what's missing and which flag to use. Pass \`--skip-validation\` to bypass.
 
@@ -186,7 +186,7 @@ one --agent actions execute <platform> <actionId> <connectionKey> [options]
 - \`--mock\` — Return example response without making an API call
 - \`--skip-validation\` — Skip input validation against the action schema
 - \`--output <path>\` — Save response to a file (for binary downloads like PDFs, images, documents)
-- \`--no-cache\` — Fetch action details fresh instead of from the local cache (execution itself is never cached)
+- \`--no-cache\` — Bypass the cached action details and re-fetch them; the fresh details still refresh the cache (execution itself is never cached)
 
 Execute reuses the action details cached by \`actions knowledge\` (method, path, schema), so in the standard search → knowledge → execute flow it makes a single API call — the action being executed. The live response is never cached. In \`--agent\` mode the response includes \`"_preflight": {"cache": "hit"|"miss"}\` showing whether the lookup was served from disk.
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -239,6 +239,28 @@ export interface CacheMeta {
   fresh: boolean;
 }
 
+export interface SearchCacheAction {
+  actionId: string;
+  title: string;
+  method: string;
+  path: string;
+}
+
+/**
+ * Payload of a search cache entry. The `platform`/`query`/`searchType` fields
+ * record the exact request that produced these results so `cache update` can
+ * re-run the search and refresh the data — the entry `key`
+ * (`platform_query_type`) isn't reversibly splittable because a query may
+ * itself contain `_`. Older entries lack these fields; treat them as
+ * non-refreshable (timestamp bump only).
+ */
+export interface SearchCacheData {
+  actions: SearchCacheAction[];
+  platform?: string;
+  query?: string;
+  searchType?: 'execute' | 'knowledge';
+}
+
 export interface ApiResponseWithMeta<T> {
   data: T;
   etag: string | null;


### PR DESCRIPTION
Follow-up hardening on top of #149 (execute-preflight-cache). **Based on `feat/execute-preflight-cache`** so the diff is just the new work — will retarget to `main` once #149 merges.

## Changes

1. **Dedupe stale-fallback warning in `--parallel`** — the resolver gained a `warn` sink and a new `stale` flag on `ResolvedActionDetails`. When several segments share one stale action (network down), the parallel caller now warns once per `actionId` instead of once per segment.

2. **`cache update-all` actually re-fetches search entries** — previously search entries only got a timestamp bump because the entry key (`platform_query_type`) isn't reversibly splittable. Search cache entries now record their request params (`platform`/`query`/`searchType`, via the new `SearchCacheData` type), so the refresh re-runs the exact search and re-applies permission/allowlist filtering. Entries written before this change (no params) fall back to the old timestamp bump.

3. **Clarify `--no-cache` semantics** — flag help + guide/README/SKILL on `execute`, `search`, and `knowledge` now say it re-fetches fresh but the response still refreshes the cache (execution itself is never cached).

4. **Human-mode execute spinner** — neutral `Resolving action details...` start, with a dim `(cached)` marker on the stop line when served from disk.

5. **Lock the `_preflight` contract with a test** — new in-process integration test (`actions.preflight.test.ts`) stands up a mock server and asserts execute / `--mock` / `--parallel` agent-mode output carries `_preflight: {cache: "hit"|"miss"}`. The parallel case exercises both states in one call: two segments of the same action resolve to `[miss, hit]`.

## Verification

Each item was tested end-to-end against a mock API:
- Parallel stale dedupe: same stale action ×2 → **1** warning; 2 distinct stale actions → **2**.
- `cache update-all`: after the server's results changed, the refresh made a real search call and the cache picked up the new result (not a TTL bump). Legacy entry → bumped, no crash, no network.
- Spinner: cold → `Action: X [POST]`; warm → `Action: X [POST] (cached)`.

## Checklist
- [x] Version bump 1.45.1 + lockfile
- [x] Docs: SKILL.md, guide-content.ts, README.md, CLI help text
- [x] Tests: +2 resolver (`stale`/`warn`), +3 `_preflight` contract — **126/126 pass**; typecheck + build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)