### PR TITLE
feat(analytics): add CLI usage telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,18 @@ export ONE_NO_AUTO_UPDATE=1
 
 Run `one update` manually whenever you want to upgrade.
 
+### Telemetry
+
+The CLI collects **anonymous usage analytics** — which command was run, the CLI version, OS/arch, and whether it ran in `--agent` mode — to help us prioritize improvements. Events are keyed to your One user id so they line up with your dashboard activity. **Command arguments, inputs, connection data, and secrets are never collected** (only the command name, e.g. `actions execute`). A one-time notice is shown on first run. Events are queued locally and sent in the background, so telemetry never slows down or blocks a command.
+
+To opt out, set either:
+
+```bash
+export ONE_NO_TELEMETRY=1     # or the cross-tool standard: DO_NOT_TRACK=1
+```
+
+Telemetry is also disabled automatically when `CI=1`. You can persist the choice by adding `"telemetry": "off"` to `~/.one/config.json`.
+
 ### Project config (`.onerc`)
 
 Drop a `.onerc` file in your project root to override global settings per-project. Simple `KEY=VALUE` format; `#` for comments. Read from the current working directory (no parent lookup).

--- a/README.md
+++ b/README.md
@@ -566,12 +566,12 @@ Run `one update` manually whenever you want to upgrade.
 
 ### Telemetry
 
-The CLI collects **anonymous usage analytics** — which command was run, the CLI version, OS/arch, and whether it ran in `--agent` mode — to help us prioritize improvements. Events are keyed to your One user id so they line up with your dashboard activity. **Command arguments, inputs, connection data, and secrets are never collected** (only the command name, e.g. `actions execute`). A one-time notice is shown on first run. Events are queued locally and sent in the background, so telemetry never slows down or blocks a command.
+The CLI collects **usage analytics** — which command was run, the CLI version, OS/arch, and whether it ran in `--agent` mode — to help us prioritize improvements. Events are linked to your One account (user id, email, name, org) so they line up with your dashboard activity. **Command arguments, inputs, connection data, and secrets are never collected** (only the command name, e.g. `actions execute`). A one-time notice is shown on first run. Events are queued locally and sent in the background, so telemetry never slows down or blocks a command.
 
-To opt out, set either:
+To opt out, set any of:
 
 ```bash
-export ONE_NO_TELEMETRY=1     # or the cross-tool standard: DO_NOT_TRACK=1
+export ONE_NO_TELEMETRY=1     # also accepted: ONE_DISABLE_TELEMETRY=1, or the cross-tool standard DO_NOT_TRACK=1
 ```
 
 Telemetry is also disabled automatically when `CI=1`. You can persist the choice by adding `"telemetry": "off"` to `~/.one/config.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.45.1",
+      "version": "1.46.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,7 +147,7 @@ program.hook('preAction', (thisCommand, actionCommand) => {
   if (opts.agent) {
     setAgentMode(true);
   }
-  // Anonymous CLI usage telemetry (opt-out). Records only the command path —
+  // CLI usage telemetry (opt-out, linked to the One account). Records only the command path —
   // never args/flags. captureCommand() queues the event to disk instantly;
   // drainQueue() then sends it (plus any left over from prior runs) in the
   // background, overlapping the command. The postAction flush below stops any

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,7 @@ import { updateCommand, checkLatestVersionCached, getCurrentVersion, isNewerVers
 import { closeBackendIfCached } from './lib/memory/runtime.js';
 import { setAgentMode, isAgentMode, json as outputJson, error as outputError } from './lib/output.js';
 import { syncSkillsIfStale, forceSyncSkills, getSkillStatus } from './lib/skill-sync.js';
+import * as analytics from './lib/analytics.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json');
@@ -141,11 +142,19 @@ program
 // Fire a non-blocking version check alongside every command
 let updateCheckPromise: Promise<{ version: string; publishedAt: string | null } | null> | undefined;
 
-program.hook('preAction', (thisCommand) => {
+program.hook('preAction', (thisCommand, actionCommand) => {
   const opts = program.opts();
   if (opts.agent) {
     setAgentMode(true);
   }
+  // Anonymous CLI usage telemetry (opt-out). Records only the command path —
+  // never args/flags. captureCommand() queues the event to disk instantly;
+  // drainQueue() then sends it (plus any left over from prior runs) in the
+  // background, overlapping the command. The postAction flush below stops any
+  // in-flight request so telemetry never blocks exit. See lib/analytics.ts.
+  analytics.maybeShowTelemetryNotice();
+  analytics.captureCommand(actionCommand);
+  analytics.drainQueue();
   // Start the fetch early so it resolves by the time the command finishes
   const commandName = thisCommand.args?.[0];
   if (commandName !== 'update') {
@@ -165,6 +174,10 @@ program.hook('postAction', async () => {
   // command's work is done. Without this, `mem search` prints its JSON
   // immediately but the process hangs for ~10s before exiting.
   await closeBackendIfCached();
+
+  // Stop any in-flight telemetry send so it can't hold the process open, and
+  // persist anything undelivered for retry next run. See lib/analytics.ts.
+  analytics.flush();
 
   if (!updateCheckPromise) return;
   const info = await updateCheckPromise;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -17,7 +17,7 @@ import {
 import { isAgentMode } from './output.js';
 
 /**
- * Anonymous CLI usage analytics for the One CLI.
+ * CLI usage analytics for the One CLI (identified — keyed to the One user).
  *
  * SCOPE — deliberately narrow. Emits ONLY CLI-specific signals the backend
  * can't see: which commands run, agent vs human, on which CLI version/OS. It
@@ -270,7 +270,7 @@ export function maybeShowTelemetryNotice(): void {
   markTelemetryNoticeShown();
   process.stderr.write(
     pc.dim(
-      'One CLI collects anonymous usage analytics (which commands run) to improve the product.\n' +
+      'One CLI collects usage analytics (which commands run, linked to your One account) to improve the product.\n' +
         'No arguments, inputs, or secrets are ever collected. Opt out anytime with ONE_NO_TELEMETRY=1.\n',
     ),
   );

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,277 @@
+import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
+import type { Command } from 'commander';
+import pc from 'picocolors';
+import {
+  readConfig,
+  getApiKey,
+  getWhoAmI,
+  getDeviceId,
+  getEnvFromApiKey,
+  telemetryNoticeShown,
+  markTelemetryNoticeShown,
+  appendAnalyticsQueue,
+  readAnalyticsQueue,
+  writeAnalyticsQueue,
+} from './config.js';
+import { isAgentMode } from './output.js';
+
+/**
+ * Anonymous CLI usage analytics for the One CLI.
+ *
+ * SCOPE — deliberately narrow. Emits ONLY CLI-specific signals the backend
+ * can't see: which commands run, agent vs human, on which CLI version/OS. It
+ * does NOT re-emit domain events — when the CLI calls pica-v2 (connect a
+ * platform, execute an action, etc.) pica-v2 already emits those server-side,
+ * so emitting them here too would double-count.
+ *
+ * TRANSPORT — PostHog's public HTTP capture API with the project's PUBLIC
+ * ingest key (write-only; safe to embed, like the dashboard's
+ * NEXT_PUBLIC_POSTHOG_KEY). Events are keyed on the One user id, so CLI
+ * activity unifies onto the same PostHog person as the dashboard.
+ *
+ * DELIVERY — a CLI process is short-lived and a network round-trip is ~1s, so
+ * we never make the user wait: each event is written to a tiny on-disk queue
+ * instantly (sync), the queue is sent in the background overlapping the
+ * command, in-flight requests are aborted at exit (so they can't hold the
+ * process open), and anything not confirmed delivered is retried on the next
+ * run. A stable `$insert_id` lets PostHog dedupe the occasional re-send. Net:
+ * zero added latency, no lost events. (This is the standard CLI-telemetry
+ * pattern used by tools like Next.js.)
+ *
+ * PRIVACY — on by default (opt-out), per CLI norms. We never send positional
+ * args or flag values (they can contain emails, queries, payloads, secrets) —
+ * only the command path. Disabled by ONE_NO_TELEMETRY / DO_NOT_TRACK / CI /
+ * `telemetry: 'off'` in config (opting out also drops any queued events).
+ */
+
+const require = createRequire(import.meta.url);
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+
+/**
+ * PUBLIC PostHog project (ingest) key for the "Pica Prod" project. Write-only:
+ * it can send events but never read data or settings — which is why it's safe
+ * to ship in a client, exactly as the dashboard ships its public
+ * `NEXT_PUBLIC_POSTHOG_KEY`. (The secret read/write key is the `phx_…`
+ * personal key, which is NOT in this codebase.) Both sandbox (test keys) and
+ * production (live keys) report here, mirroring the dashboard; the environment
+ * is recorded as the `env` property, not a separate destination. Overridable
+ * via env for internal testing.
+ */
+const DEFAULT_POSTHOG_KEY = 'phc_a9ok4w0uxiZcVoSWOISIlin85lHMXQD3vWPaYnuRlRV';
+
+interface QueuedEvent {
+  event: string;
+  distinct_id: string;
+  properties: Record<string, unknown>;
+  timestamp: string;
+}
+
+/** Abort controllers for in-flight sends, so flush() can cancel them at exit. */
+const inFlight = new Set<AbortController>();
+/** `$insert_id`s confirmed delivered this run (so flush() drops them from the queue). */
+const delivered = new Set<string>();
+
+function posthogHost(): string {
+  return process.env.ONE_POSTHOG_HOST || DEFAULT_POSTHOG_HOST;
+}
+function posthogKey(): string {
+  return process.env.ONE_POSTHOG_KEY || DEFAULT_POSTHOG_KEY;
+}
+
+function cliVersion(): string {
+  try {
+    return (require('../package.json') as { version: string }).version;
+  } catch {
+    return 'unknown';
+  }
+}
+
+function envName(): 'live' | 'test' {
+  const key = getApiKey();
+  return key ? getEnvFromApiKey(key) : 'live';
+}
+
+function isOn(value: string | undefined): boolean {
+  return value === '1' || value === 'true';
+}
+
+/** Opt-in stderr tracing for troubleshooting telemetry delivery. */
+function debugLog(message: string): void {
+  if (isOn(process.env.ONE_ANALYTICS_DEBUG)) {
+    process.stderr.write(`[analytics] ${message}\n`);
+  }
+}
+
+/**
+ * Telemetry is on by default; disabled when any opt-out signal is present.
+ * Mirrors the house `ONE_NO_AUTO_UPDATE` pattern, honors the cross-tool
+ * `DO_NOT_TRACK` standard, and auto-disables under CI (no human to consent).
+ */
+export function isTelemetryDisabled(): boolean {
+  if (isOn(process.env.ONE_NO_TELEMETRY) || isOn(process.env.ONE_DISABLE_TELEMETRY)) return true;
+  if (isOn(process.env.DO_NOT_TRACK)) return true;
+  if (isOn(process.env.CI)) return true;
+  if (readConfig()?.telemetry === 'off') return true;
+  return false;
+}
+
+function distinctId(): string {
+  return getWhoAmI()?.user?.id ?? getDeviceId();
+}
+
+function baseProperties(): Record<string, unknown> {
+  return {
+    $lib: 'one-cli',
+    cli_version: cliVersion(),
+    agent_mode: isAgentMode(),
+    env: envName(),
+    os: process.platform,
+    arch: process.arch,
+    node_version: process.versions.node,
+  };
+}
+
+/**
+ * Person properties that unify the CLI user with their dashboard profile.
+ * Only attached when we have an authenticated identity.
+ */
+function personSet(): Record<string, unknown> | undefined {
+  const whoami = getWhoAmI();
+  if (!whoami?.user) return undefined;
+  const set: Record<string, unknown> = {};
+  if (whoami.user.email) set.email = whoami.user.email;
+  if (whoami.user.name) set.name = whoami.user.name;
+  if (whoami.organization?.id) set.organization_id = whoami.organization.id;
+  return Object.keys(set).length ? set : undefined;
+}
+
+/** Fire one queued event to PostHog (best-effort); mark it delivered on success. */
+function send(item: QueuedEvent): void {
+  const insertId = item.properties.$insert_id as string | undefined;
+  const controller = new AbortController();
+  inFlight.add(controller);
+  void (async () => {
+    try {
+      const res = await fetch(`${posthogHost()}/i/v0/e/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: posthogKey(),
+          event: item.event,
+          distinct_id: item.distinct_id,
+          properties: item.properties,
+          timestamp: item.timestamp,
+        }),
+        signal: controller.signal,
+      });
+      if (res.ok && insertId) delivered.add(insertId);
+      debugLog(`"${item.event}" -> HTTP ${res.status}${res.ok ? '' : ' (retry next run)'}`);
+    } catch (err) {
+      // Best-effort: a tracking failure must never affect the command; the
+      // event stays queued and is retried on the next run.
+      debugLog(`"${item.event}" not sent: ${err instanceof Error ? err.message : String(err)} (retry next run)`);
+    } finally {
+      inFlight.delete(controller);
+    }
+  })();
+}
+
+/**
+ * Record a CLI usage event: write it to the on-disk queue instantly (sync, so
+ * it survives an immediate process exit). Sending is done by drainQueue().
+ * Never throws, never blocks. No-op when telemetry is disabled.
+ */
+export function capture(event: string, properties: Record<string, unknown> = {}): void {
+  if (isTelemetryDisabled()) {
+    debugLog(`disabled — skipping "${event}"`);
+    return;
+  }
+  const props: Record<string, unknown> = { ...baseProperties(), ...properties, $insert_id: randomUUID() };
+  const set = personSet();
+  if (set) props.$set = set;
+  const item: QueuedEvent = {
+    event,
+    distinct_id: distinctId(),
+    properties: props,
+    timestamp: new Date().toISOString(),
+  };
+  appendAnalyticsQueue(JSON.stringify(item));
+}
+
+/**
+ * Emit the "CLI Command Run" usage event for the command about to execute.
+ * Records only the command PATH (e.g. "actions execute") — never positional
+ * args or flag values, which can contain PII or secrets.
+ */
+export function captureCommand(command: Command): void {
+  capture('CLI Command Run', { command: commandPath(command) });
+}
+
+function commandPath(command: Command): string {
+  const parts: string[] = [];
+  let current: Command | null | undefined = command;
+  while (current && current.name() && current.name() !== 'one') {
+    parts.unshift(current.name());
+    current = current.parent;
+  }
+  return parts.join(' ') || command.name();
+}
+
+/**
+ * Start sending every queued event (this run's + any left over from prior
+ * runs) in the background. Called once in preAction so the requests overlap
+ * the command's own work. Opting out drops the backlog instead of sending it.
+ */
+export function drainQueue(): void {
+  if (isTelemetryDisabled()) {
+    writeAnalyticsQueue([]);
+    return;
+  }
+  for (const line of readAnalyticsQueue()) {
+    try {
+      const item = JSON.parse(line) as QueuedEvent;
+      if (item?.properties?.$insert_id) send(item);
+    } catch {
+      // Skip malformed lines; flush() prunes them from the queue.
+    }
+  }
+}
+
+/**
+ * Called from postAction. Abort any still-in-flight sends so a pending request
+ * can't hold the process open (and the user waiting) on the network, then
+ * rewrite the queue to keep only events NOT yet confirmed delivered — those
+ * are retried on the next run.
+ */
+export function flush(): void {
+  for (const controller of inFlight) controller.abort();
+
+  const remaining = readAnalyticsQueue().filter((line) => {
+    try {
+      const id = (JSON.parse(line) as QueuedEvent).properties?.$insert_id as string | undefined;
+      return id ? !delivered.has(id) : false;
+    } catch {
+      return false; // drop malformed lines
+    }
+  });
+  writeAnalyticsQueue(remaining);
+}
+
+/**
+ * One-time, opt-out disclosure printed to stderr (never stdout, so it can't
+ * corrupt `--agent` JSON or piped output). Shown once per machine, and never
+ * in agent mode or when telemetry is disabled.
+ */
+export function maybeShowTelemetryNotice(): void {
+  if (isTelemetryDisabled() || isAgentMode()) return;
+  if (telemetryNoticeShown()) return;
+  markTelemetryNoticeShown();
+  process.stderr.write(
+    pc.dim(
+      'One CLI collects anonymous usage analytics (which commands run) to improve the product.\n' +
+        'No arguments, inputs, or secrets are ever collected. Opt out anytime with ONE_NO_TELEMETRY=1.\n',
+    ),
+  );
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -407,7 +407,7 @@ function deviceIdFile(): string { return path.join(configDir(), 'device-id'); }
 function telemetryNoticeFile(): string { return path.join(configDir(), '.telemetry-notice'); }
 
 /**
- * Stable, anonymous per-install id used as the analytics distinct_id before
+ * Stable, random per-install id used as the analytics distinct_id before
  * the user authenticates (once logged in we key on the One user id instead,
  * so CLI + dashboard events unify on the same person). Stored once in
  * ~/.one/device-id. Best-effort: if the file can't be written we still return

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { randomUUID } from 'node:crypto';
 import type { Config, AccessControlSettings, PermissionLevel, WhoAmIResponse } from './types.js';
 import type { OneApi } from './api.js';
 
@@ -398,4 +399,78 @@ export async function ensureWhoAmI(api: OneApi): Promise<WhoAmIResponse | null> 
 
 export function getEnvFromApiKey(apiKey: string): 'live' | 'test' {
   return apiKey.startsWith('sk_test_') ? 'test' : 'live';
+}
+
+// ── Analytics helpers (~/.one markers, no PII) ───────────────────────
+
+function deviceIdFile(): string { return path.join(configDir(), 'device-id'); }
+function telemetryNoticeFile(): string { return path.join(configDir(), '.telemetry-notice'); }
+
+/**
+ * Stable, anonymous per-install id used as the analytics distinct_id before
+ * the user authenticates (once logged in we key on the One user id instead,
+ * so CLI + dashboard events unify on the same person). Stored once in
+ * ~/.one/device-id. Best-effort: if the file can't be written we still return
+ * a usable id for this process.
+ */
+export function getDeviceId(): string {
+  try {
+    const existing = fs.readFileSync(deviceIdFile(), 'utf-8').trim();
+    if (existing) return existing;
+  } catch { /* not created yet */ }
+
+  const id = randomUUID();
+  try {
+    if (!fs.existsSync(configDir())) fs.mkdirSync(configDir(), { mode: 0o700 });
+    fs.writeFileSync(deviceIdFile(), id, { mode: 0o600 });
+  } catch { /* best-effort; fall through with the in-memory id */ }
+  return id;
+}
+
+/** Whether the one-time telemetry disclosure has already been shown. */
+export function telemetryNoticeShown(): boolean {
+  return fs.existsSync(telemetryNoticeFile());
+}
+
+/** Record that the one-time telemetry disclosure has been shown. */
+export function markTelemetryNoticeShown(): void {
+  try {
+    if (!fs.existsSync(configDir())) fs.mkdirSync(configDir(), { mode: 0o700 });
+    fs.writeFileSync(telemetryNoticeFile(), new Date().toISOString(), { mode: 0o600 });
+  } catch { /* best-effort */ }
+}
+
+// Bounded on-disk queue of analytics events not yet confirmed delivered. A
+// CLI process is short-lived and analytics latency is ~1s, so we persist
+// events instantly (sync) and deliver them opportunistically / on a later
+// run — telemetry never blocks a command and nothing is lost when the process
+// exits before a request completes. JSONL, one event per line.
+function analyticsQueueFile(): string { return path.join(configDir(), '.analytics-queue.jsonl'); }
+const ANALYTICS_QUEUE_MAX = 500;
+
+export function appendAnalyticsQueue(line: string): void {
+  try {
+    if (!fs.existsSync(configDir())) fs.mkdirSync(configDir(), { mode: 0o700 });
+    fs.appendFileSync(analyticsQueueFile(), `${line}\n`, { mode: 0o600 });
+  } catch { /* best-effort */ }
+}
+
+export function readAnalyticsQueue(): string[] {
+  try {
+    return fs.readFileSync(analyticsQueueFile(), 'utf-8').split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** Replace the queue with `lines` (capped, newest kept); deletes it when empty. */
+export function writeAnalyticsQueue(lines: string[]): void {
+  try {
+    if (lines.length === 0) {
+      fs.rmSync(analyticsQueueFile(), { force: true });
+      return;
+    }
+    if (!fs.existsSync(configDir())) fs.mkdirSync(configDir(), { mode: 0o700 });
+    fs.writeFileSync(analyticsQueueFile(), `${lines.slice(-ANALYTICS_QUEUE_MAX).join('\n')}\n`, { mode: 0o600 });
+  } catch { /* best-effort */ }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,12 @@ export interface Config {
    * and the memory module).
    */
   memory?: unknown;
+  /**
+   * Analytics opt-out. When `'off'`, the CLI emits no usage telemetry. The
+   * primary opt-out is the `ONE_NO_TELEMETRY` env var / `DO_NOT_TRACK`; this
+   * field persists the choice in config. See lib/analytics.ts.
+   */
+  telemetry?: 'off';
 }
 
 export interface ConnectionsResponse {


### PR DESCRIPTION
Emit a single "CLI Command Run" event per invocation (command path, cli_version, agent_mode, env, os) to PostHog, keyed on the One user id so CLI activity unifies with the same person as the dashboard and backend events.

Design:
- Queue-on-disk + background send + abort-at-exit + retry-next-run with a stable $insert_id for dedup. Telemetry never blocks a command and never loses events (the standard short-lived-CLI pattern).
- Does NOT re-emit domain events (connection.created, passthrough, etc.) — pica-v2 emits those server-side, so there is no double-counting.
- Privacy: on by default with a one-time disclosure; opt out via ONE_NO_TELEMETRY / DO_NOT_TRACK / CI=1 / config telemetry:"off". Only the command name is recorded — never args, inputs, connection data, or secrets.
- Transport: public, write-only phc_ project key (same one the dashboard embeds), overridable via ONE_POSTHOG_KEY/ONE_POSTHOG_HOST for testing.

Files: src/lib/analytics.ts (new), src/lib/config.ts (queue + device-id + notice helpers), src/lib/types.ts (telemetry opt-out field), src/cli.ts (preAction/postAction wiring). Adds a README telemetry section; version 1.46.0.