### PR TITLE
feat(telemetry): roll up CLI usage to cap PostHog event volume (v1.47.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ Run `one update` manually whenever you want to upgrade.
 
 ### Telemetry
 
-The CLI collects **usage analytics** — which command was run, the CLI version, OS/arch, and whether it ran in `--agent` mode — to help us prioritize improvements. Events are linked to your One account (user id, email, name, org) so they line up with your dashboard activity. **Command arguments, inputs, connection data, and secrets are never collected** (only the command name, e.g. `actions execute`). A one-time notice is shown on first run. Events are queued locally and sent in the background, so telemetry never slows down or blocks a command.
+The CLI collects **usage analytics** — which command was run, the CLI version, OS/arch, and whether it ran in `--agent` mode — to help us prioritize improvements. Events are linked to your One account (user id, email, name, org) so they line up with your dashboard activity. **Command arguments, inputs, connection data, and secrets are never collected** (only the command name, e.g. `actions execute`). A one-time notice is shown on first run. Commands are aggregated locally and sent as periodic, batched roll-ups in the background, so telemetry never slows down or blocks a command (and stays lightweight even under heavy automation).
 
 To opt out, set any of:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.46.0",
+      "version": "1.47.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,12 +148,15 @@ program.hook('preAction', (thisCommand, actionCommand) => {
     setAgentMode(true);
   }
   // CLI usage telemetry (opt-out, linked to the One account). Records only the command path —
-  // never args/flags. captureCommand() queues the event to disk instantly;
-  // drainQueue() then sends it (plus any left over from prior runs) in the
-  // background, overlapping the command. The postAction flush below stops any
-  // in-flight request so telemetry never blocks exit. See lib/analytics.ts.
+  // never args/flags. recordCommand() appends the command to a local log and
+  // periodically rolls it up into ONE aggregated event, keeping PostHog volume
+  // (and the bill) bounded no matter how many commands an agent fires;
+  // drainQueue() then sends any due rollups (plus anything left from prior
+  // runs) in the background, overlapping the command. The postAction flush
+  // below stops any in-flight request so telemetry never blocks exit. See
+  // lib/analytics.ts.
   analytics.maybeShowTelemetryNotice();
-  analytics.captureCommand(actionCommand);
+  analytics.recordCommand(actionCommand);
   analytics.drainQueue();
   // Start the fetch early so it resolves by the time the command finishes
   const commandName = thisCommand.args?.[0];
@@ -175,8 +178,10 @@ program.hook('postAction', async () => {
   // immediately but the process hangs for ~10s before exiting.
   await closeBackendIfCached();
 
-  // Stop any in-flight telemetry send so it can't hold the process open, and
-  // persist anything undelivered for retry next run. See lib/analytics.ts.
+  // Flush any usage rollup that came due during the command, then stop any
+  // in-flight telemetry send so it can't hold the process open, persisting
+  // anything undelivered for retry next run. See lib/analytics.ts.
+  analytics.flushUsageRollups();
   analytics.flush();
 
   if (!updateCheckPromise) return;

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Command } from 'commander';
+
+import { recordCommand, flushUsageRollups } from './analytics.js';
+import { appendUsageLog, readUsageLog, readAnalyticsQueue } from './config.js';
+
+// These tests exercise the REAL rollup code against REAL files: HOME is
+// sandboxed to a temp dir so all reads/writes land under <tmp>/.one (config.ts
+// resolves home-rooted paths lazily, so flipping HOME is enough). Emitted
+// rollups are read back from the actual on-disk analytics send-queue.
+
+interface RollupEvent {
+  event: string;
+  distinct_id: string;
+  timestamp: string;
+  properties: {
+    command_count: number;
+    by_command: Record<string, number>;
+    agent_count: number;
+    human_count: number;
+    window_start: string;
+    window_end: string;
+  };
+}
+
+const WINDOW_MS = 5 * 60 * 1000;
+
+/** Parse the analytics send-queue and return only the rollup events. */
+function emittedRollups(): RollupEvent[] {
+  return readAnalyticsQueue()
+    .map((l) => JSON.parse(l) as RollupEvent)
+    .filter((e) => e.event === 'CLI Usage Rollup');
+}
+
+/** One usage-log line with controllable timestamp / command / agent / identity. */
+function logEntry(opts: { did: string; ts?: number; command?: string; agent?: boolean }): string {
+  return JSON.stringify({
+    ts: opts.ts ?? Date.now(),
+    command: opts.command ?? 'actions execute',
+    agent: opts.agent ?? false,
+    did: opts.did,
+  });
+}
+
+/** A minimal commander-like Command whose path() resolves to `pathStr`. */
+function fakeCommand(pathStr: string): Command {
+  let node = { name: () => 'one', parent: null } as unknown as Command;
+  for (const part of pathStr.split(' ')) {
+    node = { name: () => part, parent: node } as unknown as Command;
+  }
+  return node;
+}
+
+describe('CLI usage rollups', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  const orig: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ['HOME', 'CI', 'ONE_NO_TELEMETRY', 'ONE_DISABLE_TELEMETRY', 'DO_NOT_TRACK']) {
+      orig[k] = process.env[k];
+    }
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-cli-rollup-test-'));
+    const home = path.join(tmpDir, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    process.env.HOME = home;
+    process.chdir(home); // isolate from any .onerc in the dev's cwd
+    // Telemetry must be ENABLED to test the emit path.
+    delete process.env.CI;
+    delete process.env.ONE_NO_TELEMETRY;
+    delete process.env.ONE_DISABLE_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    for (const [k, v] of Object.entries(orig)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('never misses a user and keeps exact per-user counts', () => {
+    const old = Date.now() - WINDOW_MS - 1000; // aged out → all batches are due
+    const expected = new Map<string, number>();
+    for (let u = 0; u < 50; u++) {
+      const did = `user-${u}`;
+      const n = (u % 13) + 1; // 1..13 commands each (covers light + heavier)
+      for (let i = 0; i < n; i++) appendUsageLog(logEntry({ did, ts: old }));
+      expected.set(did, n);
+    }
+
+    flushUsageRollups();
+
+    const totals = new Map<string, number>();
+    for (const r of emittedRollups()) {
+      totals.set(r.distinct_id, (totals.get(r.distinct_id) ?? 0) + r.properties.command_count);
+    }
+    assert.equal(totals.size, expected.size, 'every user present, none extra');
+    for (const [did, n] of expected) {
+      assert.equal(totals.get(did), n, `user ${did} must have exact count ${n}`);
+    }
+    assert.equal(readUsageLog().length, 0, 'log fully drained');
+  });
+
+  it('aggregates a heavy burst into one exact rollup (no per-command flood)', () => {
+    const did = 'whale';
+    const N = 1234;
+    for (let i = 0; i < N; i++) appendUsageLog(logEntry({ did, agent: true }));
+
+    flushUsageRollups({ force: true });
+
+    const rollups = emittedRollups();
+    const total = rollups.reduce((s, r) => s + r.properties.command_count, 0);
+    assert.equal(total, N, 'exact total preserved');
+    assert.ok(rollups.length <= 3, `far fewer events than commands (got ${rollups.length})`);
+    const byCmdTotal = rollups.reduce(
+      (s, r) => s + Object.values(r.properties.by_command).reduce((a, b) => a + b, 0),
+      0,
+    );
+    assert.equal(byCmdTotal, N, 'by_command sums to the exact total');
+  });
+
+  it('flushes once a batch hits the size cap, even without force', () => {
+    const did = 'busy';
+    for (let i = 0; i < 600; i++) appendUsageLog(logEntry({ did })); // > MAX_BATCH (500), recent ts
+    flushUsageRollups();
+    const r = emittedRollups();
+    assert.equal(r.length, 1);
+    assert.equal(r[0].properties.command_count, 600);
+    assert.equal(readUsageLog().length, 0);
+  });
+
+  it('does NOT flush a fresh, small, current-user batch (real batching)', () => {
+    const did = 'regular';
+    for (let i = 0; i < 3; i++) appendUsageLog(logEntry({ did })); // recent
+    flushUsageRollups();
+    assert.equal(emittedRollups().length, 0, 'nothing emitted yet');
+    assert.equal(readUsageLog().length, 3, 'kept for the next window');
+  });
+
+  it('flushes a batch once it ages past the window', () => {
+    const did = 'regular';
+    const old = Date.now() - WINDOW_MS - 1000;
+    for (let i = 0; i < 3; i++) appendUsageLog(logEntry({ did, ts: old }));
+    flushUsageRollups();
+    const r = emittedRollups();
+    assert.equal(r.length, 1);
+    assert.equal(r[0].properties.command_count, 3);
+    assert.equal(readUsageLog().length, 0);
+  });
+
+  it('records exact per-command and agent/human breakdown', () => {
+    const did = 'mixed';
+    const old = Date.now() - WINDOW_MS - 1000;
+    appendUsageLog(logEntry({ did, ts: old, command: 'actions execute', agent: true }));
+    appendUsageLog(logEntry({ did, ts: old, command: 'actions execute', agent: true }));
+    appendUsageLog(logEntry({ did, ts: old, command: 'auth login', agent: false }));
+    flushUsageRollups();
+    const [r] = emittedRollups();
+    assert.equal(r.properties.command_count, 3);
+    assert.deepEqual(r.properties.by_command, { 'actions execute': 2, 'auth login': 1 });
+    assert.equal(r.properties.agent_count, 2);
+    assert.equal(r.properties.human_count, 1);
+  });
+
+  it('splits rollups by identity when a login happens mid-batch', () => {
+    appendUsageLog(logEntry({ did: 'device-abc', command: 'auth login' }));
+    appendUsageLog(logEntry({ did: 'user-123' }));
+    appendUsageLog(logEntry({ did: 'user-123' }));
+    // current identity = user-123 (last entry). The superseded device batch flushes
+    // immediately; the current small/fresh batch is kept.
+    flushUsageRollups();
+    const r = emittedRollups();
+    assert.equal(r.length, 1);
+    assert.equal(r[0].distinct_id, 'device-abc');
+    assert.equal(r[0].properties.command_count, 1);
+    assert.equal(readUsageLog().length, 2, 'current identity batch kept');
+  });
+
+  it('recordCommand captures the very first command immediately (light user never missed)', () => {
+    recordCommand(fakeCommand('actions execute'));
+    const r = emittedRollups();
+    assert.equal(r.length, 1, 'first command flushes immediately');
+    assert.equal(r[0].properties.command_count, 1);
+    assert.equal(r[0].properties.by_command['actions execute'], 1);
+  });
+
+  it('recordCommand batches later same-day commands instead of one-per-command', () => {
+    recordCommand(fakeCommand('actions execute')); // first-touch → 1 event
+    recordCommand(fakeCommand('actions execute')); // batched
+    recordCommand(fakeCommand('auth login')); // batched
+    assert.equal(emittedRollups().length, 1, 'only the first-touch event so far');
+    assert.equal(readUsageLog().length, 2, 'commands 2–3 wait in the log');
+  });
+
+  it('emits nothing and drops the backlog when telemetry is disabled', () => {
+    appendUsageLog(logEntry({ did: 'x' }));
+    process.env.ONE_NO_TELEMETRY = '1';
+    flushUsageRollups({ force: true });
+    assert.equal(emittedRollups().length, 0);
+    assert.equal(readUsageLog().length, 0, 'backlog dropped on opt-out');
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -13,6 +13,11 @@ import {
   appendAnalyticsQueue,
   readAnalyticsQueue,
   writeAnalyticsQueue,
+  appendUsageLog,
+  readUsageLog,
+  writeUsageLog,
+  readUsageState,
+  writeUsageState,
 } from './config.js';
 import { isAgentMode } from './output.js';
 
@@ -29,6 +34,13 @@ import { isAgentMode } from './output.js';
  * ingest key (write-only; safe to embed, like the dashboard's
  * NEXT_PUBLIC_POSTHOG_KEY). Events are keyed on the One user id, so CLI
  * activity unifies onto the same PostHog person as the dashboard.
+ *
+ * AGGREGATION — one event per command would let a single agent loop emit tens
+ * of thousands of events a day and blow our PostHog bill. Instead the CLI
+ * appends each command to a local log and rolls it up into ONE "CLI Usage
+ * Rollup" event with EXACT counts, flushed at most ~once per 5 min of activity
+ * per user (see recordCommand / flushUsageRollups). The first command of each
+ * day flushes immediately, so no user is ever missed — even a one-and-done try.
  *
  * DELIVERY — a CLI process is short-lived and a network round-trip is ~1s, so
  * we never make the user wait: each event is written to a tiny on-disk queue
@@ -183,30 +195,140 @@ function send(item: QueuedEvent): void {
  * it survives an immediate process exit). Sending is done by drainQueue().
  * Never throws, never blocks. No-op when telemetry is disabled.
  */
-export function capture(event: string, properties: Record<string, unknown> = {}): void {
+export function capture(
+  event: string,
+  properties: Record<string, unknown> = {},
+  opts: { distinctId?: string; timestamp?: string } = {},
+): void {
   if (isTelemetryDisabled()) {
     debugLog(`disabled — skipping "${event}"`);
     return;
   }
+  const did = opts.distinctId ?? distinctId();
   const props: Record<string, unknown> = { ...baseProperties(), ...properties, $insert_id: randomUUID() };
-  const set = personSet();
-  if (set) props.$set = set;
+  // Person props belong only to the *current* user; never tag a rollup for a
+  // previous login (distinct_id ≠ current) with the new user's email/name.
+  if (did === distinctId()) {
+    const set = personSet();
+    if (set) props.$set = set;
+  }
   const item: QueuedEvent = {
     event,
-    distinct_id: distinctId(),
+    distinct_id: did,
     properties: props,
-    timestamp: new Date().toISOString(),
+    timestamp: opts.timestamp ?? new Date().toISOString(),
   };
   appendAnalyticsQueue(JSON.stringify(item));
 }
 
+/** Flush a rollup at most ~once per this window of activity per user. */
+const ROLLUP_WINDOW_MS = 5 * 60 * 1000;
+/** ...or after this many commands accumulate (burst safety cap). */
+const ROLLUP_MAX_BATCH = 500;
+
+interface UsageEntry { ts: number; command: string; agent: boolean; did: string }
+
+/** UTC calendar day (YYYY-MM-DD) of a timestamp — the first-touch boundary. */
+function utcDay(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
 /**
- * Emit the "CLI Command Run" usage event for the command about to execute.
- * Records only the command PATH (e.g. "actions execute") — never positional
- * args or flag values, which can contain PII or secrets.
+ * Record the command about to run for usage analytics. Appends the command
+ * PATH (e.g. "actions execute") — never args/flags — to the local rollup log
+ * (instant, sync), then flushes any due rollups. The first command of the day
+ * flushes immediately so a user is captured even if they run the CLI once and
+ * never again. Never throws, never blocks. No-op when telemetry is disabled.
  */
-export function captureCommand(command: Command): void {
-  capture('CLI Command Run', { command: commandPath(command) });
+export function recordCommand(command: Command): void {
+  if (isTelemetryDisabled()) {
+    writeUsageLog([]);
+    return;
+  }
+  const did = distinctId();
+  const entry: UsageEntry = { ts: Date.now(), command: commandPath(command), agent: isAgentMode(), did };
+  appendUsageLog(JSON.stringify(entry));
+
+  const today = utcDay(entry.ts);
+  const state = readUsageState();
+  // First command today (or first ever, or right after a login) → flush now so
+  // the user is captured immediately and can never be missed.
+  const firstTouch = state.lastDay !== today || state.distinctId !== did;
+  flushUsageRollups({ force: firstTouch });
+  if (firstTouch) writeUsageState({ lastDay: today, distinctId: did });
+}
+
+/**
+ * Aggregate the local usage log into "CLI Usage Rollup" events and enqueue the
+ * ones that are due — a batch is due when forced (first-touch / exit drain),
+ * the window elapsed, it hit the size cap, or a newer login superseded it.
+ * Counts are EXACT (no sampling). Entries not yet due are kept for the next run.
+ */
+export function flushUsageRollups(opts: { force?: boolean } = {}): void {
+  if (isTelemetryDisabled()) {
+    writeUsageLog([]);
+    return;
+  }
+  const entries: UsageEntry[] = [];
+  for (const line of readUsageLog()) {
+    try {
+      const e = JSON.parse(line) as UsageEntry;
+      if (e && typeof e.ts === 'number' && typeof e.command === 'string' && typeof e.did === 'string') {
+        entries.push(e);
+      }
+    } catch {
+      // skip a malformed line
+    }
+  }
+  if (entries.length === 0) {
+    writeUsageLog([]);
+    return;
+  }
+
+  const currentDid = entries[entries.length - 1].did;
+  const now = Date.now();
+  // Group by distinct_id (a login mid-log yields one rollup per identity).
+  const groups = new Map<string, UsageEntry[]>();
+  for (const e of entries) {
+    const g = groups.get(e.did);
+    if (g) g.push(e);
+    else groups.set(e.did, [e]);
+  }
+
+  const kept: UsageEntry[] = [];
+  for (const [did, group] of groups) {
+    const due =
+      opts.force === true ||
+      did !== currentDid || // a superseded login's batch — flush it now
+      group.length >= ROLLUP_MAX_BATCH ||
+      now - group[0].ts >= ROLLUP_WINDOW_MS;
+    if (due) emitRollup(did, group);
+    else kept.push(...group);
+  }
+  writeUsageLog(kept.map((e) => JSON.stringify(e)));
+}
+
+/** Build + enqueue one "CLI Usage Rollup" event carrying exact counts for a batch. */
+function emitRollup(did: string, group: UsageEntry[]): void {
+  const byCommand: Record<string, number> = {};
+  let agentCount = 0;
+  for (const e of group) {
+    byCommand[e.command] = (byCommand[e.command] ?? 0) + 1;
+    if (e.agent) agentCount += 1;
+  }
+  capture(
+    'CLI Usage Rollup',
+    {
+      command_count: group.length,
+      by_command: byCommand,
+      agent_count: agentCount,
+      human_count: group.length - agentCount,
+      window_start: new Date(group[0].ts).toISOString(),
+      window_end: new Date(group[group.length - 1].ts).toISOString(),
+    },
+    { distinctId: did, timestamp: new Date(group[group.length - 1].ts).toISOString() },
+  );
+  debugLog(`rollup — ${group.length} command(s) for ${did}`);
 }
 
 function commandPath(command: Command): string {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -474,3 +474,57 @@ export function writeAnalyticsQueue(lines: string[]): void {
     fs.writeFileSync(analyticsQueueFile(), `${lines.slice(-ANALYTICS_QUEUE_MAX).join('\n')}\n`, { mode: 0o600 });
   } catch { /* best-effort */ }
 }
+
+// Append-only log of CLI commands awaiting roll-up. To avoid flooding PostHog
+// (and its bill) with one event per command, the CLI appends each command here
+// and periodically emits ONE aggregated "CLI Usage Rollup" event with exact
+// counts. Append-only JSONL is crash- and concurrency-safe — parallel CLI
+// invocations can't corrupt it (same property the analytics queue relies on).
+function usageLogFile(): string { return path.join(configDir(), '.cli-usage-log.jsonl'); }
+function usageStateFile(): string { return path.join(configDir(), '.cli-usage-state.json'); }
+const USAGE_LOG_MAX = 5000; // hard safety cap; the flush triggers keep it far below this
+
+export function appendUsageLog(line: string): void {
+  try {
+    if (!fs.existsSync(configDir())) fs.mkdirSync(configDir(), { mode: 0o700 });
+    fs.appendFileSync(usageLogFile(), `${line}\n`, { mode: 0o600 });
+  } catch { /* best-effort */ }
+}
+
+export function readUsageLog(): string[] {
+  try {
+    return fs.readFileSync(usageLogFile(), 'utf-8').split('\n').filter(Boolean).slice(-USAGE_LOG_MAX);
+  } catch {
+    return [];
+  }
+}
+
+/** Replace the usage log with `lines` (capped, newest kept); deletes it when empty. */
+export function writeUsageLog(lines: string[]): void {
+  try {
+    if (lines.length === 0) {
+      fs.rmSync(usageLogFile(), { force: true });
+      return;
+    }
+    if (!fs.existsSync(configDir())) fs.mkdirSync(configDir(), { mode: 0o700 });
+    fs.writeFileSync(usageLogFile(), `${lines.slice(-USAGE_LOG_MAX).join('\n')}\n`, { mode: 0o600 });
+  } catch { /* best-effort */ }
+}
+
+/** First-touch bookkeeping so every user is captured on their first command of the day. */
+export interface UsageState { lastDay?: string; distinctId?: string }
+
+export function readUsageState(): UsageState {
+  try {
+    return JSON.parse(fs.readFileSync(usageStateFile(), 'utf-8')) as UsageState;
+  } catch {
+    return {};
+  }
+}
+
+export function writeUsageState(state: UsageState): void {
+  try {
+    if (!fs.existsSync(configDir())) fs.mkdirSync(configDir(), { mode: 0o700 });
+    fs.writeFileSync(usageStateFile(), JSON.stringify(state), { mode: 0o600 });
+  } catch { /* best-effort */ }
+}


### PR DESCRIPTION
## Problem
The CLI emits **one PostHog event per command**, so a single agent loop can emit tens of thousands of events/day. CLI telemetry had grown to **~90% of all PostHog events** (~0.75–1M/mo and climbing), on track to blow the 1M/mo free tier — one user alone was ~640k/mo.

## Fix — exact-count roll-ups (no sampling)
- Each command is appended to a local **append-only** log (`~/.one/.cli-usage-log.jsonl`) — crash- and concurrency-safe, same idiom as the analytics queue.
- It's rolled up into ONE **`CLI Usage Rollup`** event with **exact** counts (`command_count`, `by_command`, `agent_count`/`human_count`, window), flushed at most **~once per 5 min of activity per user** (or a 500-command safety cap, or on login change). → ~**100× fewer events**, counts stay exact.
- **First command of each day flushes immediately** → a user is *never missed*, even a one-and-done try.
- Opt-out, privacy, delivery/retry, `$insert_id` dedup unchanged. Only the command *path* is ever recorded.

## Backwards compatible
The dashboard counts **both** legacy `CLI Command Run` rows **and** rollup `command_count` together, so recent data stays valid. (Dashboard PR is separate, lands after this is published.)

## Testing
- **10 unit tests** over real files (HOME-sandboxed): never-miss-a-user + exact per-user counts, heavy-burst aggregation, size/window flush, agent/human split, login mid-batch split, first-touch, batching, opt-out. All green.
- `tsup` build ✓.
- **Live PostHog round-trip**: emitted real rollups (`env=test`), confirmed the combined count `[40, 2]` and `by_command` extraction read back correctly.

## Release
Version **1.46.0 → 1.47.0** (+ lockfile). After merge, cut the GitHub release tag to publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)