### PR TITLE
fix(cli): agent-mode + flow engine bugs (#87, #88, #89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,9 @@ Press Ctrl+C during execution to pause - the run can be resumed later with `one 
 | `--skip-validation` | Skip input validation against action schemas |
 | `--allow-bash` | Allow bash step execution (disabled by default for security) |
 | `-v, --verbose` | Show full request/response for each step |
+| `--output-file <path>` | Stream the full result to a file instead of stdout — for large results that would otherwise be truncated or exceed the JSON string-size limit. stdout (and `--agent` output) then carries an `outputFile` pointer instead of inline `steps`. |
+
+Step-level `if`/`unless` conditions (and `while`/`condition` steps) are null-safe: a condition that references a skipped or not-yet-run step's output (e.g. `$.steps.maybeSkipped.output.x`) evaluates to `false` rather than crashing the run.
 
 ### `one flow list`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.0",
+      "version": "1.47.1",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -271,6 +271,10 @@ Selectors in data fields (`data`, `queryParams`, `pathVars`, `connectionKey`) ar
 
 The `if`, `unless`, `condition.expression`, `while.condition`, `transform.expression`, and `code.source` fields **do** support full JavaScript expressions (e.g., `$.input.email && $.input.email.length > 0`).
 
+**Condition null-safety:** `if`/`unless`, `while.condition`, and `condition.expression` are null-safe. A condition that walks into a skipped or not-yet-run step's output — e.g. `$.steps.maybeSkipped.output.value` — evaluates to `false` instead of throwing `Cannot read properties of undefined`. (This applies to *conditions* only; `transform.expression` and `code.source` still throw on undefined access, since their output feeds downstream steps and should fail loudly.)
+
+**Large results:** pass `--output-file <path>` to `flow execute` to stream the full result to a file instead of stdout. Use it when a flow aggregates large outputs that would otherwise be truncated on stdout or exceed the JSON string-size limit. stdout (and `--agent` output) then carries `{"event":"workflow:result", ..., "outputFile":"<path>"}` instead of inline `steps` — read the file for the full result.
+
 ## Step Types
 
 ### `action` — Execute a One API action

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,9 +52,14 @@ import { loginCommand } from './commands/login.js';
 import { logoutCommand } from './commands/logout.js';
 import { updateCommand, checkLatestVersionCached, getCurrentVersion, isNewerVersion, autoUpdate } from './commands/update.js';
 import { closeBackendIfCached } from './lib/memory/runtime.js';
-import { setAgentMode, isAgentMode, json as outputJson, error as outputError } from './lib/output.js';
+import { setAgentMode, isAgentMode, json as outputJson, error as outputError, silenceWarningsInAgentMode } from './lib/output.js';
 import { syncSkillsIfStale, forceSyncSkills, getSkillStatus } from './lib/skill-sync.js';
 import * as analytics from './lib/analytics.js';
+
+// Before anything runs: in --agent mode, keep process warnings off stdout/stderr
+// so they can't corrupt the JSON a machine consumer parses (#88). Done here at
+// module load — earlier than commander's flag parsing and any fetch() call.
+silenceWarningsInAgentMode();
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json');
@@ -540,7 +545,8 @@ flow
   .option('--skip-validation', 'Skip input validation against action schemas')
   .option('--allow-bash', 'Allow bash step execution (disabled by default for security)')
   .option('-v, --verbose', 'Show full request/response for each step')
-  .action(async (keyOrPath: string, options: { input?: string[]; dryRun?: boolean; verbose?: boolean; mock?: boolean; allowBash?: boolean; skipValidation?: boolean }) => {
+  .option('--output-file <path>', 'Write the full result to a file (streamed) instead of stdout — avoids truncation/string-limit errors for large results; stdout/agent output then carries an outputFile pointer')
+  .action(async (keyOrPath: string, options: { input?: string[]; dryRun?: boolean; verbose?: boolean; mock?: boolean; allowBash?: boolean; skipValidation?: boolean; outputFile?: string }) => {
     await flowExecuteCommand(keyOrPath, options);
   });
 

--- a/src/commands/flow.outputfile.test.ts
+++ b/src/commands/flow.outputfile.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { writeFlowResultFile } from './flow.js';
+import type { StepResult } from '../lib/flow-types.js';
+
+// #87: large flow results must be writable to a file as valid JSON without
+// building one giant string for stdout. writeFlowResultFile streams the
+// envelope, serializing each step separately.
+
+describe('writeFlowResultFile (#87)', () => {
+  let dir: string;
+  let out: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-flow-out-'));
+    out = path.join(dir, 'result.json');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const meta = { runId: 'run_1', logFile: '/tmp/x.log', status: 'success' };
+
+  it('writes a valid, well-formed envelope for multiple steps', async () => {
+    const steps: Record<string, StepResult> = {
+      a: { status: 'success', output: { n: 1 } },
+      b: { status: 'skipped' },
+      c: { status: 'success', output: { list: [1, 2, 3] } },
+    };
+    const abs = await writeFlowResultFile(out, meta, steps);
+    const parsed = JSON.parse(fs.readFileSync(abs, 'utf-8'));
+    assert.equal(parsed.event, 'workflow:result');
+    assert.equal(parsed.runId, 'run_1');
+    assert.equal(parsed.status, 'success');
+    assert.deepEqual(Object.keys(parsed.steps), ['a', 'b', 'c']);
+    assert.deepEqual(parsed.steps.a.output, { n: 1 });
+    assert.equal(parsed.steps.b.status, 'skipped');
+    assert.deepEqual(parsed.steps.c.output.list, [1, 2, 3]);
+  });
+
+  it('produces valid JSON with zero steps', async () => {
+    const abs = await writeFlowResultFile(out, meta, {});
+    const parsed = JSON.parse(fs.readFileSync(abs, 'utf-8'));
+    assert.deepEqual(parsed.steps, {});
+  });
+
+  it('escapes special characters in step ids and values', async () => {
+    const steps: Record<string, StepResult> = {
+      'weird"id\nwith\tchars': { status: 'success', output: { s: 'quote " and \\ backslash' } },
+    };
+    const abs = await writeFlowResultFile(out, meta, steps);
+    const parsed = JSON.parse(fs.readFileSync(abs, 'utf-8'));
+    assert.equal(parsed.steps['weird"id\nwith\tchars'].output.s, 'quote " and \\ backslash');
+  });
+
+  it('round-trips a large aggregate result', async () => {
+    const rows = Array.from({ length: 5000 }, (_, i) => ({ id: i, blob: 'x'.repeat(40) }));
+    const steps: Record<string, StepResult> = { big: { status: 'success', output: { rows } } };
+    const abs = await writeFlowResultFile(out, meta, steps);
+    const parsed = JSON.parse(fs.readFileSync(abs, 'utf-8'));
+    assert.equal(parsed.steps.big.output.rows.length, 5000);
+    assert.equal(parsed.steps.big.output.rows[4999].id, 4999);
+  });
+});

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -5,10 +5,44 @@ import * as output from '../lib/output.js';
 import { printTable } from '../lib/table.js';
 import { validateFlow } from '../lib/flow-validator.js';
 import { FlowRunner, loadFlowWithMeta, listFlows, saveFlow, resolveFlowPath, flowRequiresBash } from '../lib/flow-runner.js';
-import type { Flow, FlowEvent } from '../lib/flow-types.js';
+import type { Flow, FlowEvent, StepResult } from '../lib/flow-types.js';
 import type { PermissionLevel } from '../lib/types.js';
 import fs from 'node:fs';
 import path from 'node:path';
+
+/**
+ * Stream a `workflow:result` envelope to a file, serializing each step's
+ * result separately rather than building one giant JSON string. A flow that
+ * aggregates many/large sub-flow outputs can exceed V8's max string length
+ * (`RangeError: Invalid string length`) or get truncated on stdout — both
+ * reported in #87. Streaming bounds peak memory to the largest single step,
+ * not the sum, and keeps the full result off stdout entirely.
+ */
+export async function writeFlowResultFile(
+  filePath: string,
+  meta: { runId: string; logFile: string; status: string },
+  steps: Record<string, StepResult>,
+): Promise<string> {
+  const abs = path.resolve(filePath);
+  const ws = fs.createWriteStream(abs);
+  const done = new Promise<void>((resolve, reject) => {
+    ws.on('finish', () => resolve());
+    ws.on('error', reject);
+  });
+  ws.write(
+    `{"event":"workflow:result","runId":${JSON.stringify(meta.runId)},` +
+    `"logFile":${JSON.stringify(meta.logFile)},"status":${JSON.stringify(meta.status)},"steps":{`,
+  );
+  let first = true;
+  for (const [id, result] of Object.entries(steps)) {
+    ws.write(`${first ? '' : ','}${JSON.stringify(id)}:${JSON.stringify(result)}`);
+    first = false;
+  }
+  ws.write('}}');
+  ws.end();
+  await done;
+  return abs;
+}
 
 function getConfig() {
   const apiKey = getApiKey();
@@ -156,7 +190,7 @@ export async function flowCreateCommand(
 
 export async function flowExecuteCommand(
   keyOrPath: string,
-  options: { input?: string[]; dryRun?: boolean; verbose?: boolean; mock?: boolean; allowBash?: boolean; skipValidation?: boolean },
+  options: { input?: string[]; dryRun?: boolean; verbose?: boolean; mock?: boolean; allowBash?: boolean; skipValidation?: boolean; outputFile?: string },
 ): Promise<void> {
   output.intro(pc.bgCyan(pc.black(' One Workflow ')));
 
@@ -267,15 +301,24 @@ export async function flowExecuteCommand(
       execSpinner.stop('Workflow completed');
     }
 
+    // --output-file: write the full result to disk (streamed) instead of
+    // stdout, so a large aggregate result can't be truncated or blow the V8
+    // string limit. stdout then carries only a compact pointer. See #87.
+    const resultFile = options.outputFile
+      ? await writeFlowResultFile(options.outputFile, { runId, logFile: logPath, status: 'success' }, context.steps)
+      : undefined;
+
     if (output.isAgentMode()) {
-      output.json({
-        event: 'workflow:result',
-        runId,
-        logFile: logPath,
-        status: 'success',
-        steps: context.steps,
-      });
+      output.json(
+        resultFile
+          ? { event: 'workflow:result', runId, logFile: logPath, status: 'success', outputFile: resultFile }
+          : { event: 'workflow:result', runId, logFile: logPath, status: 'success', steps: context.steps },
+      );
       return;
+    }
+
+    if (resultFile) {
+      output.note(`Full result written to ${resultFile}`, 'Output');
     }
 
     // Print results summary

--- a/src/lib/flow-engine.test.ts
+++ b/src/lib/flow-engine.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateCondition, evaluateExpression } from './flow-engine.js';
+import type { FlowContext, StepResult } from './flow-types.js';
+
+// Regression coverage for #89: step-level `if`/`unless` (and `while` /
+// `condition` steps) must not crash when a condition references a skipped or
+// not-yet-produced step output. A missing upstream value makes the condition
+// false instead of throwing "Cannot read properties of undefined".
+
+function ctx(steps: Record<string, StepResult> = {}): FlowContext {
+  return { input: {}, env: {}, steps, loop: {} };
+}
+
+describe('evaluateCondition — null-safe condition evaluation (#89)', () => {
+  it('returns false when referencing the output of a skipped step (no output key)', () => {
+    // Exactly the #89 repro: stepA was skipped, so it has { status: 'skipped' }
+    // with no `output`. stepB's `if` reads $.steps.stepA.output.result.
+    const context = ctx({ stepA: { status: 'skipped' } });
+    assert.equal(evaluateCondition('$.steps.stepA.output.result', context), false);
+  });
+
+  it('returns false when referencing a step that never ran at all', () => {
+    assert.equal(evaluateCondition('$.steps.neverRan.output.value === true', ctx()), false);
+  });
+
+  it('returns false for deep access through several missing segments', () => {
+    assert.equal(evaluateCondition('$.steps.a.output.b.c.d', ctx()), false);
+  });
+
+  it('still evaluates truthy/falsy correctly when the value is present', () => {
+    const context = ctx({ stepA: { status: 'success', output: { result: 'hello' } } });
+    assert.equal(evaluateCondition('$.steps.stepA.output.result', context), true);
+    assert.equal(evaluateCondition("$.steps.stepA.output.result === 'hello'", context), true);
+    assert.equal(evaluateCondition("$.steps.stepA.output.result === 'nope'", context), false);
+  });
+
+  it('coerces non-boolean truthy results to a real boolean', () => {
+    const context = ctx({ s: { status: 'success', output: { n: 0, str: 'x' } } });
+    assert.strictEqual(evaluateCondition('$.steps.s.output.n', context), false);
+    assert.strictEqual(evaluateCondition('$.steps.s.output.str', context), true);
+  });
+
+  it('reads input/env without crashing', () => {
+    const context: FlowContext = { input: { flag: true }, env: { X: '1' }, steps: {}, loop: {} };
+    assert.equal(evaluateCondition('$.input.flag', context), true);
+    assert.equal(evaluateCondition('$.input.missing', context), false);
+  });
+
+  it('rethrows genuine syntax errors (does not swallow malformed expressions)', () => {
+    assert.throws(() => evaluateCondition('$.steps.a.output.(', ctx()), SyntaxError);
+  });
+
+  it('rethrows reference errors for unknown bare identifiers', () => {
+    assert.throws(() => evaluateCondition('someUndefinedGlobal === 1', ctx()), ReferenceError);
+  });
+
+  it('leaves evaluateExpression (transforms) throwing on undefined access', () => {
+    // Transforms must still fail loudly — their output feeds downstream steps.
+    assert.throws(() => evaluateExpression('$.steps.gone.output.x', ctx()), TypeError);
+  });
+});

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -267,6 +267,26 @@ export function evaluateExpression(expr: string, context: FlowContext): unknown 
   return fn(context);
 }
 
+/**
+ * Evaluate a boolean condition (`if`/`unless`, `while`, and `condition`
+ * steps). Unlike a transform — whose output feeds downstream steps and so
+ * must fail loudly — a condition that walks into a skipped or not-yet-
+ * produced step output should not crash the flow. Accessing
+ * `$.steps.skippedStep.output.x` throws a `TypeError` ("Cannot read
+ * properties of undefined"); we treat that as `false` so a missing upstream
+ * value simply makes the condition falsy. Syntax/reference errors still
+ * throw so genuinely malformed expressions surface (the validator also
+ * catches these at flow-create time). See issue #89.
+ */
+export function evaluateCondition(expr: string, context: FlowContext): boolean {
+  try {
+    return Boolean(evaluateExpression(expr, context));
+  } catch (err) {
+    if (err instanceof TypeError) return false;
+    throw err;
+  }
+}
+
 // ── Dot-path Helpers (for pagination) ──
 
 // getByDotPath and setByDotPath imported from ./dot-path.js
@@ -554,7 +574,7 @@ async function executeConditionStep(
   flowStack: string[],
 ): Promise<StepResult> {
   const condition = step.condition!;
-  const result = evaluateExpression(condition.expression, context);
+  const result = evaluateCondition(condition.expression, context);
 
   const branch = result ? condition.then : (condition.else || []);
   const branchResults = await executeSteps(branch, context, api, permissions, allowedActionIds, options, undefined, flowStack);
@@ -754,7 +774,7 @@ async function executeWhileStep(
   for (let iteration = 0; iteration < maxIterations; iteration++) {
     // Do-while: skip condition check on iteration 0
     if (iteration > 0) {
-      const conditionResult = evaluateExpression(config.condition, context);
+      const conditionResult = evaluateCondition(config.condition, context);
       if (!conditionResult) break;
     }
 
@@ -1096,7 +1116,7 @@ export async function executeSingleStep(
 ): Promise<StepResult> {
   // Conditional execution
   if (step.if) {
-    const condResult = evaluateExpression(step.if, context);
+    const condResult = evaluateCondition(step.if, context);
     if (!condResult) {
       const result: StepResult = { status: 'skipped' };
       context.steps[step.id] = result;
@@ -1104,7 +1124,7 @@ export async function executeSingleStep(
     }
   }
   if (step.unless) {
-    const condResult = evaluateExpression(step.unless, context);
+    const condResult = evaluateCondition(step.unless, context);
     if (condResult) {
       const result: StepResult = { status: 'skipped' };
       context.steps[step.id] = result;

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -84,6 +84,8 @@ one --agent flow list                                 # List all workflows
 - AI analysis via bash steps: \`claude --print\` with \`parseJson: true\`
 - Use \`--allow-bash\` to enable bash steps, \`--mock\` for dry-run with realistic mock responses (uses example data from action schemas)
 - Use \`--skip-validation\` to bypass input validation on action steps
+- Use \`--output-file <path>\` to stream the full result to a file instead of stdout — for large results that would otherwise be truncated or hit the JSON string-size limit; stdout (and \`--agent\` output) then carries an \`outputFile\` pointer instead of inline \`steps\`
+- Step-level \`if\`/\`unless\` (and \`while\`/\`condition\` steps) are null-safe: a condition referencing a skipped or not-yet-run step's output (e.g. \`$.steps.maybeSkipped.output.x\`) evaluates to \`false\` instead of crashing the flow
 
 ### 3. Relay — Webhook event forwarding between platforms
 Receive webhooks from platforms (Stripe, GitHub, Airtable, Attio, Google Calendar) and forward event data to any connected platform using passthrough actions with Handlebars templates. No middleware, no code.

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { silenceWarningsInAgentMode } from './output.js';
+
+// #88: in --agent mode, process warnings (e.g. Node's experimental-feature
+// warnings) must not be emitted, so they can't interleave with the JSON a
+// machine consumer parses off stdout/stderr.
+
+describe('silenceWarningsInAgentMode (#88)', () => {
+  let origArgv: string[];
+  let origAgentEnv: string | undefined;
+  let origNoWarn: string | undefined;
+  let origEmit: typeof process.emitWarning;
+
+  beforeEach(() => {
+    origArgv = process.argv;
+    origAgentEnv = process.env.ONE_AGENT;
+    origNoWarn = process.env.NODE_NO_WARNINGS;
+    origEmit = process.emitWarning;
+    delete process.env.ONE_AGENT;
+    delete process.env.NODE_NO_WARNINGS;
+  });
+
+  afterEach(() => {
+    process.argv = origArgv;
+    if (origAgentEnv === undefined) delete process.env.ONE_AGENT; else process.env.ONE_AGENT = origAgentEnv;
+    if (origNoWarn === undefined) delete process.env.NODE_NO_WARNINGS; else process.env.NODE_NO_WARNINGS = origNoWarn;
+    process.emitWarning = origEmit;
+  });
+
+  it('is a no-op in human mode — warnings still fire', () => {
+    process.argv = ['node', 'one', 'actions', 'search', 'gmail', 'x'];
+    silenceWarningsInAgentMode();
+    assert.equal(process.emitWarning, origEmit, 'emitWarning must be untouched in human mode');
+    assert.equal(process.env.NODE_NO_WARNINGS, undefined);
+  });
+
+  it('suppresses emitWarning when --agent is in argv', () => {
+    process.argv = ['node', 'one', '--agent', 'actions', 'execute', 'x', 'y', 'z'];
+    let fired = false;
+    process.on('warning', () => { fired = true; });
+    silenceWarningsInAgentMode();
+    process.emitWarning('Fetch API is an experimental feature');
+    process.removeAllListeners('warning');
+    assert.equal(fired, false, 'no warning should propagate after suppression');
+    assert.equal(process.env.NODE_NO_WARNINGS, '1');
+  });
+
+  it('suppresses when ONE_AGENT=1 even without the flag', () => {
+    process.argv = ['node', 'one', 'actions', 'execute', 'x', 'y', 'z'];
+    process.env.ONE_AGENT = '1';
+    silenceWarningsInAgentMode();
+    assert.notEqual(process.emitWarning, origEmit, 'emitWarning must be replaced under ONE_AGENT=1');
+    assert.equal(process.env.NODE_NO_WARNINGS, '1');
+  });
+});

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -10,6 +10,28 @@ export function isAgentMode(): boolean {
   return _agentMode || process.env.ONE_AGENT === '1';
 }
 
+/**
+ * In agent mode, machine consumers parse the CLI's output as JSON. Node (and
+ * some dependencies) emit process warnings — e.g. the "Fetch API is an
+ * experimental feature" ExperimentalWarning on older Node, or `Readable.fromWeb`
+ * during a binary download — via `process.emitWarning`. Harnesses that merge
+ * stdout+stderr then see those lines interleaved with the JSON response and
+ * fail to parse it (#88). Silence them when `--agent` is active.
+ *
+ * Detected straight from argv/env (not the `setAgentMode()` flag) so it can run
+ * at process startup, before the first warning fires and before commander has
+ * parsed the flag. A no-op in interactive/human mode — warnings still show.
+ */
+export function silenceWarningsInAgentMode(): void {
+  const agent = process.argv.includes('--agent') || process.env.ONE_AGENT === '1';
+  if (!agent) return;
+  // Belt: respected by any child processes the CLI spawns.
+  process.env.NODE_NO_WARNINGS = '1';
+  // Suspenders: silence warnings emitted by *this* process after startup.
+  process.removeAllListeners('warning');
+  process.emitWarning = (() => {}) as typeof process.emitWarning;
+}
+
 export function createSpinner(): { start(msg: string): void; stop(msg: string): void } {
   if (isAgentMode()) {
     return { start() {}, stop() {} };


### PR DESCRIPTION
Batched bug fixes for the agent/flow surface. Each was reproduced before fixing and is covered by a new test. **v1.47.1.**

## #89 — Step `if`/`unless` crash on skipped-step output
A skipped step is recorded as `{ status: 'skipped' }` (no `output` key), so a downstream `if: "$.steps.stepA.output.result"` did `undefined.result` and crashed the whole flow with *"Cannot read properties of undefined"*.

**Fix:** new `evaluateCondition()` in `flow-engine.ts` wraps condition evaluation and treats the `TypeError` from undefined dot-path access as `false` — applied to `if`/`unless`, `while.condition`, and `condition` steps. Syntax/reference errors still throw, and `transform`/`code` (`evaluateExpression`) still fail loudly since their output feeds downstream steps.

**Verified:** the issue's exact repro flow — `someFlag=false` → stepA skipped → stepB's `if` reads the skipped output → both skip cleanly, flow succeeds (was: crash). `someFlag=true` → stepA runs → stepB runs (positive path intact).

## #88 — Node warnings pollute JSON in `--agent` mode
Process warnings (the "Fetch API is an experimental feature" `ExperimentalWarning` on older Node, `Readable.fromWeb` during binary downloads) are emitted via `process.emitWarning` and a stream-merging agent harness sees them interleaved with the JSON response.

**Fix:** `silenceWarningsInAgentMode()` in `output.ts` overrides `process.emitWarning` (and sets `NODE_NO_WARNINGS`) when `--agent`/`ONE_AGENT=1`, called at `cli.ts` load — before commander parses flags and before any `fetch()`. No-op in human mode (warnings still show).

**Verified:** runtime-emitted warning on the **combined** (`2>&1`) stream is suppressed in agent mode, still present in human mode. (Audited the agent-heavy paths — every `console.log` is behind the `isAgentMode()` early-return; telemetry/update/skill-sync already write to stderr or run silent.)

## #87 — Large flow result truncated / `Invalid string length`
A flow aggregating large sub-flow outputs could exceed V8's max string length or get truncated on stdout.

**Fix:** new `--output-file <path>` on `flow execute` **streams** the result envelope to disk, serializing each step separately so peak memory is bounded by the largest single step — not the aggregate. stdout (and `--agent` output) then carries `{"event":"workflow:result", ..., "outputFile":"<path>"}` instead of inline `steps`.

**Verified:** a ~3.7MB / 20K-row result writes as valid JSON to the file; stdout carries only the compact pointer.

## Tests & docs
- +16 tests across `flow-engine.test.ts`, `output.test.ts`, `flow.outputfile.test.ts`. **152/152 pass**; typecheck + build green.
- Docs: `guide-content.ts`, `README.md`, `skills/one/references/flows.md`.
- Version bump 1.47.1 + lockfile.

## Note on #79
The Google Calendar `{{sendNotifications}}` issue was confirmed fixed on the connection-definition side (the CD no longer bakes in that default query template; the CLI builds a clean URL) and **closed separately** — no code change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)