### PR TITLE
fix(flow-validate): catch step/input refs inside external code.module files (#75)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.0",
+      "version": "1.47.3",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.3",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -145,7 +145,7 @@ Two rules: (1) prepend the stdin-read line, (2) replace `return X` with `process
 one --agent flow validate <key>
 ```
 
-`flow validate` parses every inline `code.source` and runs `node --check` on every `code.module` file, so syntax errors (brace/paren mismatches, duplicate `let`, etc.) surface here instead of after upstream steps have already run. It also extracts `$.steps.X` and `$.input.X` references from inside `code.source` and `transform.expression` and reports any reference to an undefined step/input or to a step declared **after** the current one (forward references resolve to `undefined` at runtime — silent data loss). The same checks run automatically at the start of `flow execute` so a broken step in position 15 fails the run immediately rather than 15 minutes in.
+`flow validate` parses every inline `code.source` and runs `node --check` on every `code.module` file, so syntax errors (brace/paren mismatches, duplicate `let`, etc.) surface here instead of after upstream steps have already run. It also extracts `$.steps.X` and `$.input.X` references from inside `code.source`, `transform.expression`, **and external `code.module` `.mjs` files**, and reports any reference to an undefined step/input or to a step declared **after** the current one (forward references resolve to `undefined` at runtime — silent data loss). The same checks run automatically at the start of `flow execute` so a broken step in position 15 fails the run immediately rather than 15 minutes in.
 
 ### Step 6: Execute
 

--- a/src/lib/flow-validator.module-refs.test.ts
+++ b/src/lib/flow-validator.module-refs.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { validateFlow } from './flow-validator.js';
+import type { Flow } from './flow-types.js';
+
+// #75: forward/undefined $.steps and $.input references inside an external
+// code.module .mjs file must be caught by `flow validate`, the same as inline
+// code.source. Requires rootDir (the module file is read from disk).
+
+describe('flow validate — references inside code.module files (#75)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-modref-'));
+    fs.mkdirSync(path.join(dir, 'lib'), { recursive: true });
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  function writeModule(name: string, body: string): void {
+    fs.writeFileSync(path.join(dir, 'lib', name), body);
+  }
+
+  const baseFlow = (steps: Flow['steps']): Flow => ({
+    key: 'modflow', name: 'Mod', inputs: {}, steps,
+  } as Flow);
+
+  it('flags a forward reference to a later step from inside a module', () => {
+    writeModule('cache.mjs', 'const $ = {}; const r = $.steps.buildResult.output; void r;');
+    const flow = baseFlow([
+      { id: 'buildCacheEntry', name: 'cache', type: 'code', code: { module: 'lib/cache.mjs' } },
+      { id: 'buildResult', name: 'result', type: 'code', code: { source: "return {data:'x'};" } },
+    ] as Flow['steps']);
+    const errors = validateFlow(flow, dir);
+    assert.ok(
+      errors.some(e => e.path === 'steps[0].code.module' && /declared after the current step/.test(e.message)),
+      `expected a forward-ref error on the module; got ${JSON.stringify(errors)}`,
+    );
+  });
+
+  it('flags an undefined step reference from inside a module', () => {
+    writeModule('m.mjs', 'const $ = {}; void $.steps.ghost.output;');
+    const flow = baseFlow([
+      { id: 'a', name: 'a', type: 'code', code: { module: 'lib/m.mjs' } },
+    ] as Flow['steps']);
+    const errors = validateFlow(flow, dir);
+    assert.ok(errors.some(e => /references undefined step "ghost"/.test(e.message)));
+  });
+
+  it('flags an undefined input reference from inside a module', () => {
+    writeModule('m.mjs', 'const $ = {}; void $.input.missing;');
+    const flow = baseFlow([
+      { id: 'a', name: 'a', type: 'code', code: { module: 'lib/m.mjs' } },
+    ] as Flow['steps']);
+    const errors = validateFlow(flow, dir);
+    assert.ok(errors.some(e => /references undefined input "missing"/.test(e.message)));
+  });
+
+  it('passes when the module only references earlier steps and declared inputs', () => {
+    writeModule('ok.mjs', 'const $ = {}; void $.steps.first.output; void $.input.token;');
+    const flow: Flow = {
+      key: 'modflow', name: 'Mod',
+      inputs: { token: { type: 'string', required: false } },
+      steps: [
+        { id: 'first', name: 'first', type: 'code', code: { source: 'return {};' } },
+        { id: 'second', name: 'second', type: 'code', code: { module: 'lib/ok.mjs' } },
+      ],
+    } as Flow;
+    const errors = validateFlow(flow, dir);
+    assert.deepEqual(errors, [], `expected no errors; got ${JSON.stringify(errors)}`);
+  });
+
+  it('does not scan module refs when rootDir is absent (no file access)', () => {
+    // Without rootDir the validator can't read the file — must not crash, and
+    // simply skips the module scan (validateCodeModules also needs rootDir).
+    const flow = baseFlow([
+      { id: 'a', name: 'a', type: 'code', code: { module: 'lib/whatever.mjs' } },
+    ] as Flow['steps']);
+    const errors = validateFlow(flow);
+    assert.equal(errors.some(e => e.path.endsWith('.code.module')), false);
+  });
+});

--- a/src/lib/flow-validator.ts
+++ b/src/lib/flow-validator.ts
@@ -368,7 +368,7 @@ export function validateStepIds(flow: Flow): ValidationError[] {
 
 // ── Selector reference validation ──
 
-export function validateSelectorReferences(flow: Flow): ValidationError[] {
+export function validateSelectorReferences(flow: Flow, rootDir?: string): ValidationError[] {
   const errors: ValidationError[] = [];
   const inputNames = new Set(Object.keys(flow.inputs));
   const nestedKeys = getNestedStepsKeys();
@@ -510,6 +510,23 @@ export function validateSelectorReferences(flow: Flow): ValidationError[] {
           if (typeof text === 'string') {
             const fieldName = step.type === 'code' ? 'source' : 'expression';
             checkSelectors(extractSelectors(text), `${pathPrefix}.${descriptor.configKey}.${fieldName}`, preceding);
+          }
+          // External code modules: scan the .mjs file's $.steps.X / $.input.X
+          // tokens through the same ordering + undefined checks as inline
+          // source, so a module reading a later/undefined step is caught at
+          // validate time too (cli#75). Skipped when the file is missing —
+          // validateCodeModules already reports that.
+          const modulePath = step.type === 'code' ? (c.module as string | undefined) : undefined;
+          if (rootDir && typeof modulePath === 'string' && modulePath.length > 0) {
+            const abs = path.resolve(rootDir, modulePath);
+            if (fs.existsSync(abs)) {
+              try {
+                const moduleText = fs.readFileSync(abs, 'utf-8');
+                checkSelectors(extractSelectors(moduleText), `${pathPrefix}.${descriptor.configKey}.module`, preceding);
+              } catch {
+                // Unreadable file — validateCodeModules surfaces I/O errors.
+              }
+            }
           }
         }
       }
@@ -728,7 +745,7 @@ export function validateFlow(flow: unknown, rootDir?: string): ValidationError[]
   const f = flow as Flow;
   return [
     ...validateStepIds(f),
-    ...validateSelectorReferences(f),
+    ...validateSelectorReferences(f, rootDir),
     ...validateOutputSchemas(f),
     ...(rootDir ? validateCodeModules(f, rootDir) : []),
   ];


### PR DESCRIPTION
Closes the remaining #75 gap. Linear: INT-3203. **v1.47.3.**

## Context
`flow validate` already detects forward-references and undefined `$.steps`/`$.input` references across inline `code.source`, `transform.expression`, `if`/`unless`, `requires`, action data, and file-write content (this is also what closed #91 — dependency ordering, verified already-fixed). The one gap #75 called out: references inside **external `code.module` `.mjs` files** were only `node --check`'d for syntax — their selector references weren't validated.

## Change
`validateSelectorReferences` now accepts `rootDir`. For a code step with a `code.module`, it reads the file and runs the module's `$.steps.X` / `$.input.X` tokens through the **same** ordering + undefined-reference checks (the `preceding` step-id set) that inline `code.source` already gets. Missing files are skipped (`validateCodeModules` already reports not-found); unreadable files are ignored.

## Verified
End-to-end with a flow whose `lib/cache.mjs` reads a later step + an undeclared input:
- forward-ref → error at `steps[0].code.module`: *"references step buildResult which is declared after the current step…"*
- undefined input → *"references undefined input…"*
- reorder steps + declare the input → `valid:true`

## Tests & docs
- +5 tests (`flow-validator.module-refs.test.ts`: forward-ref, undefined step, undefined input, happy path, no-rootDir skip). **141/141 pass**; typecheck + build green.
- Docs: `references/flows.md` validate section now lists `code.module` files.
- Version bump 1.47.3 + lockfile.

#91 (dependency ordering) was verified already-fixed and closed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)