### PR TITLE
chore(deps): pin pgserve to 2.2.3 ahead of upcoming breaking change (#136)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.0",
+      "version": "1.47.4",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",
         "open": "^10.1.0",
-        "pgserve": "^2.2.3",
+        "pgserve": "2.2.3",
         "picocolors": "^1.1.1",
         "smol-toml": "^1.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.4",
   "description": "CLI for managing One",
   "type": "module",
   "files": [
@@ -30,7 +30,7 @@
     "@clack/prompts": "^0.9.1",
     "commander": "^13.1.0",
     "open": "^10.1.0",
-    "pgserve": "^2.2.3",
+    "pgserve": "2.2.3",
     "picocolors": "^1.1.1",
     "smol-toml": "^1.6.0"
   },


### PR DESCRIPTION
Closes #136. Linear: INT-3209. **v1.47.4.**

## Context
[@namastex888](https://github.com/withoneai/cli/issues/136) (pgserve's creator) gave a heads-up about an **upcoming breaking change** — signed-app / role isolation so agents can't trivially drop databases (moving off `postgres:postgres`). pgserve backs the default `embedded-postgres` mem backend, and our dependency was `"pgserve": "^2.2.3"`, so a 2.x minor carrying the breaking change would auto-land on the next clean install and could break `one mem` for everyone. He explicitly recommended pinning until we migrate.

## Change
Pin to exact `"pgserve": "2.2.3"` in `package.json` + lockfile. **Pure spec pin** — resolution is unchanged (the lock already resolved 2.2.3), so there's no runtime behavior change; it just prevents an unintended auto-upgrade.

## Follow-up
Revisit and migrate to the new signed-app/role model when Felipe posts the migration docs on #136 (tracked).

Version bump 1.47.4 + lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)