### PR TITLE
fix(flow-validate): allow downstream refs to parallel/nested-block children (#58)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.0",
+      "version": "1.47.5",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.5",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -387,7 +387,7 @@ Use when fetching from 2+ independent data sources before combining results. Eac
 }
 ```
 
-After a parallel step, access each substep's output by its `id`: `$.steps.fetchEmails.response`, `$.steps.fetchEvents.response`.
+After a parallel step, access each substep's output by its `id`: `$.steps.fetchEmails.response`, `$.steps.fetchEvents.response`. Each substep also carries its own result metadata — `$.steps.<id>.status` (`"success"` | `"failed"` | `"timeout"` | `"skipped"`), `.error`, `.errorCode` (e.g. `"TIMEOUT"`), `.durationMs` — so a downstream gate can tell a timed-out substep (retry-able) from one that genuinely returned nothing: `$.steps.fetchEvents.status === 'timeout'`. These substep references resolve at runtime (the engine stores each child in the context) and `flow validate` recognizes them — referencing a parallel/`loop`/`while`/`condition` child from a later step is not a forward-reference error.
 
 ### `file-read` / `file-write` — Filesystem access
 

--- a/src/lib/flow-validator.nested-refs.test.ts
+++ b/src/lib/flow-validator.nested-refs.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateFlow } from './flow-validator.js';
+import type { Flow } from './flow-types.js';
+
+// #58: a parallel/nested-block step stores its children directly in
+// context.steps, so a step AFTER the block can reference them
+// (`$.steps.parallelChild.status`). The validator must not flag those as
+// forward references — while still catching genuine forward/intra-block ones.
+
+const flow = (steps: unknown[]): Flow => ({ key: 'f', name: 'F', inputs: {}, steps } as Flow);
+
+describe('flow validate — nested-block child references (#58)', () => {
+  it('allows a later step to reference a parallel child', () => {
+    const errors = validateFlow(flow([
+      { id: 'block', name: 'block', type: 'parallel', parallel: { steps: [
+        { id: 'fast', name: 'fast', type: 'code', code: { source: 'return {};' } },
+        { id: 'slow', name: 'slow', type: 'code', code: { source: 'return {};' } },
+      ] } },
+      { id: 'gate', name: 'gate', type: 'code', code: { source: 'return { s: $.steps.slow.status };' } },
+    ]));
+    assert.deepEqual(errors, [], `expected no errors; got ${JSON.stringify(errors)}`);
+  });
+
+  it('allows a later step to reference a child of a condition branch', () => {
+    const errors = validateFlow(flow([
+      { id: 'cond', name: 'cond', type: 'condition', condition: {
+        expression: 'true',
+        then: [{ id: 'branchStep', name: 'b', type: 'code', code: { source: 'return {x:1};' } }],
+      } },
+      { id: 'after', name: 'after', type: 'code', code: { source: 'return { v: $.steps.branchStep.output };' } },
+    ]));
+    assert.deepEqual(errors, []);
+  });
+
+  it('still flags a genuine forward reference at the top level', () => {
+    const errors = validateFlow(flow([
+      { id: 'a', name: 'a', type: 'code', code: { source: 'return $.steps.b.output;' } },
+      { id: 'b', name: 'b', type: 'code', code: { source: 'return {};' } },
+    ]));
+    assert.ok(errors.some(e => /references step "b" which is declared after/.test(e.message)));
+  });
+
+  it('still flags an intra-block forward reference (child reads a later sibling child)', () => {
+    const errors = validateFlow(flow([
+      { id: 'block', name: 'block', type: 'parallel', parallel: { steps: [
+        { id: 'c1', name: 'c1', type: 'code', code: { source: 'return $.steps.c2.output;' } },
+        { id: 'c2', name: 'c2', type: 'code', code: { source: 'return {};' } },
+      ] } },
+    ]));
+    assert.ok(errors.some(e => /references step "c2" which is declared after/.test(e.message)));
+  });
+
+  it('still flags a reference to a nested child from BEFORE its containing block', () => {
+    // `early` runs before `block`, so block's child `kid` is not yet available.
+    const errors = validateFlow(flow([
+      { id: 'early', name: 'early', type: 'code', code: { source: 'return $.steps.kid.output;' } },
+      { id: 'block', name: 'block', type: 'parallel', parallel: { steps: [
+        { id: 'kid', name: 'kid', type: 'code', code: { source: 'return {};' } },
+      ] } },
+    ]));
+    assert.ok(errors.some(e => /references step "kid" which is declared after/.test(e.message)));
+  });
+
+  it('exposes deeply nested (grandchild) ids to later siblings', () => {
+    const errors = validateFlow(flow([
+      { id: 'outer', name: 'outer', type: 'parallel', parallel: { steps: [
+        { id: 'inner', name: 'inner', type: 'parallel', parallel: { steps: [
+          { id: 'grand', name: 'grand', type: 'code', code: { source: 'return {g:1};' } },
+        ] } },
+      ] } },
+      { id: 'use', name: 'use', type: 'code', code: { source: 'return { g: $.steps.grand.output };' } },
+    ]));
+    assert.deepEqual(errors, []);
+  });
+});

--- a/src/lib/flow-validator.ts
+++ b/src/lib/flow-validator.ts
@@ -464,7 +464,16 @@ export function validateSelectorReferences(flow: Flow): ValidationError[] {
     }
   }
 
-  function checkStep(step: FlowStep, pathPrefix: string, preceding: Set<string>): void {
+  // Returns the set of step ids declared *within this step's nested subtree*
+  // (a parallel block's children, a loop/while body, a condition's branches).
+  // The engine stores those children directly in the shared `context.steps`
+  // when the block runs, so steps that come AFTER the block can legitimately
+  // reference them (e.g. a gate reading `$.steps.parallelChild.status`). The
+  // caller merges this set into `preceding` so those downstream references
+  // don't false-positive as forward references (cli#58). Intra-block ordering
+  // is unaffected — children are still only visible to *later* siblings.
+  function checkStep(step: FlowStep, pathPrefix: string, preceding: Set<string>): Set<string> {
+    const subtreeIds = new Set<string>();
     // if/unless are JS expressions — validate selector references but allow operators
     if (step.if) checkSelectors(extractSelectors(step.if), `${pathPrefix}.if`, preceding);
     if (step.unless) checkSelectors(extractSelectors(step.unless), `${pathPrefix}.unless`, preceding);
@@ -523,19 +532,27 @@ export function validateSelectorReferences(flow: Flow): ValidationError[] {
           if (c && Array.isArray(c[fieldName])) {
             const childPreceding = new Set(preceding);
             (c[fieldName] as FlowStep[]).forEach((s, i) => {
-              checkStep(s, `${pathPrefix}.${configKey}.${fieldName}[${i}]`, childPreceding);
+              const childSubtree = checkStep(s, `${pathPrefix}.${configKey}.${fieldName}[${i}]`, childPreceding);
+              // Earlier siblings (and their subtrees) are visible to later
+              // siblings within the same block — preserves intra-block ordering.
               childPreceding.add(s.id);
+              for (const id of childSubtree) childPreceding.add(id);
+              // Surface this child + its descendants to the parent's later siblings.
+              subtreeIds.add(s.id);
+              for (const id of childSubtree) subtreeIds.add(id);
             });
           }
         }
       }
     }
+    return subtreeIds;
   }
 
   const preceding = new Set<string>();
   flow.steps.forEach((step, i) => {
-    checkStep(step, `steps[${i}]`, preceding);
+    const subtree = checkStep(step, `steps[${i}]`, preceding);
     preceding.add(step.id);
+    for (const id of subtree) preceding.add(id);
   });
   return errors;
 }


### PR DESCRIPTION
Closes #58. Linear: INT-3215. **v1.47.5.**

## Finding
#58 asked for per-step `status`/`duration`/`error` metadata to tell a timed-out parallel substep from one that returned empty. **That metadata already exists** (shipped in #69): a step that times out under `onError: continue` is stored as `{ status: 'timeout', error, errorCode: 'TIMEOUT', durationMs }`, distinct from `failed`/`success`/`skipped`. Verified live — a timed-out parallel child reports `status:'timeout'`, `errorCode:'TIMEOUT'`, `durationMs`.

## The real gap (fixed here)
A `parallel` block (and `loop`/`while`/`condition` bodies) stores each child directly in `context.steps`, so a later step can read `$.steps.<childId>.status`. But `flow validate` only propagated a block's child ids *within* the block — so a downstream reference false-positived as *"references step X which is declared after the current step"*, **rejecting the exact #58 gate pattern**.

`checkStep` now returns the set of step ids declared in its nested subtree, and the caller merges them into `preceding`, so references to nested-block children from *later* steps validate. Preserved: intra-block ordering, top-level forward refs, and refs to a child from *before* its containing block are all still flagged.

## Verified
A parallel block with a timed-out child + a downstream gate reading `$.steps.slow.status`:
- `flow validate` → `valid:true` (was: forward-ref error)
- `flow execute` → gate sees `slowStatus: timeout`, `slowErrorCode: TIMEOUT`, `slowDurationMs`

## Tests & docs
- +6 tests (`flow-validator.nested-refs.test.ts`): allow parallel + condition-branch child refs, grandchild propagation; still flag genuine forward / intra-block / pre-block refs. **142/142 pass**; typecheck + build green.
- Docs: `references/flows.md` (parallel substep metadata + downstream access).
- Version bump 1.47.5 + lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)