### PR TITLE
feat(connection): one add --tag to tag a connection at creation (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,14 @@ Connect a new platform via OAuth.
 one add shopify
 one add hubspot
 one add gmail
+one add gmail --tag work        # tag the connection
 ```
 
 Opens your browser, you authorize, done. The CLI polls until the connection is live. Platform names are lowercase (with dashes for multi-word names) - run `one platforms` to see them all.
+
+| Flag | What it does |
+|------|-------------|
+| `--tag <name>` | Tag the new connection once it's created. Lets sync/flow profiles target a specific connection via `"connection": { "platform": "gmail", "tag": "work" }` when you have several connections for one platform (e.g. personal vs work Gmail). |
 
 ### `one list`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.0",
+      "version": "1.47.6",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.6",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -251,7 +251,7 @@ Without declared paths, the default walker concatenates every string in the reco
 
 **Sync rejects custom actions** — profiles must use passthrough. `sync init` only surfaces passthrough models; `sync run` aborts if the list or enrich action is tagged `custom`. If no passthrough exists, compose a flow instead.
 
-**Connections are late-bound** — profiles use `"connection": { "platform": "<name>" }`, not literal `connectionKey` strings. The key is resolved at sync time, so `one add <platform>` (re-auth) doesn't break the profile. For multi-account platforms, add `"tag": "<connection-tag>"` to disambiguate. Don't hardcode connection keys in profiles.
+**Connections are late-bound** — profiles use `"connection": { "platform": "<name>" }`, not literal `connectionKey` strings. The key is resolved at sync time, so `one add <platform>` (re-auth) doesn't break the profile. For multi-account platforms, add `"tag": "<connection-tag>"` to disambiguate, and create the tagged connection with `one add <platform> --tag <name>`. Don't hardcode connection keys in profiles.
 
 **Advanced features** (enrich, transform, exclude, identityKey, hooks, --full-refresh, alternative backends, embedding tuning): run `one guide memory` or `one guide sync` for the full reference.
 
@@ -267,8 +267,9 @@ One also supports more advanced patterns. Read the relevant reference file befor
 If the user needs a platform that isn't connected yet, tell them to run:
 ```bash
 one add <platform>
+one add <platform> --tag <name>   # tag it (for multiple connections per platform)
 ```
-This is interactive and opens the browser for OAuth. After connecting, the platform will appear in `one --agent connection list`.
+This is interactive and opens the browser for OAuth. After connecting, the platform will appear in `one --agent connection list`. Use `--tag` when the user has (or will have) more than one connection for the same platform so sync/flow profiles can target a specific one via `"connection": { "platform": "<name>", "tag": "<name>" }`.
 
 ## Removing Connections
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -416,8 +416,9 @@ connection
   .command('add [platform]')
   .alias('a')
   .description('Add a new connection')
-  .action(async (platform) => {
-    await connectionAddCommand(platform);
+  .option('--tag <name>', 'Tag the new connection (disambiguates multiple connections per platform in sync/flow profiles)')
+  .action(async (platform, options) => {
+    await connectionAddCommand(platform, { tag: options.tag });
   });
 
 connection
@@ -812,8 +813,9 @@ program
 program
   .command('add [platform]')
   .description('Shortcut for: connection add')
-  .action(async (platform) => {
-    await connectionAddCommand(platform);
+  .option('--tag <name>', 'Tag the new connection (disambiguates multiple connections per platform in sync/flow profiles)')
+  .action(async (platform, options) => {
+    await connectionAddCommand(platform, { tag: options.tag });
   });
 
 program

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -8,7 +8,7 @@ import { printTable } from '../lib/table.js';
 import * as output from '../lib/output.js';
 import type { Connection } from '../lib/types.js';
 
-export async function connectionAddCommand(platformArg?: string): Promise<void> {
+export async function connectionAddCommand(platformArg?: string, options?: { tag?: string }): Promise<void> {
   if (output.isAgentMode()) {
     output.error('This command requires interactive input. Run without --agent.');
   }
@@ -120,7 +120,26 @@ export async function connectionAddCommand(platformArg?: string): Promise<void> 
     const connection = await api.waitForConnection(platform, 5 * 60 * 1000, 5000);
     pollSpinner.stop(`${platform} connected!`);
 
-    p.log.success(`${pc.green('✓')} ${connection.platform} is now available to your AI agents.`);
+    // Tag the freshly-created connection so sync/flow profiles can target it
+    // via `connection: { platform, tag }` when multiple connections share a
+    // platform (e.g. personal vs work Gmail). See cli#122.
+    const tag = options?.tag?.trim();
+    if (tag) {
+      const tagSpinner = p.spinner();
+      tagSpinner.start(`Tagging connection "${tag}"...`);
+      try {
+        await api.updateConnectionTags(connection.id, [tag]);
+        tagSpinner.stop(`Tagged "${tag}"`);
+      } catch (err) {
+        tagSpinner.stop('Could not set tag');
+        p.log.warn(
+          `Connected, but tagging failed: ${err instanceof Error ? err.message : 'Unknown error'}\n` +
+          `The connection is usable; set the tag later in the dashboard or retry.`
+        );
+      }
+    }
+
+    p.log.success(`${pc.green('✓')} ${connection.platform} is now available to your AI agents.${tag ? ` (tag: ${tag})` : ''}`);
     p.outro('Connection complete!');
   } catch (error) {
     pollSpinner.stop('Connection timed out');

--- a/src/lib/api-update-tags.test.ts
+++ b/src/lib/api-update-tags.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { OneApi } from './api.js';
+
+// #122: `one add --tag` tags a connection after the OAuth flow creates it.
+// Lock the request contract against pica-v2/core's
+// `PATCH /v1/vault/connections/{id}` (UpdateConnection { tags }).
+
+describe('OneApi.updateConnectionTags (#122)', () => {
+  let calls: Array<{ url: string; init: RequestInit }>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    calls = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: any, init: any) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response('', { status: 200 });
+    }) as typeof globalThis.fetch;
+  });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('issues PATCH /vault/connections/{id} with a tags body', async () => {
+    const api = new OneApi('sk_test_key', 'https://api.example.test/v1');
+    await api.updateConnectionTags('conn-123', ['personal']);
+
+    assert.equal(calls.length, 1);
+    const { url, init } = calls[0];
+    assert.equal(url, 'https://api.example.test/v1/vault/connections/conn-123');
+    assert.equal(init.method, 'PATCH');
+    assert.deepEqual(JSON.parse(init.body as string), { tags: ['personal'] });
+    const headers = init.headers as Record<string, string>;
+    assert.equal(headers['x-one-secret'], 'sk_test_key');
+    assert.equal(headers['Content-Type'], 'application/json');
+  });
+
+  it('sends multiple tags verbatim (replaces the set)', async () => {
+    const api = new OneApi('sk_test_key', 'https://api.example.test/v1');
+    await api.updateConnectionTags('c1', ['work', 'eu']);
+    assert.deepEqual(JSON.parse(calls[0].init.body as string), { tags: ['work', 'eu'] });
+  });
+
+  it('propagates API errors (e.g. 403/404) to the caller', async () => {
+    globalThis.fetch = (async () => new Response('forbidden', { status: 403 })) as typeof globalThis.fetch;
+    const api = new OneApi('sk_test_key', 'https://api.example.test/v1');
+    await assert.rejects(() => api.updateConnectionTags('c1', ['x']));
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -124,6 +124,17 @@ export class OneApi {
   }
 
   /**
+   * Set the tag set on a connection (replaces existing tags). Backs
+   * `one add <platform> --tag <name>`, which tags a connection right after
+   * the OAuth flow creates it so sync/flow profiles can reference it via
+   * `connection: { platform, tag }` when several connections share a platform.
+   * Maps to `PATCH /v1/vault/connections/{id}` (UpdateConnection { tags }).
+   */
+  async updateConnectionTags(id: string, tags: string[]): Promise<void> {
+    await this.requestFull({ path: `/vault/connections/${id}`, method: 'PATCH', body: { tags } });
+  }
+
+  /**
    * Resolve a late-bound `ConnectionRef` to a current `Connection`. Pass
    * `cache` (a pre-fetched connection list) when resolving many refs in a
    * loop, so each resolve doesn't repeat the listConnections round-trip.


### PR DESCRIPTION
Implements the missing half of #122. Linear: INT-3216. **v1.47.6.**

## Context
Sync/flow profiles already resolve `connection: { platform, tag }`, and `connection list` shows a Tags column — but there was **no CLI way to set a tag**, so users tagged via the dashboard or wrapper scripts. This adds the creation ergonomic the issue centers on.

## Change
`one add <platform> --tag <name>` (and `one connection add --tag`) tags the connection right after the OAuth flow creates it:
- New `OneApi.updateConnectionTags(id, tags)` → `PATCH /v1/vault/connections/{id}` with `{ tags }`. Endpoint + body shape (`UpdateConnection { tags }`) confirmed from `pica-v2/core` (`update_vault_connection_tags`).
- After `waitForConnection` returns the new connection, its tag is set; success line shows `(tag: <name>)`. Tagging failure is **non-fatal** — the connection is usable, with a warning to set it later.

## Verification
- 3 unit tests (`api-update-tags.test.ts`) lock the request contract via a fetch stub: `PATCH /vault/connections/{id}`, body `{ tags }`, `x-one-secret` header, multi-tag replace, and error propagation. **139/139 pass**; typecheck + build green.
- `--tag` appears in `one add --help` and `one connection add --help`.

**Scope note:** the live OAuth → PATCH path wasn't runtime-verified (needs a real connection; would mutate shared vault data), so it's built against the source-confirmed contract + unit-tested request construction. "Refresh-in-place" on re-add (issue point 4) is deferred — it needs connect-flow support in `core-ui`, not CLI-only.

## Already done (not in this PR)
- Sync tag resolution (`connection: { platform, tag }`) — works today.
- `connection list` Tags column — works today.

Docs: README `one add`, SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)