### PR TITLE
feat(flow): flow-level defaultOnError inherited by steps (#93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.0",
+      "version": "1.47.7",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.7",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -562,6 +562,22 @@ the outputSchema declaration.
 
 Strategies: `fail` (default), `continue`, `retry`, `fallback`.
 
+**Flow-level default (cli#93).** Set `defaultOnError` at the top of the flow and every step without its own `onError` inherits it — handy when most steps should `continue` (e.g. rendering/formatting pipelines) and you don't want to repeat it N times. A step opts out by declaring its own `onError`:
+
+```json
+{
+  "key": "render-report",
+  "defaultOnError": { "strategy": "continue" },
+  "steps": [
+    { "id": "critical", "onError": { "strategy": "fail" }, ... },   // stays fatal
+    { "id": "chart", ... },                                          // inherits continue
+    { "id": "thumbnail", ... }                                       // inherits continue
+  ]
+}
+```
+
+Scoped per-flow: a sub-flow uses its own `defaultOnError`, not the parent's.
+
 **Retry backoff.** By default each retry waits exactly `retryDelayMs`. For rate-limited APIs add `"backoff": "exponential"` (or `"exponential-jitter"`) and an optional `"maxDelayMs"` cap (defaults to 30000):
 
 ```json

--- a/src/lib/flow-default-onerror.test.ts
+++ b/src/lib/flow-default-onerror.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { executeFlow } from './flow-engine.js';
+import { validateFlow } from './flow-validator.js';
+import type { Flow } from './flow-types.js';
+import type { OneApi } from './api.js';
+
+// #93: a flow-level `defaultOnError` is inherited by every step without its own
+// `onError`; a step opts out with its own `onError`. Scoped per-flow.
+
+// executeFlow needs an api for action steps; these flows use only code steps,
+// so a stub that's never called suffices.
+const api = {} as unknown as OneApi;
+const run = (flow: Flow) => executeFlow(flow, {}, api, 'admin', ['*']);
+
+const boom = { id: 'boom', name: 'boom', type: 'code', code: { source: 'throw new Error("boom");' } };
+const after = { id: 'after', name: 'after', type: 'code', code: { source: 'return { ran: true };' } };
+
+describe('flow defaultOnError (#93)', () => {
+  it('a failing step with no onError inherits the flow default (continue)', async () => {
+    const ctx = await run({
+      key: 'f', name: 'F', inputs: {},
+      defaultOnError: { strategy: 'continue' },
+      steps: [boom, after],
+    } as Flow);
+    assert.equal(ctx.steps.boom.status, 'failed');
+    assert.equal(ctx.steps.after.status, 'success');   // downstream still ran
+  });
+
+  it('a step with its own onError overrides the flow default', async () => {
+    await assert.rejects(() => run({
+      key: 'f', name: 'F', inputs: {},
+      defaultOnError: { strategy: 'continue' },
+      steps: [{ ...boom, onError: { strategy: 'fail' } }, after],
+    } as Flow), /boom/);
+  });
+
+  it('without a flow default, a failing step is still fatal (unchanged)', async () => {
+    await assert.rejects(() => run({
+      key: 'f', name: 'F', inputs: {}, steps: [boom, after],
+    } as Flow), /boom/);
+  });
+
+  it('does not affect steps that succeed', async () => {
+    const ctx = await run({
+      key: 'f', name: 'F', inputs: {},
+      defaultOnError: { strategy: 'continue' },
+      steps: [after],
+    } as Flow);
+    assert.equal(ctx.steps.after.status, 'success');
+    assert.deepEqual(ctx.steps.after.output, { ran: true });
+  });
+
+  it('validates defaultOnError.strategy', () => {
+    const ok = validateFlow({ key: 'f', name: 'F', inputs: {}, defaultOnError: { strategy: 'continue' }, steps: [after] });
+    assert.deepEqual(ok, []);
+    const bad = validateFlow({ key: 'f', name: 'F', inputs: {}, defaultOnError: { strategy: 'bogus' }, steps: [after] });
+    assert.ok(bad.some(e => e.path === 'defaultOnError.strategy'));
+    const notObj = validateFlow({ key: 'f', name: 'F', inputs: {}, defaultOnError: 'continue', steps: [after] });
+    assert.ok(notObj.some(e => e.path === 'defaultOnError'));
+  });
+});

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -1114,17 +1114,21 @@ export async function executeSingleStep(
 
   const startTime = Date.now();
   let lastError: Error | undefined;
-  const maxAttempts = (step.onError?.strategy === 'retry' && step.onError.retries) ? step.onError.retries + 1 : 1;
+  // Effective error config: the step's own `onError`, else the flow-level
+  // `defaultOnError` (cli#93). Resolved once and used for every retry/strategy
+  // decision below so a step inherits the flow default unless it overrides.
+  const onError = step.onError ?? context._defaultOnError;
+  const maxAttempts = (onError?.strategy === 'retry' && onError.retries) ? onError.retries + 1 : 1;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       if (attempt > 1) {
-        const delay = computeRetryDelay(step.onError!, attempt);
+        const delay = computeRetryDelay(onError!, attempt);
         options.onEvent?.({
           event: 'step:retry',
           stepId: step.id,
           attempt,
-          maxRetries: step.onError!.retries!,
+          maxRetries: onError!.retries!,
           delayMs: delay,
         });
         await sleep(delay);
@@ -1236,9 +1240,9 @@ export async function executeSingleStep(
 
       // Conditional retry (cli#53): if retryOn/failFastOn are set, decide
       // whether THIS particular error should be retried at all.
-      if (step.onError?.strategy === 'retry' &&
-          (step.onError.retryOn || step.onError.failFastOn)) {
-        const decision = shouldRetryError(lastError, step.onError);
+      if (onError?.strategy === 'retry' &&
+          (onError.retryOn || onError.failFastOn)) {
+        const decision = shouldRetryError(lastError, onError);
         if (!decision.retry) {
           options.onEvent?.({
             event: 'step:retry-skip',
@@ -1254,7 +1258,7 @@ export async function executeSingleStep(
 
   // Handle error with strategy
   const errorMessage = lastError?.message || 'Unknown error';
-  const strategy = step.onError?.strategy || 'fail';
+  const strategy = onError?.strategy || 'fail';
   const retriesUsed = Math.max(0, maxAttempts - 1);
   const isTimeout = lastError instanceof StepTimeoutError;
   const errorCode = (lastError as { errorCode?: string } | undefined)?.errorCode;
@@ -1271,7 +1275,7 @@ export async function executeSingleStep(
     return result;
   }
 
-  if (strategy === 'fallback' && step.onError?.fallbackStepId) {
+  if (strategy === 'fallback' && onError?.fallbackStepId) {
     // The fallback step must already be defined in the flow
     // We mark this step as failed and the caller should handle fallback
     const result: StepResult = {
@@ -1434,6 +1438,10 @@ export async function executeFlow(
     loop: {},
   };
   context.input = resolvedInputs;
+  // Per-flow error default — steps without their own `onError` inherit this.
+  // Set on the context (not options) so a sub-flow's executeFlow scopes its
+  // own default rather than leaking the parent's. See cli#93.
+  context._defaultOnError = flow.defaultOnError;
 
   const completedStepIds = resumeState
     ? new Set(resumeState.completedSteps)

--- a/src/lib/flow-schema.ts
+++ b/src/lib/flow-schema.ts
@@ -52,6 +52,7 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
     version:     { type: 'string', required: false, description: 'Semver or arbitrary version string' },
     inputs:      { type: 'object', required: true, description: 'Input declarations (Record<string, InputDeclaration>)' },
     steps:       { type: 'array', required: true, description: 'Ordered array of steps', stepsArray: true },
+    defaultOnError: { type: 'object', required: false, description: 'Default error strategy inherited by every step without its own `onError` (e.g. { "strategy": "continue" }). A step opts out with its own `onError`.' },
   },
 
   inputFields: {

--- a/src/lib/flow-types.ts
+++ b/src/lib/flow-types.ts
@@ -210,6 +210,14 @@ export interface Flow {
   version?: string;
   inputs: Record<string, FlowInputDeclaration>;
   steps: FlowStep[];
+  /**
+   * Flow-wide default error strategy. Every step that does not declare its own
+   * `onError` inherits this; a step opts out by setting its own `onError`
+   * (e.g. `{ strategy: "fail" }` to stay fatal in an otherwise continue-on-error
+   * flow). Scoped per-flow — a sub-flow uses its own `defaultOnError`, not the
+   * parent's. See cli#93.
+   */
+  defaultOnError?: FlowStepErrorConfig;
 }
 
 export interface StepResult {
@@ -245,6 +253,13 @@ export interface FlowContext {
    * the run's lifetime is safe.
    */
   _connections?: import('./types.js').Connection[];
+  /**
+   * The running flow's `defaultOnError`, set by `executeFlow` so the step
+   * executor can fall back to it for steps without their own `onError`.
+   * Per-flow scoped — each (sub-)flow's `executeFlow` builds its own context
+   * and sets its own default. See cli#93.
+   */
+  _defaultOnError?: FlowStepErrorConfig;
 }
 
 export interface FlowRunState {

--- a/src/lib/flow-validator.ts
+++ b/src/lib/flow-validator.ts
@@ -39,6 +39,19 @@ export function validateFlowSchema(flow: unknown): ValidationError[] {
     errors.push({ path: 'version', message: '"version" must be a string' });
   }
 
+  // Flow-level default error strategy (cli#93) — inherited by steps without
+  // their own `onError`. Validate its strategy the same way step `onError` is.
+  if (f.defaultOnError !== undefined) {
+    if (!f.defaultOnError || typeof f.defaultOnError !== 'object' || Array.isArray(f.defaultOnError)) {
+      errors.push({ path: 'defaultOnError', message: '"defaultOnError" must be an object (e.g. { "strategy": "continue" })' });
+    } else {
+      const oe = f.defaultOnError as Record<string, unknown>;
+      if (!FLOW_SCHEMA.errorStrategies.includes(oe.strategy as string)) {
+        errors.push({ path: 'defaultOnError.strategy', message: `Error strategy must be one of: ${FLOW_SCHEMA.errorStrategies.join(', ')}` });
+      }
+    }
+  }
+
   // ── Validate inputs ──
 
   if (!f.inputs || typeof f.inputs !== 'object' || Array.isArray(f.inputs)) {


### PR DESCRIPTION
Closes #93. Linear: INT-3232. **v1.47.7.**

## What
A flow-level `defaultOnError` that every step without its own `onError` inherits — so a continue-on-error flow doesn't need `onError: {strategy:"continue"}` repeated on every step, and one un-annotated step can't crash the whole run. A step opts out by declaring its own `onError`.

```json
{
  "key": "render-report",
  "defaultOnError": { "strategy": "continue" },
  "steps": [
    { "id": "critical", "onError": { "strategy": "fail" }, ... },   // stays fatal (override)
    { "id": "chart", ... },                                          // inherits continue
    { "id": "thumbnail", ... }                                       // inherits continue
  ]
}
```

## How
- `Flow` type, schema descriptor, and `validateFlowSchema` gain `defaultOnError` (validated like step `onError`).
- `executeFlow` sets `context._defaultOnError = flow.defaultOnError`; the step executor resolves `effectiveOnError = step.onError ?? context._defaultOnError` for every retry/strategy/fallback decision.
- Set on the **context**, not options — so a sub-flow's `executeFlow` scopes its own default rather than inheriting the parent's.

## Verified (e2e + unit)
- `defaultOnError: continue` + failing step with no `onError` → step `failed` but **flow succeeds**, downstream runs.
- Per-step `onError: { strategy: "fail" }` → **overrides** → flow fails.
- No flow default → unchanged fatal behavior.
- Invalid `defaultOnError.strategy` / non-object → validation error.

Tests: +5 (`flow-default-onerror.test.ts`). **141/141 pass**; typecheck + build green. Docs: `references/flows.md` + the auto-generated `one guide flows` flow-fields table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)