### PR TITLE
feat(sync): one sync schema <platform/model> — inspect synced JSON structure (#106)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.0",
+      "version": "1.47.8",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.0",
+  "version": "1.47.8",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -229,6 +229,7 @@ one --agent sync test attio/attioPeople --show-searchable
 
 # Run — memory is always written; pass --no-memory to skip (rare)
 one --agent sync run stripe
+one --agent sync schema stripe/customers         # inspect field paths/types before querying
 one --agent sync query stripe/balanceTransactions --where "status=available" --limit 20
 one --agent sync search "refund"                 # hybrid across all synced platforms
 one --agent sync list stripe                     # progress + freshness

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -649,6 +649,7 @@ one --agent sync run stripe
 one --agent mem sync run stripe                    # identical (alias)
 
 # 5. Query + search (read from memory)
+one --agent sync schema stripe/customers                            # inspect field paths/types first
 one --agent sync query stripe/balanceTransactions --where "status=available" --limit 20
 one --agent sync query stripe/customers --where 'address.city=SF'   # dotted --where paths
 one --agent sync search "refund" --platform stripe                  # hybrid FTS + semantic
@@ -889,6 +890,7 @@ Every \`sync X\` command is also exposed as \`mem sync X\` — same handlers, sa
 | \`sync suggest-searchable <plat>/<model>\` | Rank candidate \`memory.searchable\` paths by signal density; emits paste-ready config |
 | \`sync run <platform>\` | Sync data (\`--full-refresh\`, \`--since\`, \`--dry-run\`, \`--no-memory\`) |
 | \`sync query <plat>/<model>\` | Query memory with \`--where\` (dotted paths), \`--after/before\` |
+| \`sync schema <plat>/<model>\` | Inspect the JSON structure of synced records (field paths, types, examples) — run before writing \`--where\` / query paths |
 | \`sync search "<query>"\` | Hybrid FTS + semantic across all synced data |
 | \`sync list [platform]\` | Show profiles, record counts, freshness |
 | \`sync schedule add/list/status/remove/repair\` | Manage cron schedules |

--- a/src/lib/memory/sync/index.ts
+++ b/src/lib/memory/sync/index.ts
@@ -1366,6 +1366,14 @@ function registerSyncSubcommands(sync: Command): void {
     });
 
   sync
+    .command('schema <platform/model>')
+    .description('Inspect the JSON structure of synced records (field paths, types, examples) — useful before writing `sync sql` queries')
+    .action(async (platformModel: string) => {
+      const { syncSchemaCommand } = await import('./schema.js');
+      await syncSchemaCommand(platformModel);
+    });
+
+  sync
     .command('delete <platform/model>')
     .description('Delete records from local sync data (e.g. one sync delete notion/pages --id "abc-123")')
     .option('--id <value>', 'Delete record by ID')

--- a/src/lib/memory/sync/schema.test.ts
+++ b/src/lib/memory/sync/schema.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { inferSyncSchema } from './schema.js';
+
+// #106: infer field paths → types + example + presence from a sample of
+// synced record `data` objects.
+
+const byPath = (fields: ReturnType<typeof inferSyncSchema>) =>
+  Object.fromEntries(fields.map(f => [f.path, f]));
+
+describe('inferSyncSchema (#106)', () => {
+  it('infers flat primitive fields with types and examples', () => {
+    const f = byPath(inferSyncSchema([{ id: 'thread_abc', count: 5, open: true }]));
+    assert.deepEqual(f.id.types, ['string']);
+    assert.equal(f.id.example, 'thread_abc');
+    assert.deepEqual(f.count.types, ['number']);
+    assert.equal(f.count.example, 5);
+    assert.deepEqual(f.open.types, ['boolean']);
+    assert.equal(f.open.example, true);
+  });
+
+  it('walks nested objects with dotted paths', () => {
+    const f = byPath(inferSyncSchema([{ meta: { score: 9, label: 'hot' } }]));
+    assert.deepEqual(f.meta.types, ['object']);
+    assert.equal(f.meta.example, undefined);          // containers have no example
+    assert.deepEqual(f['meta.score'].types, ['number']);
+    assert.equal(f['meta.score'].example, 9);
+    assert.deepEqual(f['meta.label'].types, ['string']);
+  });
+
+  it('describes arrays of objects via [] element paths', () => {
+    const f = byPath(inferSyncSchema([{ messages: [{ sender: 'a@b.com', subject: 'Hi' }] }]));
+    assert.deepEqual(f.messages.types, ['array[object]']);
+    assert.deepEqual(f['messages[].sender'].types, ['string']);
+    assert.equal(f['messages[].sender'].example, 'a@b.com');
+    assert.deepEqual(f['messages[].subject'].types, ['string']);
+  });
+
+  it('labels arrays of primitives by element type', () => {
+    const f = byPath(inferSyncSchema([{ tags: ['urgent', 'billing'] }, { tags: [] }]));
+    // first record: array[string]; second: empty → array[unknown]
+    assert.deepEqual(f.tags.types, ['array[string]', 'array[unknown]']);
+    assert.equal(f.tags.presence, 2);
+  });
+
+  it('aggregates mixed types and tracks presence across records', () => {
+    const f = byPath(inferSyncSchema([
+      { v: 1, only_in_first: 'x' },
+      { v: 'two' },
+      { v: 3 },
+    ]));
+    assert.deepEqual(f.v.types, ['number', 'string']); // sorted
+    assert.equal(f.v.presence, 3);
+    assert.equal(f.only_in_first.presence, 1);          // sparse field
+  });
+
+  it('handles null leaves and truncates long example strings', () => {
+    const long = 'x'.repeat(100);
+    const f = byPath(inferSyncSchema([{ empty: null, big: long }]));
+    assert.deepEqual(f.empty.types, ['null']);
+    assert.equal(f.empty.example, undefined);           // null is not captured as an example
+    assert.equal((f.big.example as string).length, 58); // 57 + ellipsis
+    assert.ok((f.big.example as string).endsWith('…'));
+  });
+
+  it('returns a path-sorted list and ignores non-object records', () => {
+    const fields = inferSyncSchema([{ b: 1, a: 2 }, null as any, 'nope' as any]);
+    assert.deepEqual(fields.map(f => f.path), ['a', 'b']);
+  });
+});

--- a/src/lib/memory/sync/schema.ts
+++ b/src/lib/memory/sync/schema.ts
@@ -1,0 +1,144 @@
+/**
+ * `one sync schema <platform/model>` — infer and print the JSON structure of
+ * synced records so users can write `sync sql` `json_extract(...)` queries
+ * without guessing paths. Samples up to N records of the type, walks each
+ * record's `data`, and aggregates field paths → observed type(s), an example
+ * value, and how often the path appears across the sample. See cli#106.
+ */
+
+import pc from 'picocolors';
+import * as output from '../../output.js';
+import { getBackend } from '../runtime.js';
+import { requireMemoryInit, okJson } from '../../../commands/mem/util.js';
+
+const SAMPLE_SIZE = 100;
+
+export interface SchemaField {
+  /** Dot/`[]` path, e.g. `messages[].sender`. */
+  path: string;
+  /** Observed type(s): `string` | `number` | `boolean` | `null` | `object` | `array[<elem>]`. */
+  types: string[];
+  /** First non-null example value for a leaf path (omitted for object/array containers). */
+  example?: unknown;
+  /** Number of sampled records in which this path appeared. */
+  presence: number;
+}
+
+function typeOf(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  return typeof v; // 'string' | 'number' | 'boolean' | 'object' | 'undefined'
+}
+
+/** Truncate long example strings so the schema stays scannable. */
+function exampleOf(v: unknown): unknown {
+  if (typeof v === 'string') return v.length > 60 ? `${v.slice(0, 57)}…` : v;
+  return v;
+}
+
+interface Acc {
+  types: Set<string>;
+  example?: unknown;
+  hasExample: boolean;
+  presence: number;
+}
+
+function addPath(path: string, value: unknown, acc: Map<string, Acc>): void {
+  const t = typeOf(value);
+  let typeLabel: string;
+
+  if (t === 'array') {
+    const arr = value as unknown[];
+    const elemType = arr.length ? typeOf(arr[0]) : 'unknown';
+    typeLabel = `array[${elemType}]`;
+  } else {
+    typeLabel = t;
+  }
+
+  const entry = acc.get(path) ?? { types: new Set<string>(), hasExample: false, presence: 0 };
+  entry.types.add(typeLabel);
+  entry.presence += 1;
+  // Capture an example only for leaf primitives — containers are described by
+  // their type label and their child paths.
+  if (!entry.hasExample && t !== 'object' && t !== 'array' && value !== null && value !== undefined) {
+    entry.example = exampleOf(value);
+    entry.hasExample = true;
+  }
+  acc.set(path, entry);
+
+  // Recurse into structure.
+  if (t === 'object') {
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      addPath(path ? `${path}.${k}` : k, v, acc);
+    }
+  } else if (t === 'array') {
+    const arr = value as unknown[];
+    if (arr.length && typeOf(arr[0]) === 'object') {
+      // Describe element-object fields from the first element.
+      for (const [k, v] of Object.entries(arr[0] as Record<string, unknown>)) {
+        addPath(`${path}[].${k}`, v, acc);
+      }
+    }
+  }
+}
+
+/**
+ * Infer a flat, sorted field list from a sample of record `data` objects.
+ * Pure — no I/O — so it's directly unit-testable.
+ */
+export function inferSyncSchema(dataRecords: Array<Record<string, unknown>>): SchemaField[] {
+  const acc = new Map<string, Acc>();
+  for (const data of dataRecords) {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) continue;
+    for (const [k, v] of Object.entries(data)) addPath(k, v, acc);
+  }
+  return [...acc.entries()]
+    .map(([path, e]) => ({
+      path,
+      types: [...e.types].sort(),
+      ...(e.hasExample ? { example: e.example } : {}),
+      presence: e.presence,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export async function syncSchemaCommand(platformModel: string, _options: Record<string, unknown> = {}): Promise<void> {
+  requireMemoryInit();
+  const type = platformModel;
+  const backend = await getBackend();
+
+  let recordCount = 0;
+  try { recordCount = await backend.count(type, { status: 'active' }); } catch { /* best effort */ }
+
+  const records = await backend.list(type, { limit: SAMPLE_SIZE, status: 'active' });
+  if (records.length === 0) {
+    if (output.isAgentMode()) {
+      okJson({ type, recordCount: 0, sampled: 0, fields: [] });
+      return;
+    }
+    output.note(`No records found for "${type}". Run \`one sync run <platform>\` first, or check \`one --agent sync status\`.`, 'Schema');
+    return;
+  }
+
+  const fields = inferSyncSchema(records.map(r => r.data));
+
+  if (output.isAgentMode()) {
+    okJson({ type, recordCount, sampled: records.length, fields });
+    return;
+  }
+
+  // Human: aligned tree of path / type / example.
+  console.log();
+  console.log(`${pc.bold(type)} ${pc.dim(`(${recordCount.toLocaleString()} record${recordCount === 1 ? '' : 's'}, sampled ${records.length})`)}`);
+  console.log();
+  const pathWidth = Math.min(Math.max(...fields.map(f => f.path.length), 4) + 2, 50);
+  const typeWidth = Math.max(...fields.map(f => f.types.join('|').length), 4) + 2;
+  for (const f of fields) {
+    const optional = f.presence < records.length ? pc.yellow(' ?') : '';
+    const ex = f.example !== undefined ? pc.dim(JSON.stringify(f.example)) : '';
+    console.log(`  ${f.path.padEnd(pathWidth)}${pc.cyan(f.types.join('|').padEnd(typeWidth))}${ex}${optional}`);
+  }
+  console.log();
+  console.log(pc.dim(`  ? = present in only some sampled records (optional/sparse field)`));
+  console.log();
+}


### PR DESCRIPTION
Closes #106. Linear: INT-3233. **v1.47.8.**

## What
`one sync schema <platform/model>` inspects the JSON structure of synced records so you can write `sync query` / SQL paths without guessing at `json_extract` shapes.

```
$ one sync schema demo/widgets

demo/widgets (3 records, sampled 3)

  extra               string                        "sparse" ?
  id                  string                        "w3"
  messages            array[object]                  ?
  messages[].sender   string                        "x@y.com" ?
  meta                object
  meta.score          number                        1
  tags                array[string]|array[unknown]

  ? = present in only some sampled records (optional/sparse field)
```

## How
- Samples up to 100 records (`backend.list(type, {limit})`, `backend.count(type)` for the total).
- `inferSyncSchema(dataRecords)` (pure, in `src/lib/memory/sync/schema.ts`) walks each record's `data`: dotted paths for nested objects, `field[]` for array-of-object element fields, `array[<elem>]` labels, mixed-type aggregation, and per-record presence.
- Human: aligned path / type / example tree with `?` for sparse fields. `--agent`: `{ type, recordCount, sampled, fields: [{ path, types, example, presence }] }`.

## Verified
End-to-end against seeded `demo/widgets` records — nested `meta.score`, `messages[].sender`, `array[string]`, and the sparse-field `?` marker all render in both human and agent output.

Tests: +7 (`schema.test.ts`) covering flat/nested/array/mixed-type/presence/null/truncation/sorting. **143/143 pass**; typecheck + build green. Docs: guide-content + SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)