### PR TITLE
feat(flow): JSON-Schema validation for file-read steps (#80)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.6",
+  "version": "1.47.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.6",
+      "version": "1.47.9",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.6",
+  "version": "1.47.9",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -400,6 +400,28 @@ After a parallel step, access each substep's output by its `id`: `$.steps.fetchE
 { "id": "write", "type": "file-write", "fileWrite": { "path": "./output/results.json", "content": "$.steps.transform.output" } }
 ```
 
+**Validate a read config (`fileRead.schema`).** With `parseJson: true` you can add an optional `schema` that is **enforced at runtime** — a mismatch throws (`errorCode: "SCHEMA_VALIDATION"`) and is handled by the step's `onError`, so a bad config file fails fast with a clear message instead of producing garbage downstream. (This is distinct from `step.outputSchema`, which is documentation/wiring only and never checked at runtime.)
+
+```json
+{
+  "id": "read", "type": "file-read",
+  "fileRead": {
+    "path": "./data/config.json", "parseJson": true,
+    "schema": {
+      "name": { "type": "string", "required": true },
+      "mode": { "type": "string", "required": true, "enum": ["dev", "staging", "prod"] },
+      "retries": { "type": "number" },
+      "tags": { "type": "array", "items": "string", "minItems": 1, "maxItems": 10 },
+      "coords": { "type": "array", "length": 2, "items": "number" },
+      "owner": { "type": "object", "required": true,
+                 "properties": { "id": "string", "email": { "type": "string", "required": true } } }
+    }
+  }
+}
+```
+
+Field rules (a richer field-rule format inspired by `outputSchema`): a value is a bare type string (`"string"`, optional) or `{ type, required, enum, items, minItems, maxItems, length, properties }`. Types: `string`/`number`/`boolean`/`object`/`array`/`null`/`unknown` (`unknown` passes anything). **Array constraints (`items`/`minItems`/`maxItems`/`length`) require `type: "array"`, and `properties` requires `type: "object"`** — `flow validate` rejects them otherwise (so they can't silently no-op). All violations are reported in one error; paths are dotted/indexed (`owner.email`, `tags[3]`); a non-object root reports `expected an object at the root but got <type>`. `flow validate` checks the schema's shape (and that `parseJson:true` is set). With `onError: { strategy: "continue" }` the step lands as `{ status: "failed", errorCode: "SCHEMA_VALIDATION" }` so downstream steps can branch on it; `retry`/`fallback` and `retryOn:["SCHEMA_VALIDATION"]` work too.
+
 ### `while` — Condition-driven loop (do-while)
 
 ```json

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -16,6 +16,9 @@ import type {
   FlowEvent,
   FlowExecuteOptions,
   FlowActionConfig,
+  FileReadSchema,
+  FileReadFieldSchema,
+  FileReadSchemaLeafType,
 } from './flow-types.js';
 import { getByDotPath, setByDotPath } from './dot-path.js';
 
@@ -46,6 +49,126 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, stepId: string):
   return Promise.race([promise, timeoutPromise]).finally(() => {
     if (timer) clearTimeout(timer);
   }) as Promise<T>;
+}
+
+/**
+ * Thrown when a `file-read` step's parsed output fails its declared
+ * `fileRead.schema`. Carries `errorCode: 'SCHEMA_VALIDATION'` so it rides the
+ * existing onError/retry/fallback machinery (matchable via retryOn/failFastOn).
+ * See cli#80.
+ */
+class FileReadSchemaError extends Error {
+  errorCode = 'SCHEMA_VALIDATION' as const;
+  constructor(stepId: string, violations: string[]) {
+    super(`Step "${stepId}" output failed schema validation: ${violations.join('; ')}`);
+    this.name = 'FileReadSchemaError';
+  }
+}
+
+/** Normalize a field rule (bare type string → descriptor). */
+function asFieldSchema(node: FileReadSchemaLeafType | FileReadFieldSchema): FileReadFieldSchema {
+  return typeof node === 'string' ? { type: node } : node;
+}
+
+function actualType(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  return typeof v; // 'string' | 'number' | 'boolean' | 'object' | 'undefined'
+}
+
+/** True when `v` matches the leaf type (`unknown` always matches). */
+function matchesLeafType(v: unknown, t: FileReadSchemaLeafType): boolean {
+  switch (t) {
+    case 'unknown': return true;
+    case 'null': return v === null;
+    case 'array': return Array.isArray(v);
+    case 'object': return v !== null && typeof v === 'object' && !Array.isArray(v);
+    default: return typeof v === t; // string | number | boolean
+  }
+}
+
+/** Recursively collect human-readable violations of `value` against a field map. */
+function isPlainObjectValue(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function collectFileReadViolations(value: unknown, schema: FileReadSchema, basePath: string, out: string[]): void {
+  // The root (and any `properties` object) is validated key-by-key. A
+  // non-object here is itself a violation — report it clearly rather than
+  // silently passing (e.g. an all-optional schema against a bare array/scalar)
+  // or attributing it to a missing required field. See cli#80 review.
+  if (!isPlainObjectValue(value)) {
+    const where = basePath ? `at "${basePath.replace(/\.$/, '')}"` : 'at the root';
+    out.push(`expected an object ${where} but got ${actualType(value)}`);
+    return;
+  }
+  const obj = value;
+  for (const [field, raw] of Object.entries(schema)) {
+    const rule = asFieldSchema(raw);
+    const path = `${basePath}${field}`;
+    const present = Object.prototype.hasOwnProperty.call(obj, field) && obj[field] !== undefined;
+
+    if (!present) {
+      if (rule.required) out.push(`field "${path}" is required but missing`);
+      continue; // absent optional field — nothing else to check
+    }
+    checkFileReadRule(obj[field], rule, path, out);
+  }
+}
+
+/** Validate a single present value against its field rule. */
+function checkFileReadRule(value: unknown, rule: FileReadFieldSchema, path: string, out: string[]): void {
+  if (rule.type && !matchesLeafType(value, rule.type)) {
+    out.push(`field "${path}" expected ${rule.type} but got ${actualType(value)}`);
+    return; // type wrong — downstream checks would be noise
+  }
+  // Array.isArray guard so a malformed schema reaching runtime (e.g. via
+  // --skip-validation, where the load-time enum-shape check is bypassed)
+  // degrades to a no-op instead of throwing a raw TypeError without errorCode.
+  if (Array.isArray(rule.enum) && !rule.enum.some(e => e === value)) {
+    out.push(`field "${path}" value ${JSON.stringify(value)} is not one of [${rule.enum.map(e => JSON.stringify(e)).join(', ')}]`);
+  }
+  // Array constraints. `items`/`minItems`/`maxItems`/`length` require
+  // `type:'array'` (enforced at load time), so a non-array value is already
+  // caught above; this block is defensive for the --skip-validation path too.
+  const hasArrayConstraint =
+    rule.items !== undefined || rule.minItems !== undefined || rule.maxItems !== undefined || rule.length !== undefined;
+  if (hasArrayConstraint) {
+    if (!Array.isArray(value)) {
+      if (!rule.type) out.push(`field "${path}" expected array but got ${actualType(value)}`);
+    } else {
+      if (rule.length !== undefined && value.length !== rule.length) {
+        out.push(`field "${path}" expected array of length ${rule.length} but got length ${value.length}`);
+      }
+      if (rule.minItems !== undefined && value.length < rule.minItems) {
+        out.push(`field "${path}" expected at least ${rule.minItems} item${rule.minItems === 1 ? '' : 's'} but got ${value.length}`);
+      }
+      if (rule.maxItems !== undefined && value.length > rule.maxItems) {
+        out.push(`field "${path}" expected at most ${rule.maxItems} item${rule.maxItems === 1 ? '' : 's'} but got ${value.length}`);
+      }
+      if (rule.items !== undefined) {
+        const itemRule = asFieldSchema(rule.items);
+        value.forEach((el, i) => checkFileReadRule(el, itemRule, `${path}[${i}]`, out));
+      }
+    }
+  }
+  // `properties` requires `type:'object'` (enforced at load time). Self-enforce
+  // here too so a non-object value yields a clear violation rather than a
+  // silently-skipped nested schema.
+  if (rule.properties) {
+    if (isPlainObjectValue(value)) {
+      collectFileReadViolations(value, rule.properties, `${path}.`, out);
+    } else if (!rule.type) {
+      out.push(`field "${path}" expected object but got ${actualType(value)}`);
+    }
+  }
+}
+
+/** Throw a single FileReadSchemaError enumerating every violation (empty ⇒ ok). */
+export function assertMatchesFileReadSchema(value: unknown, schema: FileReadSchema, stepId: string): void {
+  const violations: string[] = [];
+  collectFileReadViolations(value, schema, '', violations);
+  if (violations.length > 0) throw new FileReadSchemaError(stepId, violations);
 }
 
 /**
@@ -725,6 +848,11 @@ function executeFileReadStep(step: FlowStep, context: FlowContext): StepResult {
   const resolvedPath = path.resolve(filePath);
   const content = fs.readFileSync(resolvedPath, 'utf-8');
   const output = config.parseJson ? JSON.parse(stripCodeFences(content)) : content;
+  // Optional runtime shape check on the parsed output (cli#80). Throws a
+  // FileReadSchemaError that the executeSingleStep catch routes through onError.
+  if (config.parseJson && config.schema) {
+    assertMatchesFileReadSchema(output, config.schema, step.id);
+  }
   return { status: 'success', output, response: output };
 }
 

--- a/src/lib/flow-file-read-schema.test.ts
+++ b/src/lib/flow-file-read-schema.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { assertMatchesFileReadSchema, executeFlow } from './flow-engine.js';
+import { validateFlow } from './flow-validator.js';
+import type { FileReadSchema, Flow } from './flow-types.js';
+import type { OneApi } from './api.js';
+
+// #80: runtime + load-time validation for `fileRead.schema`.
+
+function violations(value: unknown, schema: FileReadSchema): string[] {
+  try { assertMatchesFileReadSchema(value, schema, 'readConfig'); return []; }
+  catch (e) {
+    assert.equal((e as { errorCode?: string }).errorCode, 'SCHEMA_VALIDATION');
+    assert.match((e as Error).message, /^Step "readConfig" output failed schema validation: /);
+    return (e as Error).message.replace(/^Step "readConfig" output failed schema validation: /, '').split('; ');
+  }
+}
+
+describe('assertMatchesFileReadSchema — runtime (#80)', () => {
+  const full: FileReadSchema = {
+    name: { type: 'string', required: true },
+    retries: { type: 'number', required: true },
+    mode: { type: 'string', required: true, enum: ['dev', 'staging', 'prod'] },
+    tags: { type: 'array', items: 'string', minItems: 1, maxItems: 3 },
+    coords: { type: 'array', length: 2, items: 'number' },
+    owner: { type: 'object', required: true, properties: { id: 'string', email: { type: 'string', required: true } } },
+  };
+  const ok = { name: 'x', retries: 3, mode: 'dev', tags: ['a'], coords: [1, 2], owner: { id: 'o1', email: 'a@b.com' } };
+
+  it('passes a fully conforming object', () => {
+    assert.deepEqual(violations(ok, full), []);
+  });
+
+  it('flags a missing required field', () => {
+    const v = violations({ ...ok, name: undefined }, full);
+    assert.ok(v.includes('field "name" is required but missing'));
+  });
+
+  it('flags a wrong type with actual vs expected', () => {
+    const v = violations({ ...ok, retries: '3' }, full);
+    assert.ok(v.some(m => /field "retries" expected number but got string/.test(m)));
+  });
+
+  it('flags an enum violation', () => {
+    const v = violations({ ...ok, mode: 'qa' }, full);
+    assert.ok(v.some(m => /field "mode" value "qa" is not one of/.test(m)));
+  });
+
+  it('flags array length: exact / min / max', () => {
+    assert.ok(violations({ ...ok, coords: [1, 2, 3] }, full).some(m => /coords" expected array of length 2 but got length 3/.test(m)));
+    assert.ok(violations({ ...ok, tags: [] }, full).some(m => /tags" expected at least 1 item but got 0/.test(m)));
+    assert.ok(violations({ ...ok, tags: ['a', 'b', 'c', 'd'] }, full).some(m => /tags" expected at most 3 items but got 4/.test(m)));
+  });
+
+  it('flags a bad array element via indexed path', () => {
+    const v = violations({ ...ok, tags: ['a', 5] }, full);
+    assert.ok(v.some(m => /field "tags\[1\]" expected string but got number/.test(m)));
+  });
+
+  it('flags a nested required field via dotted path', () => {
+    const v = violations({ ...ok, owner: { id: 'o1' } }, full);
+    assert.ok(v.includes('field "owner.email" is required but missing'));
+  });
+
+  it('reports ALL violations in one throw (not fail-fast)', () => {
+    const v = violations({ retries: '3', mode: 'qa' }, full); // name & owner missing, retries wrong, mode bad enum
+    assert.ok(v.length >= 4, `expected multiple violations, got ${JSON.stringify(v)}`);
+    assert.ok(v.includes('field "name" is required but missing'));
+    assert.ok(v.includes('field "owner" is required but missing'));
+  });
+
+  it('shorthand "field":"string" is an OPTIONAL string', () => {
+    assert.deepEqual(violations({}, { note: 'string' }), []);                 // absent optional ok
+    assert.ok(violations({ note: 5 }, { note: 'string' }).some(m => /expected string but got number/.test(m)));
+  });
+
+  it('null handling: type:object rejects null, type:null accepts null', () => {
+    assert.ok(violations({ x: null }, { x: { type: 'object' } }).some(m => /expected object but got null/.test(m)));
+    assert.deepEqual(violations({ x: null }, { x: { type: 'null' } }), []);
+  });
+
+  it('type:unknown passes anything', () => {
+    assert.deepEqual(violations({ a: 1, b: 'x', c: [1], d: null }, { a: 'unknown', b: 'unknown', c: 'unknown', d: 'unknown' }), []);
+  });
+
+  it('flags a non-object root (array/scalar/null) clearly, even with all-optional schema', () => {
+    for (const root of [[1, 2], 'hello', 42, null] as unknown[]) {
+      const v = violations(root, { name: 'string' });
+      assert.ok(v.some(m => /^expected an object at the root but got /.test(m)), `root ${JSON.stringify(root)} → ${JSON.stringify(v)}`);
+    }
+  });
+
+  it('type:object rejects an array value', () => {
+    assert.ok(violations({ owner: [1] }, { owner: { type: 'object', properties: { id: { type: 'string', required: true } } } })
+      .some(m => /field "owner" expected object but got array/.test(m)));
+  });
+
+  it('enum matches strictly and supports number/boolean/null entries', () => {
+    assert.deepEqual(violations({ n: 2, b: true, z: null }, { n: { enum: [1, 2, 3] }, b: { enum: [true, false] }, z: { enum: [null] } }), []);
+    // strict: string "2" is not number 2
+    assert.ok(violations({ n: '2' }, { n: { enum: [1, 2] } }).some(m => /is not one of/.test(m)));
+  });
+
+  it('allows extra/unknown keys (open schema)', () => {
+    assert.deepEqual(violations({ name: 'x', extra: 'ok', more: [1] }, { name: { type: 'string', required: true } }), []);
+  });
+});
+
+describe('validateFileReadSchemas — load-time shape (#80)', () => {
+  const flow = (fileRead: Record<string, unknown>): Flow => ({
+    key: 'f', name: 'F', inputs: {},
+    steps: [{ id: 'r', name: 'r', type: 'file-read', fileRead }],
+  } as unknown as Flow);
+  const paths = (f: Flow) => validateFlow(f).map(e => e.path);
+
+  it('accepts a valid schema with parseJson:true', () => {
+    assert.deepEqual(validateFlow(flow({ path: './c.json', parseJson: true, schema: {
+      name: { type: 'string', required: true }, mode: { type: 'string', enum: ['a', 'b'] },
+      tags: { type: 'array', items: 'string', minItems: 1, maxItems: 5 },
+    } })), []);
+  });
+
+  it('errors when schema is set without parseJson:true', () => {
+    const errs = validateFlow(flow({ path: './c.json', schema: { x: 'string' } }));
+    assert.ok(errs.some(e => e.path === 'steps[0].fileRead.schema' && /only checked when parseJson:true/.test(e.message)));
+  });
+
+  it('flags an unknown leaf type', () => {
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: 'strngg' } })).includes('steps[0].fileRead.schema.x'));
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: { type: 'blob' } } })).includes('steps[0].fileRead.schema.x.type'));
+  });
+
+  it('flags empty enum and bad enum entries', () => {
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: { enum: [] } } })).includes('steps[0].fileRead.schema.x.enum'));
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: { enum: [{ a: 1 }] } } })).includes('steps[0].fileRead.schema.x.enum'));
+  });
+
+  it('requires type:array for any array constraint (items/minItems/maxItems/length)', () => {
+    for (const rule of [{ items: 'number' }, { minItems: 1 }, { maxItems: 2 }, { length: 2 }, { type: 'string', items: 'number' }]) {
+      assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: rule } })).includes('steps[0].fileRead.schema.x.type'),
+        `expected type-gate error for ${JSON.stringify(rule)}`);
+    }
+    // valid when type:array is declared
+    assert.deepEqual(validateFlow(flow({ path: 'c', parseJson: true, schema: { x: { type: 'array', items: 'number', minItems: 1 } } })), []);
+  });
+
+  it('requires type:object for properties', () => {
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: { properties: { y: 'string' } } } })).includes('steps[0].fileRead.schema.x.properties'));
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: { type: 'string', properties: { y: 'string' } } } })).includes('steps[0].fileRead.schema.x.properties'));
+    assert.deepEqual(validateFlow(flow({ path: 'c', parseJson: true, schema: { x: { type: 'object', properties: { y: 'string' } } } })), []);
+  });
+
+  it('reports an items-descriptor error under a clean .items path (no synthetic [])', () => {
+    const p = paths(flow({ path: 'c', parseJson: true, schema: { x: { type: 'array', items: { type: 'bogus' } } } }));
+    assert.ok(p.includes('steps[0].fileRead.schema.x.items.type'), `got ${JSON.stringify(p)}`);
+    assert.ok(!p.some(s => s.includes('[]')), 'no synthetic [] segment should leak into paths');
+  });
+
+  it('flags bad array-length bounds', () => {
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: { type: 'array', minItems: -1 } } })).includes('steps[0].fileRead.schema.x.minItems'));
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: { type: 'array', minItems: 5, maxItems: 2 } } })).includes('steps[0].fileRead.schema.x.minItems'));
+    assert.ok(paths(flow({ path: 'c', parseJson: true, schema: { x: { type: 'array', length: 2, minItems: 1 } } })).includes('steps[0].fileRead.schema.x.length'));
+  });
+
+  it('validates schemas inside nested blocks (parallel)', () => {
+    const f = { key: 'f', name: 'F', inputs: {}, steps: [
+      { id: 'p', name: 'p', type: 'parallel', parallel: { steps: [
+        { id: 'r', name: 'r', type: 'file-read', fileRead: { path: 'c', parseJson: true, schema: { x: 'nope' } } },
+      ] } },
+    ] } as unknown as Flow;
+    assert.ok(validateFlow(f).some(e => e.path === 'steps[0].parallel.steps[0].fileRead.schema.x'));
+  });
+});
+
+describe('file-read schema — executor integration / onError (#80)', () => {
+  let dir: string;
+  let file: string;
+  const api = {} as unknown as OneApi; // file-read needs no API
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-fr-schema-'));
+    file = path.join(dir, 'config.json');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const schema = { name: { type: 'string', required: true }, mode: { type: 'string', required: true, enum: ['dev', 'prod'] } };
+  const flow = (onError?: unknown): Flow => ({
+    key: 'f', name: 'F', inputs: {},
+    steps: [
+      { id: 'read', name: 'read', type: 'file-read', ...(onError ? { onError } : {}), fileRead: { path: file, parseJson: true, schema } },
+      { id: 'after', name: 'after', type: 'code', code: { source: 'return { ran: true };' } },
+    ],
+  } as unknown as Flow);
+
+  it('onError:continue → step failed with errorCode SCHEMA_VALIDATION, downstream runs', async () => {
+    fs.writeFileSync(file, JSON.stringify({ name: 'svc' }));   // missing required mode
+    const ctx = await executeFlow(flow({ strategy: 'continue' }), {}, api, 'admin', ['*']);
+    assert.equal(ctx.steps.read.status, 'failed');
+    assert.equal(ctx.steps.read.errorCode, 'SCHEMA_VALIDATION');
+    assert.match(String(ctx.steps.read.error), /field "mode" is required but missing/);
+    assert.equal(ctx.steps.after.status, 'success');   // run continued
+  });
+
+  it('default fail → schema mismatch aborts the run', async () => {
+    fs.writeFileSync(file, JSON.stringify({ name: 'svc', mode: 'qa' }));   // bad enum
+    await assert.rejects(() => executeFlow(flow(), {}, api, 'admin', ['*']), /SCHEMA_VALIDATION|is not one of/);
+  });
+
+  it('conforming file → success', async () => {
+    fs.writeFileSync(file, JSON.stringify({ name: 'svc', mode: 'dev' }));
+    const ctx = await executeFlow(flow(), {}, api, 'admin', ['*']);
+    assert.equal(ctx.steps.read.status, 'success');
+    assert.deepEqual(ctx.steps.read.output, { name: 'svc', mode: 'dev' });
+  });
+
+  it('retryOn:[SCHEMA_VALIDATION] re-reads + re-validates (recovers when the file is fixed mid-retry)', async () => {
+    fs.writeFileSync(file, JSON.stringify({ name: 'svc' }));   // initially invalid
+    // Fix the file shortly after the run starts, before retries are exhausted.
+    setTimeout(() => fs.writeFileSync(file, JSON.stringify({ name: 'svc', mode: 'dev' })), 40);
+    const ctx = await executeFlow(
+      flow({ strategy: 'retry', retries: 5, retryDelayMs: 30, retryOn: ['SCHEMA_VALIDATION'] }),
+      {}, api, 'admin', ['*'],
+    );
+    assert.equal(ctx.steps.read.status, 'success');
+  });
+});

--- a/src/lib/flow-schema.ts
+++ b/src/lib/flow-schema.ts
@@ -183,14 +183,22 @@ export const FLOW_SCHEMA: FlowSchemaDescriptor = {
     {
       type: 'file-read',
       configKey: 'fileRead',
-      description: 'Read a file (optional JSON parse)',
+      description: 'Read a file (optional JSON parse). With parseJson:true you may add an optional `schema` (field → type string, or { type, required, enum, items, minItems/maxItems/length, properties }) enforced at runtime — a mismatch throws (errorCode SCHEMA_VALIDATION) handled by the step\'s onError. Array constraints (items/minItems/maxItems/length) require type:"array" and properties requires type:"object". Unlike outputSchema (doc/wiring only), this checks the actual parsed value.',
       fields: {
         path:      { type: 'string', required: true, description: 'File path to read' },
         parseJson: { type: 'boolean', required: false, description: 'Parse contents as JSON (default: false)' },
       },
       example: {
         id: 'readConfig', name: 'Read config file', type: 'file-read',
-        fileRead: { path: './data/config.json', parseJson: true },
+        fileRead: {
+          path: './data/config.json',
+          parseJson: true,
+          schema: {
+            name: { type: 'string', required: true },
+            mode: { type: 'string', required: true, enum: ['dev', 'staging', 'prod'] },
+            tags: { type: 'array', items: 'string', minItems: 1, maxItems: 10 },
+          },
+        },
       },
     },
     {

--- a/src/lib/flow-types.ts
+++ b/src/lib/flow-types.ts
@@ -64,9 +64,47 @@ export interface FlowParallelConfig {
   maxConcurrency?: number;
 }
 
+export type FileReadSchemaLeafType =
+  | 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null' | 'unknown';
+
+/**
+ * Per-field rule for a `fileRead.schema`. A field value may be a bare type
+ * string (shorthand for `{ type }`, optional) or this descriptor.
+ */
+export interface FileReadFieldSchema {
+  /** Expected type. `unknown` passes anything; `array`/`object` checked structurally. */
+  type?: FileReadSchemaLeafType;
+  /** Field must be present (not undefined). Default false — matches FlowOutputSchema. */
+  required?: boolean;
+  /** Value must strictly equal one of these. */
+  enum?: (string | number | boolean | null)[];
+  /** Schema applied to each element when `type: 'array'`. */
+  items?: FileReadSchemaLeafType | FileReadFieldSchema;
+  /** Array length lower/upper bounds. */
+  minItems?: number;
+  maxItems?: number;
+  /** Exact array length. */
+  length?: number;
+  /** Nested field schema when `type: 'object'`. */
+  properties?: FileReadSchema;
+}
+
+/** A `fileRead.schema`: field name → leaf type (shorthand) or a field descriptor. */
+export type FileReadSchema = {
+  [field: string]: FileReadSchemaLeafType | FileReadFieldSchema;
+};
+
 export interface FlowFileReadConfig {
   path: string;
   parseJson?: boolean;
+  /**
+   * Optional runtime shape check applied to the PARSED output (only consulted
+   * when `parseJson: true`). Unlike `step.outputSchema` — which is a
+   * documentation/wiring aid the engine never enforces — a mismatch here
+   * THROWS (errorCode `SCHEMA_VALIDATION`) and is handled by the step's
+   * `onError`. Absent ⇒ no check, behaviour unchanged. See cli#80.
+   */
+  schema?: FileReadSchema;
 }
 
 export interface FlowFileWriteConfig {

--- a/src/lib/flow-validator.ts
+++ b/src/lib/flow-validator.ts
@@ -764,6 +764,7 @@ export function validateFlow(flow: unknown, rootDir?: string): ValidationError[]
     ...validateStepIds(f),
     ...validateSelectorReferences(f, rootDir),
     ...validateOutputSchemas(f),
+    ...validateFileReadSchemas(f),
     ...(rootDir ? validateCodeModules(f, rootDir) : []),
   ];
 }
@@ -804,6 +805,127 @@ export function validateCodeModules(flow: Flow, rootDir: string): ValidationErro
         }
       }
       // Recurse into nested step arrays
+      for (const { configKey, fieldName } of nestedKeys) {
+        const config = (step as unknown as Record<string, unknown>)[configKey] as Record<string, unknown> | undefined;
+        if (config && Array.isArray(config[fieldName])) {
+          walk(config[fieldName] as FlowStep[], `${stepPath}.${configKey}.${fieldName}`);
+        }
+      }
+    }
+  }
+
+  walk(flow.steps, 'steps');
+  return errors;
+}
+
+// ── file-read schema shape validation (cli#80) ──
+
+const VALID_FILE_READ_SCHEMA_TYPES = new Set(['string', 'number', 'boolean', 'object', 'array', 'null', 'unknown']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** Validate one field rule (type string or descriptor object) at `fieldPath`. */
+function validateFileReadFieldRule(raw: unknown, fieldPath: string, errors: ValidationError[]): void {
+  if (typeof raw === 'string') {
+    if (!VALID_FILE_READ_SCHEMA_TYPES.has(raw)) {
+      errors.push({ path: fieldPath, message: `unknown type "${raw}". Allowed: ${[...VALID_FILE_READ_SCHEMA_TYPES].join(', ')}.` });
+    }
+    return;
+  }
+  if (!isPlainObject(raw)) {
+    errors.push({ path: fieldPath, message: 'field rule must be a type string or an object (e.g. { "type": "string", "required": true })' });
+    return;
+  }
+  const rule = raw;
+  if (rule.type !== undefined && (typeof rule.type !== 'string' || !VALID_FILE_READ_SCHEMA_TYPES.has(rule.type))) {
+    errors.push({ path: `${fieldPath}.type`, message: `unknown type "${String(rule.type)}". Allowed: ${[...VALID_FILE_READ_SCHEMA_TYPES].join(', ')}.` });
+  }
+  if (rule.required !== undefined && typeof rule.required !== 'boolean') {
+    errors.push({ path: `${fieldPath}.required`, message: '"required" must be a boolean' });
+  }
+  if (rule.enum !== undefined) {
+    if (!Array.isArray(rule.enum) || rule.enum.length === 0) {
+      errors.push({ path: `${fieldPath}.enum`, message: '"enum" must be a non-empty array of allowed values' });
+    } else if (rule.enum.some(e => e !== null && typeof e === 'object')) {
+      errors.push({ path: `${fieldPath}.enum`, message: '"enum" entries must be primitives (string/number/boolean) or null' });
+    }
+  }
+  for (const k of ['minItems', 'maxItems', 'length'] as const) {
+    const n = rule[k];
+    if (n !== undefined && (typeof n !== 'number' || !Number.isInteger(n) || n < 0)) {
+      errors.push({ path: `${fieldPath}.${k}`, message: `"${k}" must be a non-negative integer` });
+    }
+  }
+  if (typeof rule.minItems === 'number' && typeof rule.maxItems === 'number' && rule.minItems > rule.maxItems) {
+    errors.push({ path: `${fieldPath}.minItems`, message: '"minItems" must be <= "maxItems"' });
+  }
+  if (rule.length !== undefined && (rule.minItems !== undefined || rule.maxItems !== undefined)) {
+    errors.push({ path: `${fieldPath}.length`, message: '"length" cannot be combined with "minItems"/"maxItems"' });
+  }
+  // Array constraints require `type:'array'` (otherwise they're silently a
+  // no-op at runtime). Require the type, don't just tolerate it. See cli#80 review.
+  const hasArrayConstraint =
+    rule.items !== undefined || rule.minItems !== undefined || rule.maxItems !== undefined || rule.length !== undefined;
+  if (hasArrayConstraint && rule.type !== 'array') {
+    errors.push({ path: `${fieldPath}.type`, message: '"items"/"minItems"/"maxItems"/"length" require "type": "array"' });
+  }
+  if (rule.items !== undefined) {
+    if (typeof rule.items === 'string') {
+      if (!VALID_FILE_READ_SCHEMA_TYPES.has(rule.items)) {
+        errors.push({ path: `${fieldPath}.items`, message: `unknown item type "${rule.items}". Allowed: ${[...VALID_FILE_READ_SCHEMA_TYPES].join(', ')}.` });
+      }
+    } else if (isPlainObject(rule.items)) {
+      validateFileReadFieldRule(rule.items, `${fieldPath}.items`, errors);
+    } else {
+      errors.push({ path: `${fieldPath}.items`, message: '"items" must be a type string or a field rule object' });
+    }
+  }
+  // `properties` requires `type:'object'`.
+  if (rule.properties !== undefined) {
+    if (rule.type !== 'object') {
+      errors.push({ path: `${fieldPath}.properties`, message: '"properties" requires "type": "object"' });
+    }
+    errors.push(...validateFileReadSchemaShape(rule.properties, `${fieldPath}.properties`));
+  }
+}
+
+/** Validate the *shape* of a `fileRead.schema` declaration (not a file value). */
+function validateFileReadSchemaShape(schema: unknown, location: string): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (!isPlainObject(schema)) {
+    errors.push({ path: location, message: '"schema" must be an object mapping field names to type/rules' });
+    return errors;
+  }
+  for (const [field, raw] of Object.entries(schema)) {
+    validateFileReadFieldRule(raw, `${location}.${field}`, errors);
+  }
+  return errors;
+}
+
+/**
+ * Validate every `fileRead.schema` declaration in the flow tree (cli#80):
+ * malformed schema shapes, and `schema` set without `parseJson: true`.
+ */
+export function validateFileReadSchemas(flow: Flow): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const nestedKeys = getNestedStepsKeys();
+
+  function walk(steps: FlowStep[], pathPrefix: string): void {
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      const stepPath = `${pathPrefix}[${i}]`;
+      if (step.type === 'file-read' && step.fileRead && (step.fileRead as { schema?: unknown }).schema !== undefined) {
+        const fr = step.fileRead as { parseJson?: unknown; schema?: unknown };
+        if (fr.parseJson !== true) {
+          errors.push({
+            path: `${stepPath}.fileRead.schema`,
+            message: 'fileRead.schema is only checked when parseJson:true — set parseJson:true or remove schema.',
+          });
+        }
+        errors.push(...validateFileReadSchemaShape(fr.schema, `${stepPath}.fileRead.schema`));
+      }
       for (const { configKey, fieldName } of nestedKeys) {
         const config = (step as unknown as Record<string, unknown>)[configKey] as Record<string, unknown> | undefined;
         if (config && Array.isArray(config[fieldName])) {


### PR DESCRIPTION
## What

Adds an optional `schema` to `fileRead` steps (only meaningful with `parseJson: true`) that validates the parsed JSON **at runtime**. On a mismatch the step throws with `errorCode: SCHEMA_VALIDATION`, so a malformed config/data file fails fast with one clear, all-violations-at-once message instead of feeding garbage into downstream steps.

Closes #80.

### Why this is distinct from `outputSchema`
`step.outputSchema` is documentation/wiring metadata — it is never enforced at runtime. This is a real guard on data read from disk, which is exactly where bad input enters a flow.

### Format
```yaml
- id: read-config
  type: file-read
  config:
    path: ./config.json
    parseJson: true
    schema:
      name: string                       # bare-type shorthand
      port: { type: number, required: true }
      env: { type: string, enum: [dev, staging, prod] }
      tags: { type: array, items: string, minItems: 1, maxItems: 10 }
      owner: { type: object, properties: { email: string } }
```
Types: `string | number | boolean | object | array | null | unknown`. Field rules: `type, required, enum, items, minItems, maxItems, length, properties`.

### Behaviour
- Rides the step's existing `onError` machinery — `retry` / `fallback` / `continue` all work against `SCHEMA_VALIDATION` (e.g. `retryOn: [SCHEMA_VALIDATION]`).
- Accumulates **all** violations in one message with dotted paths (`owner.email`, `tags[1]`).
- No new dependency — a small custom validator reusing the existing `ValidationError` + `onError` plumbing.

## Hardening (from adversarial review)
- Array constraints (`items`/`minItems`/`maxItems`/`length`) require `type: "array"`, and `properties` requires `type: "object"`, enforced at **load time** — so they can never silently no-op.
- A non-object parsed root reports a clear violation instead of passing silently.
- Runtime `enum` check is `Array.isArray`-guarded — no raw `TypeError` under `--skip-validation`.
- The items-descriptor validation path no longer leaks a synthetic `[]` segment.

## Tests
+28 tests (`src/lib/flow-file-read-schema.test.ts`) across three layers: runtime `assertMatchesFileReadSchema`, load-time `validateFlow`, and executor-level `executeFlow` (onError + retry recovery). **198/198 pass**; `typecheck` + `build` green.

## Docs
`skills/one/references/flows.md` + the `file-read` descriptor in `flow-schema.ts` (feeds `one guide flows`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)