### PR TITLE
fix(actions): render text/* responses inline instead of misclassifying as binary (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ one actions execute stripe <actionId> <connectionKey> \
 | `--dry-run` | Show the request without executing it |
 | `--mock` | Return example response without making an API call |
 | `--skip-validation` | Skip input validation against the action schema |
-| `--output <path>` | Save response to a file (for binary downloads) |
+| `--output <path>` | Save response to a file (for genuine binary downloads — PDFs, images). Text responses (text/plain, HTML, CSV, XML) render inline automatically. |
 | `--no-cache` | Bypass the cached action details and re-fetch them; the fresh details still refresh the cache (execution itself is never cached) |
 
 The CLI validates required parameters (path variables, query params, body fields) against the action schema before executing. Missing params return a clear error with the flag name and description. Pass `--skip-validation` to bypass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.6",
+  "version": "1.47.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.6",
+      "version": "1.47.11",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.6",
+  "version": "1.47.11",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -89,7 +89,7 @@ Options:
 - `--dry-run` — Preview the request without executing
 - `--mock` — Return example response without making an API call (useful for building UI)
 - `--skip-validation` — Skip input validation against the action schema
-- `--output <path>` — Save response to a file (for binary downloads like PDFs, images, documents)
+- `--output <path>` — Save response to a file (for binary downloads like PDFs, images, documents). Text responses (text/plain, HTML, CSV, XML) render inline automatically; `--output` is only needed for genuinely binary payloads.
 - `--no-cache` — Bypass the cached action details and re-fetch them; the fresh details still refresh the cache (execution itself is never cached)
 
 The CLI validates required parameters before executing. Missing params return a structured error with the flag name, parameter name, and description. Pass `--skip-validation` to bypass.

--- a/src/commands/actions.ts
+++ b/src/commands/actions.ts
@@ -486,7 +486,15 @@ export async function actionsExecuteCommand(
     } else {
       console.log();
       console.log(pc.bold('Response:'));
-      console.log(JSON.stringify(result.responseData, null, 2));
+      const rd = result.responseData as { text?: unknown; contentType?: unknown } | null;
+      if (rd && typeof rd === 'object' && typeof rd.text === 'string' && 'contentType' in rd) {
+        // Text body (text/plain, text/html, CSV, …) — print it inline rather
+        // than as an escaped JSON string. (#163)
+        if (rd.contentType) console.log(pc.dim(`(${rd.contentType})`));
+        console.log(rd.text);
+      } else {
+        console.log(JSON.stringify(result.responseData, null, 2));
+      }
     }
   } catch (error) {
     spinner.stop('Execution failed');

--- a/src/lib/api-text-response.test.ts
+++ b/src/lib/api-text-response.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { OneApi, isTextualContentType, looksLikeText } from './api.js';
+import type { ActionDetails, ExecuteActionArgs } from './types.js';
+
+// #163: `actions execute` classified ANY non-JSON response as binary, hiding
+// readable text/plain, text/html, CSV, etc. behind "Binary response received".
+// The proxy also mislabels text endpoints as application/octet-stream, so the
+// fix needs both a content-type check and a text-sniff fallback.
+
+describe('isTextualContentType (#163)', () => {
+  for (const ct of [
+    'text/plain', 'text/html', 'text/csv', 'TEXT/PLAIN',
+    'text/plain; charset=utf-8', 'application/json', 'application/json; charset=utf-8',
+    'application/xml', 'application/javascript', 'application/x-www-form-urlencoded',
+    'application/yaml', 'application/ld+json', 'image/svg+xml',
+  ]) {
+    it(`treats "${ct}" as textual`, () => assert.equal(isTextualContentType(ct), true));
+  }
+  for (const ct of [
+    'application/octet-stream', 'image/png', 'image/jpeg', 'application/pdf',
+    'application/zip', 'audio/mpeg', '',
+  ]) {
+    it(`treats "${ct || '<empty>'}" as NOT textual`, () => assert.equal(isTextualContentType(ct), false));
+  }
+});
+
+describe('looksLikeText (#163)', () => {
+  it('accepts plain ascii / whitespace / unicode', () => {
+    assert.equal(looksLikeText('8.8.8.8\n'), true);
+    assert.equal(looksLikeText('<!DOCTYPE html><title>Example</title>'), true);
+    assert.equal(looksLikeText('a,b,c\n1,2,3\n'), true);
+    assert.equal(looksLikeText('café — über'), true); // accented UTF-8 + em dash
+    assert.equal(looksLikeText(''), true);
+  });
+  it('rejects a NUL byte or invalid-UTF8 replacement char', () => {
+    assert.equal(looksLikeText('abc\u0000def'), false);
+    assert.equal(looksLikeText('abc\uFFFDdef'), false);
+  });
+  it('rejects bodies dense with control characters (binary)', () => {
+    // PNG magic + IHDR-ish control bytes (written as escapes — pure-ASCII source)
+    assert.equal(looksLikeText('\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x01\x02\x03\x04'), false);
+    assert.equal(looksLikeText('\x01\x02\x03\x04\x05\x06\x07\x08'), false);
+  });
+});
+
+describe('OneApi.executePassthroughRequest — text vs binary classification (#163)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  const api = new OneApi('test-key', 'http://proxy/v1');
+
+  const action = { _id: 'a1', method: 'GET', path: '/x', tags: [] } as unknown as ActionDetails;
+  const args: ExecuteActionArgs = { platform: 'p', actionId: 'a1', connectionKey: 'k' };
+
+  function mockResponse(body: string, contentType: string) {
+    globalThis.fetch = (async () =>
+      new Response(body, { status: 200, headers: contentType ? { 'content-type': contentType } : {} })
+    ) as typeof globalThis.fetch;
+  }
+
+  beforeEach(() => { originalFetch = globalThis.fetch; });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('returns plain text as a string (text/plain, not JSON)', async () => {
+    mockResponse('8.8.8.8\n', 'text/plain; charset=utf-8');
+    const { responseData } = await api.executePassthroughRequest(args, action);
+    assert.deepEqual(responseData, { text: '8.8.8.8\n', contentType: 'text/plain; charset=utf-8' });
+  });
+
+  it('returns HTML as text (text/html)', async () => {
+    mockResponse('<!DOCTYPE html><title>Example Domain</title>', 'text/html');
+    const { responseData } = await api.executePassthroughRequest(args, action) as { responseData: any };
+    assert.equal(responseData.text, '<!DOCTYPE html><title>Example Domain</title>');
+    assert.equal(responseData.contentType, 'text/html');
+  });
+
+  it('still parses JSON when the body is JSON (text/* or application/json)', async () => {
+    mockResponse('{"token":"abc","n":2}', 'application/json');
+    const { responseData } = await api.executePassthroughRequest(args, action);
+    assert.deepEqual(responseData, { token: 'abc', n: 2 });
+  });
+
+  it('parses JSON that the proxy mislabeled as octet-stream', async () => {
+    mockResponse('{"ok":true}', 'application/octet-stream');
+    const { responseData } = await api.executePassthroughRequest(args, action);
+    assert.deepEqual(responseData, { ok: true });
+  });
+
+  it('THE #163 REPRO: octet-stream text body is returned as text, not a binary stub', async () => {
+    mockResponse('8.8.8.8\n', 'application/octet-stream');
+    const { responseData } = await api.executePassthroughRequest(args, action) as { responseData: any };
+    assert.equal(responseData.binary, undefined, 'must NOT be classified binary');
+    assert.equal(responseData.text, '8.8.8.8\n');
+    assert.equal(responseData.contentType, 'application/octet-stream');
+  });
+
+  it('still returns the binary stub for genuinely binary octet-stream bytes', async () => {
+    mockResponse('\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x01\x02\x03\x04', 'application/octet-stream');
+    const { responseData } = await api.executePassthroughRequest(args, action) as { responseData: any };
+    assert.equal(responseData.binary, true);
+    assert.equal(responseData.contentType, 'application/octet-stream');
+    assert.match(responseData.message, /Binary response received/);
+  });
+
+  it('a text/plain body that happens to be valid JSON is parsed (JSON wins)', async () => {
+    mockResponse('[1,2,3]', 'text/plain');
+    const { responseData } = await api.executePassthroughRequest(args, action);
+    assert.deepEqual(responseData, [1, 2, 3]);
+  });
+
+  it('an empty body returns {}', async () => {
+    mockResponse('', 'text/plain');
+    const { responseData } = await api.executePassthroughRequest(args, action);
+    assert.deepEqual(responseData, {});
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,6 +25,49 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * True if a `Content-Type` names a textual format that should be rendered as a
+ * string, not treated as binary. Covers `text/*` plus the common textual
+ * `application/*` types (JSON, XML, JS, form-encoded, YAML, and `+json`/`+xml`
+ * structured-suffix variants), ignoring any `; charset=…` parameter. See #163.
+ */
+export function isTextualContentType(contentType: string): boolean {
+  const ct = contentType.toLowerCase().split(';')[0].trim();
+  if (ct.startsWith('text/')) return true;
+  if (ct.endsWith('+json') || ct.endsWith('+xml')) return true;
+  return [
+    'application/json',
+    'application/xml',
+    'application/javascript',
+    'application/ecmascript',
+    'application/x-www-form-urlencoded',
+    'application/yaml',
+    'application/x-yaml',
+    'application/csv',
+  ].includes(ct);
+}
+
+/**
+ * Heuristic: does a UTF-8-decoded body look like human-readable text rather than
+ * binary? The API proxy mislabels text endpoints as `application/octet-stream`
+ * (#163), so when the content-type is unhelpful we sniff the decoded string. A
+ * NUL byte or a U+FFFD replacement char (invalid UTF-8) means binary; otherwise
+ * we allow a small fraction of control characters (some text legitimately
+ * contains the odd control byte) before calling it binary.
+ */
+export function looksLikeText(s: string): boolean {
+  if (s.length === 0) return true;
+  if (s.includes('\u0000') || s.includes('\uFFFD')) return false;
+  let control = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    // Allow tab (0x09), LF (0x0a), CR (0x0d), and (rarely) other whitespace;
+    // count the remaining C0 control chars as binary signal.
+    if ((c < 0x09 || (c > 0x0d && c < 0x20)) || c === 0x7f) control++;
+  }
+  return control / s.length < 0.05;
+}
+
 /** Parse a Retry-After header value (either delta-seconds or HTTP-date). */
 function parseRetryAfter(value: string | null): number | undefined {
   if (!value) return undefined;
@@ -488,16 +531,25 @@ export class OneApi {
     }
 
     const responseContentType = response.headers.get('content-type') || '';
-    const isExplicitJson = responseContentType.includes('application/json') || responseContentType.includes('text/');
 
-    if (isExplicitJson || !responseContentType) {
-      // Explicit JSON/text content-type — fast path
+    // Textual content-type (text/*, application/json|xml|…) or none: read as
+    // text, parse JSON when possible, otherwise return the raw text instead of
+    // crashing on JSON.parse — e.g. text/plain, text/html, CSV, XML. (#163)
+    if (isTextualContentType(responseContentType) || !responseContentType) {
       const responseText = await response.text();
-      const responseData = responseText ? JSON.parse(responseText) : {};
-      return { requestConfig: sanitizedConfig, responseData };
+      if (!responseText) return { requestConfig: sanitizedConfig, responseData: {} };
+      try {
+        return { requestConfig: sanitizedConfig, responseData: JSON.parse(responseText) };
+      } catch {
+        return {
+          requestConfig: sanitizedConfig,
+          responseData: { text: responseText, contentType: responseContentType || 'text/plain' },
+        };
+      }
     }
 
-    // Ambiguous content-type (e.g. application/octet-stream from the API proxy).
+    // Non-textual content-type (e.g. application/octet-stream — which the proxy
+    // also uses for JSON responses AND for mislabeled text endpoints, #163).
     // With --output: stream to disk (memory-safe for large binary files).
     if (args.output) {
       const outputPath = resolve(args.output);
@@ -515,14 +567,21 @@ export class OneApi {
       };
     }
 
-    // Without --output: try JSON parse, fall back to binary metadata.
-    // The API proxy often returns application/octet-stream for JSON responses,
-    // so we must attempt parsing before assuming binary.
+    // Without --output: try JSON parse (the proxy often sends JSON as
+    // octet-stream); then sniff — a printable body is a text endpoint the proxy
+    // mislabeled, so return it as text (#163); only genuine bytes become the
+    // binary stub.
     const responseText = await response.text();
     try {
       const responseData = responseText ? JSON.parse(responseText) : {};
       return { requestConfig: sanitizedConfig, responseData };
     } catch {
+      if (looksLikeText(responseText)) {
+        return {
+          requestConfig: sanitizedConfig,
+          responseData: { text: responseText, contentType: responseContentType },
+        };
+      }
       const contentLength = response.headers.get('content-length');
       const size = contentLength ? parseInt(contentLength, 10) : responseText.length;
       return {

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -58,7 +58,7 @@ one --agent actions execute <platform> <actionId> <key> -d '{}'  # Execute it
 - \`--dry-run\` — Preview request without executing
 - \`--mock\` — Return example response without making an API call (useful for building UI against a response shape)
 - \`--skip-validation\` — Skip input validation against the action schema
-- \`--output <path>\` — Save response to a file (for binary downloads like PDFs, images, documents)
+- \`--output <path>\` — Save response to a file (for binary downloads like PDFs, images, documents). Text responses (text/plain, HTML, CSV, XML) render inline automatically — \`--output\` is only needed for genuinely binary payloads.
 - \`--no-cache\` — Bypass the cached action details and re-fetch them; the fresh details still refresh the cache (execution itself is never cached)
 
 The CLI validates required parameters against the action schema before executing. If you're missing a required path variable, query param, or body field, you'll get a clear error listing what's missing and which flag to use. Pass \`--skip-validation\` to bypass.
@@ -187,7 +187,7 @@ one --agent actions execute <platform> <actionId> <connectionKey> [options]
 - \`--dry-run\` — Preview without executing
 - \`--mock\` — Return example response without making an API call
 - \`--skip-validation\` — Skip input validation against the action schema
-- \`--output <path>\` — Save response to a file (for binary downloads like PDFs, images, documents)
+- \`--output <path>\` — Save response to a file (for binary downloads like PDFs, images, documents). Text responses (text/plain, HTML, CSV, XML) render inline automatically — \`--output\` is only needed for genuinely binary payloads.
 - \`--no-cache\` — Bypass the cached action details and re-fetch them; the fresh details still refresh the cache (execution itself is never cached)
 
 Execute reuses the action details cached by \`actions knowledge\` (method, path, schema), so in the standard search → knowledge → execute flow it makes a single API call — the action being executed. The live response is never cached. In \`--agent\` mode the response includes \`"_preflight": {"cache": "hit"|"miss"}\` showing whether the lookup was served from disk.


### PR DESCRIPTION
## Bug

`one actions execute` classified **any non-JSON response as binary** and hid it behind `"Binary response received. Use --output"`, even for human-readable `text/plain`, `text/html`, `text/csv`, XML. The call is a clean `200`, but the operator had to re-run with `--output` and `cat`/`od` the file to confirm the integration even worked.

Closes #163.

### Two root causes
1. The explicit-text fast path did an **unconditional `JSON.parse`**, which *threw* on genuine non-JSON text.
2. The API proxy **mislabels text endpoints as `application/octet-stream`**, so the "not JSON ⇒ binary" fallback swallowed them — a content-type check alone wouldn't catch it (the ipinfo repro literally returns `contentType: application/octet-stream` for `8.8.8.8\n`).

## Fix — classify by content-type **and** sniff the body
- **`isTextualContentType()`** — `text/*`, `application/json|xml|javascript|ecmascript|x-www-form-urlencoded|yaml|csv`, and `+json`/`+xml` structured suffixes (charset param ignored). Textual ⇒ parse JSON if possible, else return the raw text instead of crashing.
- **`looksLikeText()`** — for `octet-stream`, sniff the decoded body: a NUL byte or `U+FFFD` (invalid UTF-8) ⇒ binary; otherwise allow `<5%` control chars. A printable body is a mislabeled text endpoint → returned as text.
- Genuinely-binary bytes still get the binary stub; `--output` still streams to disk (memory-safe).

### Return shape
Text responses return `{ text, contentType }` — a string in the `--agent` envelope alongside `contentType` (exactly what the issue asks for). Human mode prints the text **inline** under `Response:` instead of an escaped JSON blob.

## Tests
+31 (`src/lib/api-text-response.test.ts`): content-type matrix, the text sniff (incl. PNG-magic / NUL / replacement-char negatives), and the `executePassthroughRequest` paths — including the exact octet-stream-text repro and "JSON-mislabeled-as-octet-stream still parses". **201/201 suite pass**; typecheck + build green.

## Docs
`guide-content.ts`, `SKILL.md`, `README.md` — clarify `--output` is for genuine binaries; text renders inline. Version 1.47.11 + lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)