### PR TITLE
feat(mem): cross-platform identity keys — identityKeys, built-in profiles, mem find-by-key (#128/#129/#130/#131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,16 @@ one mem update <id> '{"status":"done"}'              # merges into data; refresh
 one mem search "design review"                       # hybrid FTS + semantic (if key set)
 one mem list note --limit 20
 
-# Identity keys are a first-class column (unique across ACTIVE records; archiving
-# frees them). Manage them after creation with `mem key` — NOT via `mem update`.
+# Merge keys (`keys[]`) are a first-class column (unique across ACTIVE records;
+# archiving frees them). Manage them after creation with `mem key` — NOT `mem update`.
 one mem key <id> --add email:x@y.com                 # also --remove / --set <csv>
+
+# Find every record tied to a person/company, grouped by type. Spans BOTH columns:
+# `keys[]` (this record IS the entity — drives merge) and `identity_keys[]` (this
+# record INVOLVES the entity — Gmail thread participants, calendar attendees; never merges).
+one mem find-by-key email:jane@acme.com              # every record carrying the key
+one mem find-by-key email:jane@acme.com --type gmail/gmailThreads
+one mem find-by-key email:jane@acme.com email:bob@acme.com   # intersection — records with BOTH
 
 # Backfill searchable_text for rows that landed NULL or with UUID-noise-heavy text
 # (drops ids/timestamps, leads with name/title/email). No embedding provider needed.
@@ -389,7 +396,9 @@ one mem status                                       # backend, provider, _upgra
 one mem doctor                                       # 7-check health report
 ```
 
-Key surfaces: `add`, `get`, `update`, `archive`, `list`, `search` (`--deep` forces semantic), `context`, `link`/`linked`/`unlink`, `sources`, `find-by-source`, `export`, `import`, `migrate`, `vacuum`, `reindex`. Run `one guide memory` for the full reference.
+Key surfaces: `add`, `get`, `update`, `archive`, `list`, `search` (`--deep` forces semantic), `context`, `link`/`linked`/`unlink`, `key`, `sources`, `find-by-source`, `find-by-key`, `export`, `import`, `migrate`, `vacuum`, `reindex`. Run `one guide memory` for the full reference.
+
+`find-by-key` is the cross-platform join: keys are matched **case-insensitively** (they are lowercased on write, and the query is lowercased to match), `--type` narrows to one record type, and `--limit` (default 10) caps how many records are *shown per type* while the reported per-type `count` and overall `total` stay full match counts. Above 2000 matches the response flags `truncated` and the counts become floors — re-run with `--type` for an exact answer. Populate `identity_keys[]` from a sync profile's `identityKeys` field (see `one guide sync`), which ships pre-wired for `gmail/gmailThreads`, `google-calendar/events`, and `fathom/meetings`.
 
 ### `one sync` (and `one mem sync` alias)
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,10 @@ one sync test stripe/balanceTransactions --show-searchable
 # Run — every row lands in memory (SQLite also written for enrich-phase compat)
 one sync run stripe --since 90d
 one mem sync run stripe                              # identical (alias)
+# Profiles with `enrich` run a second detail pass. It enriches each record ONCE;
+# the list pass thereafter merges rather than replaces, so the enriched payload
+# survives (reported as `memPreserved`). `--full-refresh` does not re-enrich —
+# delete .one/sync/data/<platform>.db to force that.
 
 # Query + search (reads from memory)
 one sync query stripe/balanceTransactions --where "status=available" --limit 20

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.6",
+  "version": "1.47.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.47.6",
+      "version": "1.47.12",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node": "^22.13.1",
         "@types/pg": "^8.20.0",
         "tsup": "^8.3.6",
+        "tsx": "^4.23.1",
         "typescript": "^5.7.3"
       },
       "engines": {
@@ -2627,6 +2628,509 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.47.6",
+  "version": "1.47.12",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/node": "^22.13.1",
     "@types/pg": "^8.20.0",
     "tsup": "^8.3.6",
+    "tsx": "^4.23.1",
     "typescript": "^5.7.3"
   },
   "repository": {

--- a/profiles/fathom/meetings.json
+++ b/profiles/fathom/meetings.json
@@ -17,6 +17,10 @@
   "queryParams": {
     "include_action_items": "true"
   },
+  "identityKeys": [
+    { "prefix": "email", "path": "recorded_by.email" },
+    { "prefix": "email", "path": "calendar_invitees[].email" }
+  ],
   "enrich": {
     "actionId": "conn_mod_def::GIpBYFV5Mog::G6aag6ykQ-uD6XCeUUnq7Q",
     "pathVars": {

--- a/profiles/gmail/gmailThreads.json
+++ b/profiles/gmail/gmailThreads.json
@@ -15,6 +15,11 @@
   "defaultLimit": 100,
   "pathVars": { "userId": "me" },
   "queryParams": { "q": "category:primary" },
+  "identityKeys": [
+    { "prefix": "email", "path": "messages[].payload.headers[name=From].value" },
+    { "prefix": "email", "path": "messages[].payload.headers[name=To].value" },
+    { "prefix": "email", "path": "messages[].payload.headers[name=Cc].value" }
+  ],
   "enrich": {
     "actionId": "conn_mod_def::GJ3ok0Eq0R8::AAzgZVLqTg2iBuITKpJLZg",
     "pathVars": { "userId": "me", "id": "{id}" },

--- a/profiles/google-calendar/events.json
+++ b/profiles/google-calendar/events.json
@@ -13,5 +13,9 @@
   },
   "pathVars": { "calendarId": "primary" },
   "defaultLimit": 250,
-  "limitParam": "maxResults"
+  "limitParam": "maxResults",
+  "identityKeys": [
+    { "prefix": "email", "path": "organizer.email" },
+    { "prefix": "email", "path": "attendees[].email" }
+  ]
 }

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -318,6 +318,8 @@ Without declared paths, the default walker concatenates every string in the reco
 
 Both are queryable with `one --agent mem find-by-key <prefix>:<value>`.
 
+**Enriching profiles** (`gmail/gmailThreads`, `fathom/meetings`) sync in two phases: a list pass, then a detail pass that fetches full bodies/transcripts. Two things follow. Enrichment happens **once per record** — phase 2 only visits rows it has never enriched, and `--full-refresh` does *not* reset that, so re-running a sync will not refresh detail content (delete `.one/sync/data/<platform>.db` to force it). And the list pass never overwrites an enriched record: `data` merges rather than replaces, and `searchable_text` / `identity_keys[]` are left alone. `sync run` reports these as `memPreserved`. So on an enriching profile, a record whose upstream *detail* changed will look stale until the mirror is cleared — that is expected, not a sync failure.
+
 **Advanced features** (enrich, transform, exclude, hooks, --full-refresh, alternative backends, embedding tuning): run `one guide memory` or `one guide sync` for the full reference.
 
 ## Beyond Single Actions

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -189,10 +189,17 @@ one --agent mem search "deadline"                       # hybrid if key set, els
 one --agent mem list note --limit 20
 one --agent mem link <from-id> <to-id> relates_to --bi
 
-# Identity keys (first-class column, NOT data). Unique across ACTIVE records;
-# archiving a record frees its keys. `mem update '{"keys":[...]}'` is rejected.
-one --agent mem key <id> --add email:x@y.com            # add/--remove/--set
-one --agent mem find-by-source email:x@y.com            # prefers the active owner
+# Merge keys — the `keys[]` column (first-class, NOT data). Unique across ACTIVE
+# records; archiving a record frees its keys. `mem update '{"keys":[...]}'` is rejected.
+one --agent mem key <id> --add email:x@y.com            # add/--remove/--set — EDITS keys[]
+one --agent mem find-by-source attio/attioPeople:abc-1  # ONE record (prefers the active owner)
+
+# Identity keys — cross-platform lookup. READ-ONLY query, does not edit anything.
+# Spans BOTH `keys[]` (record IS the entity) and `identity_keys[]` (record INVOLVES
+# the entity: Gmail thread From/To/Cc, calendar attendees — never merges).
+one --agent mem find-by-key email:jane@acme.com                # every record involving this person
+one --agent mem find-by-key email:jane@acme.com --type gmail/gmailThreads
+one --agent mem find-by-key email:a@x.com email:b@y.com        # intersection — records with BOTH
 
 # Backfill searchable_text (no embedding provider needed) — fixes NULL/noisy text
 one --agent mem reindex --searchable --type attio/attioPeople
@@ -201,6 +208,33 @@ one --agent mem reindex --searchable --type attio/attioPeople
 one --agent mem status                                  # backend, provider, _upgrade hint
 one --agent mem doctor                                  # full health report
 ```
+
+**Don't confuse `mem key` with `mem find-by-key`.** `mem key` WRITES the merge column (`keys[]`) on one record — adding a key another active record already owns is an error, and `--set` replaces the whole array. `mem find-by-key` only READS, across both key columns. If you want "show me everything about this person", you always want `find-by-key`.
+
+`find-by-key` agent output is grouped by record type:
+
+```json
+{
+  "keys": ["email:jane@acme.com"],
+  "total": 13,
+  "truncated": false,
+  "fetchCap": 2000,
+  "perTypeLimit": 10,
+  "byType": {
+    "attio/attioPeople": { "count": 1,  "items": [ {"id": "...", "type": "...", "data": {}, "keys": ["attio/attioPeople:J1", "email:jane@acme.com"], "updated_at": "..."} ] },
+    "gmail/gmailThreads": { "count": 12, "items": [] }
+  }
+}
+```
+
+`items` are whole mem records. `keys` and `identity_keys` are OMITTED, not `[]`, when the record has none — the contact above matched on `keys[]` and so carries no `identity_keys` field at all. Always read them as `(item.identity_keys ?? [])`.
+
+Read it in this order:
+
+1. **`truncated`** — if `true`, more than `fetchCap` (2000) records matched. `total` and every `count` are then floors, and because rows come back ordered by type, whole types sorting after the cut are MISSING from `byType` entirely. Re-run with `--type <type>` to get an accurate answer; do not report the counts as-is.
+2. **`total` / `count`** — ungrouped and per-type match counts (accurate when `truncated` is `false`).
+3. **`items`** — whole mem records, same fields as `mem get`, capped at `perTypeLimit` (`--limit`, default 10). `count > items.length` just means display truncation — raise `--limit`.
+4. **`keys`** — the key form that actually matched. Lookups are lowercased/trimmed first (matching how sync writes them), with a one-shot verbatim retry for hand-written mixed-case keys, so `email:Jane@Acme.com` finds `email:jane@acme.com`.
 
 ### Adding OpenAI for semantic search
 
@@ -277,7 +311,14 @@ Without declared paths, the default walker concatenates every string in the reco
 
 **Connections are late-bound** — profiles use `"connection": { "platform": "<name>" }`, not literal `connectionKey` strings. The key is resolved at sync time, so `one add <platform>` (re-auth) doesn't break the profile. For multi-account platforms, add `"tag": "<connection-tag>"` to disambiguate, and create the tagged connection with `one add <platform> --tag <name>`. Don't hardcode connection keys in profiles.
 
-**Advanced features** (enrich, transform, exclude, identityKey, hooks, --full-refresh, alternative backends, embedding tuning): run `one guide memory` or `one guide sync` for the full reference.
+**Cross-platform identity on a profile.** Two separate fields, and picking the wrong one silently mangles data:
+
+- `"identityKey": "properties.email"` — singular. "This record IS this entity." One dot-path; the value lands in `keys[]` and MERGES records for the same entity across platforms (HubSpot + Attio for one person collapse into a single record).
+- `"identityKeys": [{"prefix": "email", "path": "attendees[].email"}]` — plural. "This record INVOLVES these people." Paths support `[]` wildcards and a `[name=From]` equality filter (Gmail headers). Values land in the separate `identity_keys[]` column, which does NOT merge — a 20-attendee event stays one event, not 20 contacts. Use this for anything with N participants.
+
+Both are queryable with `one --agent mem find-by-key <prefix>:<value>`.
+
+**Advanced features** (enrich, transform, exclude, hooks, --full-refresh, alternative backends, embedding tuning): run `one guide memory` or `one guide sync` for the full reference.
 
 ## Beyond Single Actions
 

--- a/src/commands/mem.ts
+++ b/src/commands/mem.ts
@@ -27,6 +27,7 @@ import {
   memLinkedCommand,
   memSourcesCommand,
   memFindBySourceCommand,
+  memFindByKeyCommand,
 } from './mem/records.js';
 import { memDoctorCommand } from './mem/doctor.js';
 import { memExportCommand, memImportCommand } from './mem/export.js';
@@ -189,6 +190,13 @@ export function registerMemoryCommands(program: Command): void {
   mem.command('find-by-source <sourceKey>')
     .description('Look up the record owning "<system>/<model>:<external_id>"')
     .action(memFindBySourceCommand);
+
+  mem.command('find-by-key <key> [secondKey]')
+    .description('Records sharing an identity key (e.g. email:jane@acme.com), grouped by type. Two keys = intersection.')
+    .option('--type <type>', 'Only this record type (e.g. gmail/gmailThreads)')
+    .option('--limit <n>', 'Max records shown per type (default 10)')
+    .action((key: string, secondKey: string | undefined, flags: { type?: string; limit?: string }) =>
+      memFindByKeyCommand(key, secondKey, flags));
 
   // Sync subverb: mounted as a full alias of `one sync`. Same handlers, same
   // options — only the command path differs. Keeps `one mem sync` feeling

--- a/src/commands/mem.ts
+++ b/src/commands/mem.ts
@@ -117,7 +117,7 @@ export function registerMemoryCommands(program: Command): void {
   mem.command('add <type> <data>')
     .description('Add a new memory record (data is JSON)')
     .option('--tags <csv>', 'Comma-separated tags')
-    .option('--keys <csv>', 'Comma-separated keys (prefixed, e.g. email:x@y.com)')
+    .option('--keys <csv>', 'Comma-separated merge keys (`keys[]`, prefixed, e.g. email:x@y.com — unique across active records)')
     .option('--weight <n>', 'Importance 1-10 (default 5)')
     .option('--embed', 'Force embedding for this record')
     .option('--no-embed', 'Skip embedding for this record')
@@ -132,11 +132,15 @@ export function registerMemoryCommands(program: Command): void {
     .description('Update a record (patch is JSON merged into data; regenerates searchable_text)')
     .action(memUpdateCommand);
 
+  // "identity keys" now means the non-merging `identity_keys[]` column (#128),
+  // so this command — which writes `keys[]` — must not claim that phrase. An
+  // agent told these were "identity keys" would attach a participant here and
+  // either hit the 23505 uniqueness trigger or merge the record away.
   mem.command('key <id>')
-    .description('Manage a record\'s identity keys (unique across active records)')
-    .option('--add <csv>', 'Keys to add (comma-separated, e.g. email:x@y.com)')
-    .option('--remove <csv>', 'Keys to remove (comma-separated)')
-    .option('--set <csv>', 'Replace all keys with this comma-separated list')
+    .description('Manage a record\'s merge keys (`keys[]` — unique across active records; these drive upsert-merge). Not participant associations — those live in `identity_keys[]`, written by a sync profile\'s `identityKeys`.')
+    .option('--add <csv>', 'Merge keys to add (comma-separated, e.g. email:x@y.com)')
+    .option('--remove <csv>', 'Merge keys to remove (comma-separated)')
+    .option('--set <csv>', 'Replace all merge keys with this comma-separated list')
     .action((id: string, flags: { add?: string; remove?: string; set?: string }) => memKeyCommand(id, flags));
 
   mem.command('archive <id>')
@@ -202,8 +206,8 @@ export function registerMemoryCommands(program: Command): void {
     .action(memFindBySourceCommand);
 
   mem.command('find-by-key <key> [secondKey]')
-    .description('Records sharing an identity key (e.g. email:jane@acme.com), grouped by type. Two keys = intersection.')
-    .option('--type <type>', 'Only this record type (e.g. gmail/gmailThreads)')
+    .description('Records carrying a key (e.g. email:jane@acme.com) in either `keys[]` or `identity_keys[]`, grouped by type. Two keys = intersection. Keys are matched case-insensitively.')
+    .option('--type <type>', 'Only this record type (e.g. gmail/gmailThreads) — also the way past the 2000-match fetch cap')
     .option('--limit <n>', 'Max records shown per type (default 10)')
     .action((key: string, secondKey: string | undefined, flags: { type?: string; limit?: string }) =>
       memFindByKeyCommand(key, secondKey, flags));

--- a/src/commands/mem/export-import.test.ts
+++ b/src/commands/mem/export-import.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { memExportCommand, memImportCommand } from './export.js';
+import { getBackend, resetBackendSingleton } from '../../lib/memory/runtime.js';
+import { registerBackend } from '../../lib/memory/plugins.js';
+import { pglitePlugin } from '../../lib/memory/plugins/pglite/index.js';
+import { updateMemoryConfig, DEFAULT_MEMORY_CONFIG } from '../../lib/memory/config.js';
+import { writeConfig } from '../../lib/config.js';
+
+/** Swallow the command's stdout report so the test output stays readable. */
+async function quiet(fn: () => Promise<void>): Promise<void> {
+  const orig = process.stdout.write.bind(process.stdout);
+  (process.stdout as unknown as { write: (c: string) => boolean }).write = () => true;
+  try { await fn(); } finally { (process.stdout as unknown as { write: typeof orig }).write = orig; }
+}
+
+/**
+ * `mem export` → FRESH store → `mem import`, asserting identity_keys survive.
+ *
+ * The fresh-store half is the whole point. `mem import` rebuilds RecordInput
+ * field-by-field, and a field it forgets is invisible when you re-import over
+ * a store that still holds the record — mem_upsert_by_keys takes its union
+ * branch and preserves what is already there. The loss only shows on the
+ * INSERT path, which is exactly the flow export|import exists for: restoring
+ * into a wiped store, or swapping backends (pglite → postgres). So this test
+ * imports into a SEPARATE, EMPTY database and asserts every record is
+ * `inserted`, not `updated`.
+ */
+describe('mem export → fresh store → mem import round-trip (#128)', () => {
+  let tmpHome: string;
+  let dumpFile: string;
+
+  /** Point the memory config at a different PGlite dir and re-open. */
+  const useStore = async (name: string) => {
+    updateMemoryConfig({
+      ...DEFAULT_MEMORY_CONFIG,
+      backend: 'pglite',
+      pglite: { dbPath: path.join(tmpHome, name) },
+    });
+    resetBackendSingleton();
+    return getBackend();
+  };
+
+  before(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mem-export-import-test-'));
+    dumpFile = path.join(tmpHome, 'dump.jsonl');
+    process.env.HOME = tmpHome;
+    fs.mkdirSync(path.join(tmpHome, '.one'), { mode: 0o700 });
+    writeConfig({ apiKey: 'sk_test_dummy', installedAgents: [], createdAt: new Date().toISOString() });
+    registerBackend(pglitePlugin);
+  });
+
+  after(async () => {
+    const backend = await getBackend();
+    await backend.close();
+    resetBackendSingleton();
+    try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('carries identity_keys through export and into an empty destination store', async () => {
+    // ── Source store ──────────────────────────────────────────────────────
+    const src = await useStore('source.pglite');
+    const now = new Date().toISOString();
+    await src.upsertByKeys({
+      type: 'gmail/gmailThreads',
+      data: { subject: 'Q2 pricing' },
+      keys: ['gmail/gmailThreads:T1'],
+      identity_keys: ['email:jane@acme.com', 'email:bob@acme.com'],
+      sources: { 'gmail/gmailThreads:T1': { last_synced_at: now } },
+    });
+    await src.upsertByKeys({
+      type: 'attio/people',
+      data: { name: 'Jane Smith' },
+      // A contact's own email is an ENTITY key (keys[]); its identity_keys
+      // are the associations. Both columns must round-trip independently.
+      keys: ['attio/people:J1', 'email:jane@acme.com'],
+      identity_keys: ['email:jane@acme.com'],
+      sources: { 'attio/people:J1': { last_synced_at: now } },
+    });
+    // A record with NO identity_keys must come back with none rather than [].
+    await src.upsertByKeys({
+      type: 'note',
+      data: { content: 'plain note' },
+      keys: ['note:N1'],
+      sources: { 'note:N1': { last_synced_at: now } },
+    });
+
+    await quiet(() => memExportCommand(dumpFile));
+    const lines = fs.readFileSync(dumpFile, 'utf-8').trim().split('\n').filter(Boolean);
+    assert.equal(lines.length, 3, 'all three records exported');
+    // Export writes the whole row, so the column is in the dump — if this
+    // fails the loss is on the export side, not the import side.
+    assert.ok(
+      lines.some(l => (JSON.parse(l) as { identity_keys?: string[] }).identity_keys?.includes('email:bob@acme.com')),
+      'identity_keys present in the JSONL',
+    );
+    await src.close();
+
+    // ── Destination store: a DIFFERENT, empty database ────────────────────
+    const dest = await useStore('dest.pglite');
+    assert.equal((await dest.stats()).recordCount, 0, 'precondition: destination is empty');
+
+    await quiet(() => memImportCommand(dumpFile));
+    assert.equal((await dest.stats()).recordCount, 3, 'every record inserted');
+
+    const thread = await dest.findBySource('gmail/gmailThreads:T1');
+    assert.ok(thread, 'thread restored');
+    assert.deepEqual(
+      (thread!.identity_keys ?? []).sort(),
+      ['email:bob@acme.com', 'email:jane@acme.com'],
+      'participant associations survive the insert path',
+    );
+
+    // The point of preserving the column: the cross-platform join still works
+    // in the restored store.
+    const joined = await dest.findByKeys(['email:jane@acme.com']);
+    assert.equal(joined.length, 2, 'thread + contact both reachable by the shared key');
+    assert.deepEqual(
+      new Set(joined.map(r => r.type)),
+      new Set(['gmail/gmailThreads', 'attio/people']),
+    );
+
+    // The plain note picked up no phantom keys.
+    const note = await dest.findBySource('note:N1');
+    assert.ok(!(note!.identity_keys ?? []).length, 'a record with no associations gains none');
+  });
+
+  it('re-importing the same dump is idempotent (updates, not duplicates)', async () => {
+    const dest = await getBackend();
+    await quiet(() => memImportCommand(dumpFile));
+    assert.equal((await dest.stats()).recordCount, 3, 'no duplicates on a second import');
+    const thread = await dest.findBySource('gmail/gmailThreads:T1');
+    assert.deepEqual(
+      (thread!.identity_keys ?? []).sort(),
+      ['email:bob@acme.com', 'email:jane@acme.com'],
+      'the update path must not drop them either',
+    );
+  });
+});

--- a/src/commands/mem/export.ts
+++ b/src/commands/mem/export.ts
@@ -94,6 +94,14 @@ export async function memImportCommand(file: string): Promise<void> {
       data: record.data,
       tags: record.tags,
       keys,
+      // Carry `identity_keys` through (#128). Export writes the whole row, so
+      // the JSONL has them; omitting them here only looked harmless because
+      // re-importing over a store that still holds the record takes the union
+      // branch in mem_upsert_by_keys and preserves what's already there. On the
+      // INSERT path — restore into a wiped store, or a backend swap
+      // (pglite → postgres), which is exactly what export|import is for —
+      // dropping them here loses every participant association permanently.
+      identity_keys: record.identity_keys,
       sources: record.sources,
       searchable_text: record.searchable_text ?? null,
       content_hash: record.content_hash ?? null,

--- a/src/commands/mem/find-by-key.test.ts
+++ b/src/commands/mem/find-by-key.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { memFindByKeyCommand } from './records.js';
+import { getBackend, resetBackendSingleton } from '../../lib/memory/runtime.js';
+import { registerBackend } from '../../lib/memory/plugins.js';
+import { pglitePlugin } from '../../lib/memory/plugins/pglite/index.js';
+import { updateMemoryConfig, DEFAULT_MEMORY_CONFIG } from '../../lib/memory/config.js';
+import { writeConfig } from '../../lib/config.js';
+
+// #131: `one mem find-by-key <key> [<key2>]` — exercises the full command path
+// (getBackend → findByKeys → group-by-type → agent JSON) against a real PGlite
+// backend seeded with identity_keys.
+
+/** Force --agent mode and capture the JSON the command writes to stdout. */
+async function runAgent(fn: () => Promise<void>): Promise<any> {
+  const prev = process.env.ONE_AGENT;
+  process.env.ONE_AGENT = '1';
+  const orig = process.stdout.write.bind(process.stdout);
+  let buf = '';
+  (process.stdout as unknown as { write: (c: string) => boolean }).write = (chunk: string) => { buf += chunk; return true; };
+  try {
+    await fn();
+  } finally {
+    (process.stdout as unknown as { write: typeof orig }).write = orig;
+    if (prev === undefined) delete process.env.ONE_AGENT; else process.env.ONE_AGENT = prev;
+  }
+  const lines = buf.trim().split('\n').filter(Boolean);
+  return JSON.parse(lines[lines.length - 1]);
+}
+
+describe('mem find-by-key command (#131)', () => {
+  let tmpHome: string;
+
+  before(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'find-by-key-test-'));
+    process.env.HOME = tmpHome;
+    fs.mkdirSync(path.join(tmpHome, '.one'), { mode: 0o700 });
+    writeConfig({ apiKey: 'sk_test_dummy', installedAgents: [], createdAt: new Date().toISOString() });
+    registerBackend(pglitePlugin);
+    updateMemoryConfig({ ...DEFAULT_MEMORY_CONFIG, backend: 'pglite', pglite: { dbPath: path.join(tmpHome, 'mem.pglite') } });
+    resetBackendSingleton();
+    const backend = await getBackend();
+
+    const now = new Date().toISOString();
+    await backend.upsertByKeys({ type: 'attio/people', data: { name: 'Jane Smith' }, keys: ['attio/people:J1'], identity_keys: ['email:jane@acme.com'], sources: { 'attio/people:J1': { last_synced_at: now } } });
+    await backend.upsertByKeys({ type: 'gmail/gmailThreads', data: { subject: 'Q2 pricing' }, keys: ['gmail/gmailThreads:T1'], identity_keys: ['email:jane@acme.com', 'email:bob@acme.com'], sources: { 'gmail/gmailThreads:T1': { last_synced_at: now } } });
+    await backend.upsertByKeys({ type: 'gmail/gmailThreads', data: { subject: 'intro' }, keys: ['gmail/gmailThreads:T2'], identity_keys: ['email:jane@acme.com'], sources: { 'gmail/gmailThreads:T2': { last_synced_at: now } } });
+  });
+
+  after(async () => {
+    const backend = await getBackend();
+    await backend.close();
+    resetBackendSingleton();
+    try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('groups records by type with counts (single key)', async () => {
+    const out = await runAgent(() => memFindByKeyCommand('email:jane@acme.com', undefined, {}));
+    assert.deepEqual(out.keys, ['email:jane@acme.com']);
+    assert.equal(out.total, 3);
+    assert.equal(out.byType['attio/people'].count, 1);
+    assert.equal(out.byType['gmail/gmailThreads'].count, 2);
+    assert.equal(out.byType['gmail/gmailThreads'].items.length, 2);
+  });
+
+  it('--type filters to one record type', async () => {
+    const out = await runAgent(() => memFindByKeyCommand('email:jane@acme.com', undefined, { type: 'gmail/gmailThreads' }));
+    assert.equal(out.total, 2);
+    assert.deepEqual(Object.keys(out.byType), ['gmail/gmailThreads']);
+  });
+
+  it('two keys return the intersection', async () => {
+    const out = await runAgent(() => memFindByKeyCommand('email:jane@acme.com', 'email:bob@acme.com', {}));
+    assert.deepEqual(out.keys, ['email:jane@acme.com', 'email:bob@acme.com']);
+    assert.equal(out.total, 1);
+    assert.equal(out.byType['gmail/gmailThreads'].count, 1);
+  });
+
+  it('--limit caps items shown per type (count stays accurate)', async () => {
+    const out = await runAgent(() => memFindByKeyCommand('email:jane@acme.com', undefined, { type: 'gmail/gmailThreads', limit: '1' }));
+    assert.equal(out.byType['gmail/gmailThreads'].count, 2, 'true count preserved');
+    assert.equal(out.byType['gmail/gmailThreads'].items.length, 1, 'items capped by --limit');
+  });
+
+  it('returns empty for an unknown key', async () => {
+    const out = await runAgent(() => memFindByKeyCommand('email:nobody@nowhere.com', undefined, {}));
+    assert.equal(out.total, 0);
+    assert.deepEqual(out.byType, {});
+  });
+});

--- a/src/commands/mem/find-by-key.test.ts
+++ b/src/commands/mem/find-by-key.test.ts
@@ -40,7 +40,10 @@ describe('mem find-by-key command (#131)', () => {
     fs.mkdirSync(path.join(tmpHome, '.one'), { mode: 0o700 });
     writeConfig({ apiKey: 'sk_test_dummy', installedAgents: [], createdAt: new Date().toISOString() });
     registerBackend(pglitePlugin);
-    updateMemoryConfig({ ...DEFAULT_MEMORY_CONFIG, backend: 'pglite', pglite: { dbPath: path.join(tmpHome, 'mem.pglite') } });
+    // ':memory:' rather than a temp dir: the truncation case below seeds
+    // >2000 rows and file-backed PGlite writes cost ~5ms each, which turned
+    // one assertion into a ten-second test. Nothing here needs persistence.
+    updateMemoryConfig({ ...DEFAULT_MEMORY_CONFIG, backend: 'pglite', pglite: { dbPath: ':memory:' } });
     resetBackendSingleton();
     const backend = await getBackend();
 
@@ -89,5 +92,117 @@ describe('mem find-by-key command (#131)', () => {
     const out = await runAgent(() => memFindByKeyCommand('email:nobody@nowhere.com', undefined, {}));
     assert.equal(out.total, 0);
     assert.deepEqual(out.byType, {});
+  });
+
+  // ─── query-key normalization ──────────────────────────────────────────────
+  //
+  // Identity values are lowercased + trimmed on write (`identityValuesFor` in
+  // sync/mem-writer.ts) but the CLI arg went straight into an exact
+  // array-containment match, so `find-by-key email:Jane@Acme.com` reported "no
+  // records linked" while dozens of rows carried `email:jane@acme.com`.
+  it('matches case-insensitively and echoes the NORMALIZED key', async () => {
+    const out = await runAgent(() => memFindByKeyCommand('  EMAIL:Jane@Acme.COM ', undefined, {}));
+    assert.equal(out.total, 3, 'same rows as the exact-case query');
+    assert.deepEqual(out.keys, ['email:jane@acme.com'], 'agents see the key that actually matched');
+  });
+
+  it('normalizes BOTH positional keys, not just the first', async () => {
+    const out = await runAgent(() => memFindByKeyCommand('email:JANE@acme.com', ' Email:BOB@Acme.com', {}));
+    assert.deepEqual(out.keys, ['email:jane@acme.com', 'email:bob@acme.com']);
+    assert.equal(out.total, 1);
+  });
+
+  it('falls back to the verbatim key for hand-written mixed-case keys', async () => {
+    // `mem add --keys` / `mem key --add` store exactly what was typed, and a
+    // custom profile prefix is interpolated verbatim too — so normalization
+    // alone would make those rows unreachable. The retry only fires when the
+    // normalized lookup found nothing AND normalization changed the input.
+    const backend = await getBackend();
+    await backend.upsertByKeys({
+      type: 'manual/note',
+      data: { note: 'hand keyed' },
+      keys: ['Slack:U-MixedCase'],
+      sources: { 'manual/note:M1': { last_synced_at: new Date().toISOString() } },
+    });
+
+    const out = await runAgent(() => memFindByKeyCommand('Slack:U-MixedCase', undefined, {}));
+    assert.equal(out.total, 1, 'the verbatim retry is load-bearing');
+    assert.deepEqual(out.keys, ['Slack:U-MixedCase'], 'echoes the form that actually matched');
+
+    // A genuine miss still reports zero — the retry must not invent results.
+    const miss = await runAgent(() => memFindByKeyCommand('Slack:U-NoSuchUser', undefined, {}));
+    assert.equal(miss.total, 0);
+  });
+
+  // ─── the two columns are one search space ─────────────────────────────────
+  it('intersects two keys even when they live in DIFFERENT columns', async () => {
+    // The interesting shape for a cross-platform join: a contact whose own
+    // email is an ENTITY key in keys[] and who is also a participant on
+    // something, so one query term hits keys[] and the other identity_keys[].
+    // The old doc claimed find-by-key only searched keys[]; the predicate is
+    // containment over the UNION of both columns.
+    const backend = await getBackend();
+    const now = new Date().toISOString();
+    await backend.upsertByKeys({
+      type: 'attio/people',
+      data: { name: 'Carol' },
+      keys: ['attio/people:C1', 'email:carol@acme.com'],   // entity key
+      identity_keys: ['email:dave@acme.com'],              // association
+      sources: { 'attio/people:C1': { last_synced_at: now } },
+    });
+    // A decoy carrying only one of the two — must not appear.
+    await backend.upsertByKeys({
+      type: 'gmail/gmailThreads',
+      data: { subject: 'dave only' },
+      keys: ['gmail/gmailThreads:D1'],
+      identity_keys: ['email:dave@acme.com'],
+      sources: { 'gmail/gmailThreads:D1': { last_synced_at: now } },
+    });
+
+    const split = await runAgent(() => memFindByKeyCommand('email:carol@acme.com', 'email:dave@acme.com', {}));
+    assert.equal(split.total, 1, 'the intersection spans keys[] + identity_keys[]');
+    assert.equal(split.byType['attio/people'].count, 1);
+    assert.equal(split.byType['gmail/gmailThreads'], undefined, 'the one-key decoy is excluded');
+
+    // Order of the two positional args must not matter.
+    const reversed = await runAgent(() => memFindByKeyCommand('email:dave@acme.com', 'email:carol@acme.com', {}));
+    assert.equal(reversed.total, 1);
+  });
+
+  // ─── truncation signal ────────────────────────────────────────────────────
+  //
+  // Runs last: it seeds >FETCH_CAP rows, and every assertion above counts
+  // records. Without a truncation flag a saturating type (gmail threads, where
+  // every From/To/Cc contributes an identity key) silently ate the whole
+  // budget and types sorting after it vanished with no signal at all, while
+  // `total` and the human header both reported a wrong number as if it were
+  // complete.
+  it('flags truncation once the fetch cap is exceeded', async () => {
+    const backend = await getBackend();
+    const key = 'email:saturating@acme.com';
+
+    const under = await runAgent(() => memFindByKeyCommand('email:jane@acme.com', undefined, {}));
+    assert.equal(under.truncated, false, 'no false positive below the cap');
+    assert.equal(under.fetchCap, 2000, 'the cap is reported so agents can reason about it');
+
+    // One past the cap is enough to prove the boundary.
+    for (let i = 0; i < under.fetchCap + 1; i++) {
+      await backend.insert({
+        type: 'bulk/threads',
+        data: { i },
+        keys: [`bulk/threads:B${i}`],
+        identity_keys: [key],
+      });
+    }
+
+    const out = await runAgent(() => memFindByKeyCommand(key, undefined, {}));
+    assert.equal(out.truncated, true, 'more matches exist than were fetched');
+    assert.equal(out.total, 2000, 'total is capped at the fetch cap, not the true count');
+    assert.equal(out.byType['bulk/threads'].count, 2000);
+    // `--type` is the documented escape hatch, and it filters in SQL BEFORE
+    // the LIMIT — so it is what actually rescues a starved type.
+    const filtered = await runAgent(() => memFindByKeyCommand(key, undefined, { type: 'bulk/threads' }));
+    assert.equal(filtered.truncated, true);
+    assert.deepEqual(Object.keys(filtered.byType), ['bulk/threads']);
   });
 });

--- a/src/commands/mem/migrate.ts
+++ b/src/commands/mem/migrate.ts
@@ -3,10 +3,12 @@
  * unified memory store.
  *
  * Idempotent: uses upsertByKeys keyed by `<platform>/<model>:<row-id>` so
- * re-runs over the same files produce zero new writes. Optional identity
- * dedup (--identity) promotes a profile's `identityKey` into a second,
- * cross-source key so Gmail/Attio/Fathom rows about the same person merge
- * into one record.
+ * re-runs over the same files produce zero new writes. An identity pre-pass
+ * (unconditional — there is no flag) promotes a profile's singular
+ * `identityKey` into a second, cross-source merge key so Gmail/Attio/Fathom
+ * rows about the same person merge into one record. It shares
+ * `resolveEntityIdentity` with the sync writer so both paths derive byte-
+ * identical keys; migrate never writes the non-merging `identity_keys[]`.
  *
  * Does not delete legacy files. Pass --cleanup after verifying the import
  * to remove them.
@@ -23,6 +25,7 @@ import { loadBuiltinProfile, getProfilesDir } from '../../lib/memory/sync/builti
 import { openDatabase, listSyncedPlatforms, listTables, countRecords } from '../../lib/memory/sync/db.js';
 import { okJson, requireMemoryInit } from './util.js';
 import { getByDotPath } from '../../lib/dot-path.js';
+import { resolveEntityIdentity, normalizeEntityIdentityValue } from '../../lib/memory/sync/mem-writer.js';
 
 interface MigrateFlags {
   platform?: string;
@@ -226,10 +229,16 @@ export async function memMigrateCommand(flags: MigrateFlags): Promise<void> {
           const keys = [sourceKey];
           let identityValueNorm: string | null = null;
           if (identityKey) {
-            const idValue = getByDotPath(hydrated, identityKey);
-            if (idValue !== undefined && idValue !== null && idValue !== '' && typeof idValue !== 'object') {
-              identityValueNorm = String(idValue).toLowerCase().trim();
-              keys.push(`${deriveIdentityPrefix(identityKey)}:${identityValueNorm}`);
+            // Shared with `sync run` (mem-writer) — migrate used to derive the
+            // prefix and normalize the value with its own copy of the rule, so
+            // a migrated row landed `email:jane smith <jane@acme.com>` while a
+            // later sync of the same person landed `email:jane@acme.com` and
+            // the two never merged. Also yields null on a fan-out path instead
+            // of writing several merge keys for one record.
+            const identity = resolveEntityIdentity(hydrated, identityKey);
+            if (identity?.key) {
+              identityValueNorm = identity.value;
+              keys.push(identity.key);
             }
           }
           // Identity-merge: if an existing row matched this identity in the
@@ -467,7 +476,10 @@ export async function buildIdentityMap(
     for (const row of res.rows) {
       const ident = row.ident;
       if (ident === null || ident === undefined || typeof ident !== 'string') continue;
-      const norm = ident.toLowerCase().trim();
+      // Normalize exactly like the key we're about to push for the incoming
+      // row (email extraction included) — the map is looked up by that value,
+      // so any divergence here turns every merge into a silent duplicate.
+      const norm = normalizeEntityIdentityValue(identityKey, ident);
       if (!norm) continue;
       // First write wins — if two existing rows somehow share the same
       // identity value, merge only into the first and leave the second
@@ -587,13 +599,4 @@ function resolveBuiltinProfilePath(platform: string, model: string): string | nu
   if (!dir) return null;
   const candidate = path.join(dir, platform, `${model}.json`);
   return fs.existsSync(candidate) ? candidate : null;
-}
-
-function deriveIdentityPrefix(path: string): string {
-  // Default heuristic: email-shaped paths get "email:", otherwise "id:".
-  const lower = path.toLowerCase();
-  if (lower.includes('email')) return 'email';
-  if (lower.includes('phone')) return 'phone';
-  if (lower.includes('domain')) return 'domain';
-  return 'id';
 }

--- a/src/commands/mem/records.ts
+++ b/src/commands/mem/records.ts
@@ -4,10 +4,12 @@
  * link, unlink, linked.
  */
 
+import pc from 'picocolors';
 import * as output from '../../lib/output.js';
 import { getBackend, addRecord } from '../../lib/memory/runtime.js';
 import { embed } from '../../lib/memory/embedding.js';
 import { getMemoryConfigOrDefault } from '../../lib/memory/index.js';
+import type { MemRecord } from '../../lib/memory/types.js';
 import { okJson, parseCsv, parseJsonArg, parsePositiveInt, printList, printRecord, requireMemoryInit, semanticSearchUpgradeHint, semanticSearchUpgradeLine } from './util.js';
 
 interface AddFlags {
@@ -260,4 +262,87 @@ export async function memFindBySourceCommand(sourceKey: string): Promise<void> {
   const record = await backend.findBySource(sourceKey);
   if (!record) output.error(`No record owns source "${sourceKey}"`);
   printRecord(record as unknown as Record<string, unknown>);
+}
+
+interface FindByKeyFlags {
+  type?: string;
+  limit?: string;
+}
+
+/** Best-effort human label for a record (the first present common title-ish field). */
+function summarizeRecord(r: MemRecord): string {
+  const d = r.data ?? {};
+  for (const field of ['title', 'subject', 'name', 'full_name', 'display_name', 'summary', 'headline', 'email']) {
+    const v = (d as Record<string, unknown>)[field];
+    if (typeof v === 'string' && v.trim()) return v.trim().slice(0, 80);
+  }
+  return pc.dim(r.id.slice(0, 8));
+}
+
+/** Compact "2d ago" style relative time. */
+function relativeTime(iso?: string): string {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const s = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60); if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60); if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24); if (d < 30) return `${d}d ago`;
+  const mo = Math.floor(d / 30); if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(mo / 12)}y ago`;
+}
+
+/**
+ * `one mem find-by-key <key> [<key2>]` — list every record whose `keys[]`
+ * contains the given identity key (e.g. `email:jane@acme.com`), grouped by
+ * type. Two keys → the intersection (records carrying BOTH). This is the
+ * cross-platform-join query surface for #131 (issue proposed `mem linked`, but
+ * that name is already taken by the relation-graph command, so this mirrors the
+ * existing `find-by-source`). Works for any prefix — `email:`, `domain:`, etc.
+ */
+export async function memFindByKeyCommand(key: string, secondKey: string | undefined, flags: FindByKeyFlags): Promise<void> {
+  requireMemoryInit();
+  const backend = await getBackend();
+  const keys = secondKey ? [key, secondKey] : [key];
+  const perType = parsePositiveInt(flags.limit, 10, '--limit');
+  const records = await backend.findByKeys(keys, { type: flags.type });
+
+  // Group by type, preserving the query's type-then-recency ordering.
+  const byType = new Map<string, MemRecord[]>();
+  for (const r of records) {
+    const list = byType.get(r.type) ?? [];
+    list.push(r);
+    byType.set(r.type, list);
+  }
+
+  if (output.isAgentMode()) {
+    const grouped: Record<string, { count: number; items: MemRecord[] }> = {};
+    for (const [type, list] of byType) {
+      grouped[type] = { count: list.length, items: list.slice(0, perType) };
+    }
+    output.json({ keys, total: records.length, byType: grouped });
+    return;
+  }
+
+  const label = keys.map(k => pc.cyan(k)).join(pc.dim(' + '));
+  if (records.length === 0) {
+    console.log(`\n  No records linked to ${label}.\n`);
+    return;
+  }
+
+  console.log();
+  console.log(`  ${label} ${pc.dim('—')} ${records.length} record${records.length === 1 ? '' : 's'} across ${byType.size} type${byType.size === 1 ? '' : 's'}`);
+  console.log();
+  const typeWidth = Math.min(30, Math.max(...[...byType.keys()].map(t => t.length)));
+  for (const [type, list] of byType) {
+    console.log(`  ${pc.bold(type.padEnd(typeWidth))}  ${pc.dim(`${list.length} record${list.length === 1 ? '' : 's'}`)}`);
+    for (const r of list.slice(0, perType)) {
+      console.log(`    ${pc.dim('·')} ${summarizeRecord(r)}  ${pc.dim(relativeTime(r.updated_at))}`);
+    }
+    if (list.length > perType) {
+      console.log(`    ${pc.dim(`… and ${list.length - perType} more (raise --limit)`)}`);
+    }
+  }
+  console.log();
 }

--- a/src/commands/mem/records.ts
+++ b/src/commands/mem/records.ts
@@ -53,8 +53,18 @@ export async function memUpdateCommand(id: string, patchRaw: string): Promise<vo
   // The patch is merged into `data`. `keys` is a first-class column, not a
   // data field — steer callers to `one mem key` instead of silently
   // burying `{"keys":[...]}` under data.keys where it does nothing.
-  if (patch && typeof patch === 'object' && !Array.isArray(patch) && 'keys' in patch) {
-    output.error('`keys` is not a data field. Use `one mem key <id> --set <csv>` (or --add/--remove) to change a record\'s keys.');
+  const isPatchObject = !!patch && typeof patch === 'object' && !Array.isArray(patch);
+  if (isPatchObject && 'keys' in patch) {
+    output.error('`keys` is not a data field. Use `one mem key <id> --set <csv>` (or --add/--remove) to change a record\'s merge keys.');
+  }
+  // Same trap one column over: `identity_keys` (#128) is a column too, so a
+  // patch naming it would land in data.identity_keys and do nothing — while
+  // looking like it worked. Unlike `keys` there's no CLI writer to point at:
+  // associations are derived on sync from the profile's plural `identityKeys`,
+  // so say that instead of offering a command that would write the wrong
+  // column (`mem key` writes the merging `keys[]`).
+  if (isPatchObject && ('identity_keys' in patch || 'identityKeys' in patch)) {
+    output.error('`identity_keys` is not a data field. Participant associations are derived on sync from the profile\'s `identityKeys` — edit the sync profile and re-run `one sync run`, then query with `one mem find-by-key <key>`.');
   }
   // Route through updateRecord so searchable_text + content_hash are
   // regenerated from the merged data (backend.update alone leaves them
@@ -72,9 +82,16 @@ interface KeyFlags {
 
 /**
  * Manage the `keys` column on an existing record — the first-class,
- * uniqueness-checked way to change identity keys after creation. Without
- * this, keys could only be set at insert time (`mem add --keys`), and
+ * uniqueness-checked way to change a record's MERGE keys after creation.
+ * Without this, keys could only be set at insert time (`mem add --keys`), and
  * `mem update '{"keys":[...]}'` silently wrote them into `data` instead.
+ *
+ * This is `keys[]` only. It is deliberately NOT a way to attach participant
+ * associations: `keys[]` is unique across active records and drives
+ * upsert-merge, so adding `email:jane@acme.com` to a thread here either fails
+ * 23505 against Jane's contact record or collapses the thread into it on the
+ * next sync. Participant associations belong in `identity_keys[]`, which the
+ * sync writer fills from a profile's plural `identityKeys` (#128).
  */
 export async function memKeyCommand(id: string, flags: KeyFlags): Promise<void> {
   requireMemoryInit();
@@ -106,7 +123,7 @@ export async function memKeyCommand(id: string, flags: KeyFlags): Promise<void> 
   if (outcome.status === 'conflict') {
     output.error(
       `Key "${outcome.key}" is already owned by active record ${outcome.recordId} (type ${outcome.recordType}). ` +
-      `Keys must be unique across active records — archive or re-key that record first.`,
+      `Merge keys must be unique across active records — archive or re-key that record first.`,
     );
   }
   printRecord((outcome as { record: unknown }).record as Record<string, unknown>);
@@ -332,7 +349,10 @@ function summarizeRecord(r: MemRecord): string {
     const v = (d as Record<string, unknown>)[field];
     if (typeof v === 'string' && v.trim()) return v.trim().slice(0, 80);
   }
-  return pc.dim(r.id.slice(0, 8));
+  // No title-ish field. The caller always prints the full id after the
+  // label, so don't repeat a truncated one here — say plainly there's
+  // nothing to show.
+  return pc.dim('(untitled)');
 }
 
 /** Compact "2d ago" style relative time. */
@@ -350,19 +370,71 @@ function relativeTime(iso?: string): string {
 }
 
 /**
- * `one mem find-by-key <key> [<key2>]` — list every record whose `keys[]`
- * contains the given identity key (e.g. `email:jane@acme.com`), grouped by
- * type. Two keys → the intersection (records carrying BOTH). This is the
- * cross-platform-join query surface for #131 (issue proposed `mem linked`, but
- * that name is already taken by the relation-graph command, so this mirrors the
- * existing `find-by-source`). Works for any prefix — `email:`, `domain:`, etc.
+ * How many matching records we pull back from the backend in one go. This is
+ * NOT `--limit`, which only slices how many rows per type get PRINTED.
+ *
+ * The backend applies `Math.min(opts.limit ?? 2000, 5000)` as a GLOBAL cap
+ * after `ORDER BY type ASC, updated_at DESC` — so leaving it implicit meant a
+ * saturating type silently ate the whole budget and every type sorting after
+ * it disappeared with no signal. That is the normal case now that the built-in
+ * profiles attach an `email:` identity key for every From/To/Cc and every
+ * attendee: on a real mailbox your own address is on nearly every synced
+ * thread, so `gmail/gmailThreads` alone can fill 2000 rows and hide
+ * `google-calendar/events` entirely. We ask for one MORE than we keep so we
+ * can detect the cap and say so, rather than reporting a wrong total.
+ */
+const FIND_BY_KEY_FETCH_CAP = 2000;
+
+/**
+ * Normalize a key the way the writer does before it hits the exact
+ * array-containment match. Identity values are lowercased + trimmed on write
+ * (see `identityValuesFor` in sync/mem-writer.ts) and the profile prefixes are
+ * lowercase, so passing the CLI arg through verbatim made
+ * `find-by-key email:Jane@Acme.com` report "no records linked" while dozens
+ * carried `email:jane@acme.com`. Trimming also absorbs the stray whitespace
+ * shell quoting leaves behind.
+ */
+function normalizeQueryKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+/**
+ * `one mem find-by-key <key> [<key2>]` — list every record carrying the given
+ * identity key (e.g. `email:jane@acme.com`), grouped by type. The match spans
+ * BOTH key columns: `keys[]` (entity/merge keys — "this record IS this
+ * entity") and `identity_keys[]` (participant associations, #128 — "this
+ * record INVOLVES this person"). Two keys → the intersection (records carrying
+ * BOTH). This is the cross-platform-join query surface for #131 (issue proposed
+ * `mem linked`, but that name is already taken by the relation-graph command,
+ * so this mirrors the existing `find-by-source`). Works for any prefix —
+ * `email:`, `domain:`, etc.
  */
 export async function memFindByKeyCommand(key: string, secondKey: string | undefined, flags: FindByKeyFlags): Promise<void> {
   requireMemoryInit();
   const backend = await getBackend();
-  const keys = secondKey ? [key, secondKey] : [key];
+  const rawKeys = secondKey ? [key, secondKey] : [key];
+  const keys = rawKeys.map(normalizeQueryKey);
   const perType = parsePositiveInt(flags.limit, 10, '--limit');
-  const records = await backend.findByKeys(keys, { type: flags.type });
+
+  const fetchPage = async (ks: string[]) => {
+    const rows = await backend.findByKeys(ks, { type: flags.type, limit: FIND_BY_KEY_FETCH_CAP + 1 });
+    return { records: rows.slice(0, FIND_BY_KEY_FETCH_CAP), truncated: rows.length > FIND_BY_KEY_FETCH_CAP };
+  };
+
+  let page = await fetchPage(keys);
+  let matchedKeys = keys;
+  // Sync writes normalized keys, but records keyed by hand (`mem add --keys`,
+  // `mem key --add`) are stored verbatim and can carry mixed case. If the
+  // normalized lookup found nothing, retry once with exactly what was typed
+  // before declaring "no records" — costs one extra query only on a miss.
+  if (page.records.length === 0 && keys.some((k, i) => k !== rawKeys[i])) {
+    const verbatim = await fetchPage(rawKeys);
+    if (verbatim.records.length > 0) {
+      page = verbatim;
+      matchedKeys = rawKeys;
+    }
+  }
+  const { records, truncated } = page;
 
   // Group by type, preserving the query's type-then-recency ordering.
   const byType = new Map<string, MemRecord[]>();
@@ -377,28 +449,44 @@ export async function memFindByKeyCommand(key: string, secondKey: string | undef
     for (const [type, list] of byType) {
       grouped[type] = { count: list.length, items: list.slice(0, perType) };
     }
-    output.json({ keys, total: records.length, byType: grouped });
+    // `total` is what we actually fetched. When `truncated` is true there are
+    // MORE matches than this and the type breakdown is incomplete — agents
+    // must re-run with `--type` rather than trust the counts.
+    output.json({
+      keys: matchedKeys,
+      total: records.length,
+      truncated,
+      fetchCap: FIND_BY_KEY_FETCH_CAP,
+      perTypeLimit: perType,
+      byType: grouped,
+    });
     return;
   }
 
-  const label = keys.map(k => pc.cyan(k)).join(pc.dim(' + '));
+  const label = matchedKeys.map(k => pc.cyan(k)).join(pc.dim(' + '));
   if (records.length === 0) {
     console.log(`\n  No records linked to ${label}.\n`);
     return;
   }
 
   console.log();
-  console.log(`  ${label} ${pc.dim('—')} ${records.length} record${records.length === 1 ? '' : 's'} across ${byType.size} type${byType.size === 1 ? '' : 's'}`);
+  console.log(`  ${label} ${pc.dim('—')} ${records.length}${truncated ? '+' : ''} record${records.length === 1 ? '' : 's'} across ${byType.size} type${byType.size === 1 ? '' : 's'}`);
   console.log();
   const typeWidth = Math.min(30, Math.max(...[...byType.keys()].map(t => t.length)));
   for (const [type, list] of byType) {
     console.log(`  ${pc.bold(type.padEnd(typeWidth))}  ${pc.dim(`${list.length} record${list.length === 1 ? '' : 's'}`)}`);
     for (const r of list.slice(0, perType)) {
-      console.log(`    ${pc.dim('·')} ${summarizeRecord(r)}  ${pc.dim(relativeTime(r.updated_at))}`);
+      // Full id, not a prefix — `one mem get` needs the whole thing, so a
+      // truncated id would make every line un-actionable.
+      console.log(`    ${pc.dim('·')} ${summarizeRecord(r)}  ${pc.dim(relativeTime(r.updated_at))}  ${pc.dim(r.id)}`);
     }
     if (list.length > perType) {
       console.log(`    ${pc.dim(`… and ${list.length - perType} more (raise --limit)`)}`);
     }
+  }
+  if (truncated) {
+    console.log();
+    console.log(`  ${pc.yellow('⚠')} Stopped at ${FIND_BY_KEY_FETCH_CAP} matches — there are more, and types sorting after the last one shown are missing entirely. Re-run with --type <type> to see them.`);
   }
   console.log();
 }

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -810,21 +810,37 @@ Transform, exclude, identityKey, and hooks all fire in **both** phases. In Phase
 
 ## Cross-Platform Identity
 
-Add \`identityKey\` to a sync profile to extract a stable cross-platform identifier (e.g. email) into a normalized \`_identity\` column:
+Two ways to tag a record with a cross-platform identifier (e.g. email), depending on whether the record IS an entity or INVOLVES many:
+
+**\`identityKey\` (singular)** — "this record IS this entity". The value goes into the record's \`keys[]\`, which the store uses to MERGE records for the same entity across platforms (Attio + HubSpot for the same person collapse into one):
 
 \`\`\`json
 {"platform": "hubspot", "model": "contacts", "identityKey": "properties.email"}
-{"platform": "stripe",  "model": "customers", "identityKey": "email"}
 {"platform": "attio",   "model": "attioPeople", "identityKey": "email_addresses[0].email_address"}
 \`\`\`
 
-The value is lowercased and trimmed, stored as a prefixed key on the mem record (e.g. \`email:jane@acme.com\`). Look up across platforms:
+**\`identityKeys\` (plural, #128)** — "this record INVOLVES these people". For records with N participants (Gmail thread From/To/Cc, calendar attendees, meeting invitees) where a single key can't capture everyone. These go into a separate \`identity_keys[]\` column that does NOT merge — so a thread with many participants stays its own record:
+
+\`\`\`json
+{"platform": "google-calendar", "model": "events", "identityKeys": [
+  {"prefix": "email", "path": "organizer.email"},
+  {"prefix": "email", "path": "attendees[].email"}
+]}
+\`\`\`
+
+Each \`path\` supports \`[]\` wildcards (one key per element) and a \`[name=From]\` equality filter (e.g. Gmail \`messages[].payload.headers[name=From].value\`). \`email\`-prefixed values are email-extracted, so display-name headers (\`"Jane <jane@acme.com>"\`) and comma-lists normalize cleanly. Values are lowercased/trimmed/deduped. \`sync test\` previews how many identity keys each record resolves.
+
+Query everything sharing an identity key, grouped by type:
 
 \`\`\`bash
+one --agent mem find-by-key email:jane@acme.com               # all records carrying this key
+one --agent mem find-by-key email:jane@acme.com --type gmail/gmailThreads
+one --agent mem find-by-key email:jane@acme.com email:bob@acme.com   # intersection (both keys)
+# Look up the single record owning a source key:
 one --agent mem find-by-source hubspot/contacts:<id>
-# Or via the dotted --where path on the identity key:
-one --agent sync query hubspot/contacts --where 'email=jane@acme.com'
 \`\`\`
+
+\`find-by-key\` spans BOTH columns — entity keys in \`keys[]\` and association keys in \`identity_keys[]\`.
 
 \`sync sql\` was retired in the unified memory cutover — a raw-SQL surface can't safely span the embedded Postgres, remote Postgres, and third-party backends without leaking specifics. Use \`mem search\` / \`sync search\` / \`sync query\` with dotted \`--where\` paths instead.
 
@@ -912,7 +928,8 @@ Every \`sync X\` command is also exposed as \`mem sync X\` — same handlers, sa
 | limitLocation | no | "query" (default) or "body" for POST endpoints |
 | enrich | no | Detail endpoint config for record enrichment (actionId, pathVars, concurrency) |
 | transform | no | Shell command to transform records (stdin: JSON array, stdout: JSON array) |
-| identityKey | no | Dot-path to cross-platform identifier (e.g. email) → stored as \`_identity\` column |
+| identityKey | no | "This record IS this entity" — dot-path to a cross-platform id (e.g. email) → \`keys[]\` (drives entity merge) |
+| identityKeys | no | "This record INVOLVES these people" — \`[{prefix, path}]\` for N participants (#128) → non-merging \`identity_keys[]\`; query with \`mem find-by-key\` |
 | exclude | no | Dot-path fields to strip before storing (e.g. \`["messages[].body"]\`) |
 | onInsert/onUpdate/onChange | no | Change hooks (shell command, "log", or flow) |
 

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -496,15 +496,18 @@ one --agent mem get <id> --links
 # Update (shallow merge into data; regenerates searchable_text from the merged data)
 one --agent mem update <id> '{"status":"done"}'
 
-# Manage identity keys AFTER creation (keys are a first-class column, NOT data).
-# Unique across ACTIVE records — a clear error names the record that owns a taken key.
+# Manage MERGE KEYS after creation — the \`keys[]\` column (a first-class column,
+# NOT data). Unique across ACTIVE records — a clear error names the record that
+# owns a taken key. This is the column that collapses two records into one.
 one --agent mem key <id> --add email:new@x.com
 one --agent mem key <id> --remove email:old@x.com
-one --agent mem key <id> --set 'email:a@x.com,phone:+1555'   # replace all keys
+one --agent mem key <id> --set 'email:a@x.com,phone:+1555'   # replace ALL merge keys
 # NOTE: passing keys to 'mem update' is rejected — keys are not a data field.
+# NOTE: 'mem key' WRITES keys[]. To READ across records, use 'mem find-by-key'
+# (see Identity keys below) — different command, different column coverage.
 
-# Archive / unarchive. Archiving FREES a record's keys: an archived record no
-# longer blocks a new active record from reusing the same key (uniqueness is
+# Archive / unarchive. Archiving FREES a record's merge keys: an archived record
+# no longer blocks a new active record from reusing the same key (uniqueness is
 # scoped to active records).
 one --agent mem archive <id> --reason superseded
 
@@ -545,6 +548,55 @@ Synced rows carry \`sources\` entries keyed by \`<platform>/<model>:<external_id
 one --agent mem sources <id>                          # list source entries
 one --agent mem find-by-source attio/attioPeople:abc-123
 \`\`\`
+
+\`find-by-source\` answers "which ONE record owns this external id" — a single record, preferring the active owner. For "everything about this person", use \`find-by-key\` below.
+
+## Identity keys (cross-platform join)
+
+Two different columns carry prefixed keys like \`email:jane@acme.com\`, and the difference is the whole point:
+
+- **\`keys[]\` — merge keys.** "This record IS this entity." Unique across active records, and \`sync\` merges any incoming record that overlaps an existing one. Written by \`mem add --keys\`, \`mem key\`, and a profile's singular \`identityKey\`.
+- **\`identity_keys[]\` — association keys (#128).** "This record INVOLVES these people." Deliberately exempt from both the uniqueness constraint and the overlap-merge, so a Gmail thread with 12 participants stays one thread instead of collapsing into a contact. Written by a profile's plural \`identityKeys\` (see \`one guide sync\`).
+
+\`mem find-by-key\` queries BOTH columns at once, so one call surfaces the CRM record, the email threads, the calendar events, and the meeting notes for the same person:
+
+\`\`\`bash
+one --agent mem find-by-key email:jane@acme.com                # every record carrying the key
+one --agent mem find-by-key email:jane@acme.com --type gmail/gmailThreads   # one record type
+one --agent mem find-by-key email:a@x.com email:b@y.com        # intersection — records with BOTH
+one --agent mem find-by-key email:jane@acme.com --limit 25     # show more per type (default 10)
+\`\`\`
+
+Any prefix works (\`email:\`, \`domain:\`, \`phone:\`, even a raw source key) — matching is plain array containment over the two columns combined, so a two-key query still matches when one key sits in \`keys[]\` and the other in \`identity_keys[]\`. Only ACTIVE records are returned. Lookup keys are lowercased/trimmed to match how sync writes them, with a verbatim retry for hand-written mixed-case keys, so \`email:Jane@Acme.com\` and \`email:jane@acme.com\` find the same records.
+
+Agent output is grouped by record type:
+
+\`\`\`json
+{
+  "keys": ["email:jane@acme.com"],
+  "total": 13,
+  "truncated": false,
+  "fetchCap": 2000,
+  "perTypeLimit": 10,
+  "byType": {
+    "attio/attioPeople": { "count": 1, "items": [ { "id": "...", "type": "...", "data": {}, "keys": ["attio/attioPeople:J1", "email:jane@acme.com"] } ] },
+    "gmail/gmailThreads": { "count": 12, "items": [] }
+  }
+}
+\`\`\`
+
+\`items\` are whole mem records. \`keys\` and \`identity_keys\` are **omitted, not \`[]\`**, when the record has none — the contact above matched on \`keys[]\` and carries no \`identity_keys\` field at all. Read them as \`(item.identity_keys ?? [])\`.
+
+There are TWO independent truncations, and conflating them gives wrong answers:
+
+- **\`--limit\` (default 10, echoed as \`perTypeLimit\`)** is display only. It slices each \`items\` array; \`total\` and \`count\` stay full match counts. \`count > items.length\` just means "raise \`--limit\` to list the rest".
+- **\`truncated: true\`** means the query hit the \`fetchCap\` (2000 matches) before it ran out of records. Now \`total\` and every \`count\` are floors, and because rows arrive ordered by type, any type sorting after the cut is absent from \`byType\` altogether. One high-volume type — your own address on every synced Gmail thread, say — can consume the whole budget. Re-run with \`--type <type>\` to get an accurate answer for the type you care about; the interactive (non-\`--agent\`) output prints a \`⚠\` and a \`2000+\` style count in the same situation.
+
+\`items\` entries are whole mem records, same fields as \`mem get\`, so no follow-up \`mem get\` is needed.
+
+\`keys\` echoes the key form that actually matched, which is the normalized one unless the verbatim retry won.
+
+Do not confuse \`mem key\` with \`mem find-by-key\`: \`mem key\` WRITES \`keys[]\` on a single record (\`--set\` replaces the array outright and can trigger a merge), while \`find-by-key\` is a read-only query across every record.
 
 ## Sync into memory
 
@@ -837,6 +889,8 @@ The transform can be any command: \`jq\`, \`python3\`, a bash script, or \`one f
 
 Transform, exclude, identityKey, and hooks all fire in **both** phases. In Phase 1 they run on the raw list page; in Phase 2 they run again on the merged (list + enriched) record so that transforms can extract columns from fields that only appear after enrichment. Phase 2 fires \`onUpdate\`/\`onChange\` for every row it writes — \`onInsert\` is Phase-1-only because the row already exists in SQL by the time enrichment runs.
 
+**Exception — plural \`identityKeys\` on an enriching profile.** When a profile declares \`enrich\`, Phase 1 deliberately writes *no opinion* about \`identity_keys[]\` (it leaves whatever is stored untouched) and only Phase 2 sets them. Phase 1 sees the list shape, where participant paths like \`messages[].payload.headers[name=From].value\` don't exist yet — if it wrote its empty result, every re-sync would erase the participants Phase 2 had resolved. Two consequences worth knowing: a row whose enrichment is skipped or rate-limited keeps \`identity_keys\` \`NULL\` until it enriches, and a participant removed upstream is only cleared once that row re-enriches.
+
 ## Cross-Platform Identity
 
 Two ways to tag a record with a cross-platform identifier (e.g. email), depending on whether the record IS an entity or INVOLVES many:
@@ -845,6 +899,7 @@ Two ways to tag a record with a cross-platform identifier (e.g. email), dependin
 
 \`\`\`json
 {"platform": "hubspot", "model": "contacts", "identityKey": "properties.email"}
+{"platform": "stripe",  "model": "customers", "identityKey": "email"}
 {"platform": "attio",   "model": "attioPeople", "identityKey": "email_addresses[0].email_address"}
 \`\`\`
 
@@ -865,11 +920,16 @@ Query everything sharing an identity key, grouped by type:
 one --agent mem find-by-key email:jane@acme.com               # all records carrying this key
 one --agent mem find-by-key email:jane@acme.com --type gmail/gmailThreads
 one --agent mem find-by-key email:jane@acme.com email:bob@acme.com   # intersection (both keys)
+one --agent mem find-by-key email:jane@acme.com --limit 25    # show more records per type
 # Look up the single record owning a source key:
 one --agent mem find-by-source hubspot/contacts:<id>
+# Or filter ONE model on the underlying field via the dotted --where path. Note
+# this is the raw data path, NOT the identity key — for the hubspot profile above
+# that's 'properties.email', the same path its identityKey extracts from.
+one --agent sync query hubspot/contacts --where 'properties.email=jane@acme.com'
 \`\`\`
 
-\`find-by-key\` spans BOTH columns — entity keys in \`keys[]\` and association keys in \`identity_keys[]\`.
+\`find-by-key\` spans BOTH columns — entity keys in \`keys[]\` and association keys in \`identity_keys[]\`. \`--limit\` (default 10) caps only how many records are listed per type; the per-type \`count\` and overall \`total\` are still full match counts, so \`count\` exceeding the listed items is the signal to raise it. A separate \`truncated\` flag reports the very different case where the 2000-match fetch cap was hit and whole types are missing — see \`one guide memory\` for the full response shape.
 
 \`sync sql\` was retired in the unified memory cutover — a raw-SQL surface can't safely span the embedded Postgres, remote Postgres, and third-party backends without leaking specifics. Use \`mem search\` / \`sync search\` / \`sync query\` with dotted \`--where\` paths instead.
 

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -891,6 +891,23 @@ Transform, exclude, identityKey, and hooks all fire in **both** phases. In Phase
 
 **Exception — plural \`identityKeys\` on an enriching profile.** When a profile declares \`enrich\`, Phase 1 deliberately writes *no opinion* about \`identity_keys[]\` (it leaves whatever is stored untouched) and only Phase 2 sets them. Phase 1 sees the list shape, where participant paths like \`messages[].payload.headers[name=From].value\` don't exist yet — if it wrote its empty result, every re-sync would erase the participants Phase 2 had resolved. Two consequences worth knowing: a row whose enrichment is skipped or rate-limited keeps \`identity_keys\` \`NULL\` until it enriches, and a participant removed upstream is only cleared once that row re-enriches.
 
+### Phase 1 never degrades an already-enriched record
+
+Phase 2 only visits rows \`WHERE _enriched_at IS NULL\`, so it never revisits a row it has already enriched. That makes Phase 1's write dangerous on every run after the first: it holds only the thin list shape, and an authoritative write would replace the enriched payload with it — permanently, since Phase 2 won't come back to repair it.
+
+So for a row the mirror reports as already enriched, Phase 1 writes **non-authoritatively**:
+
+| | Already-enriched row | Not yet enriched |
+|---|---|---|
+| \`data\` | merged — enrich-only fields survive, list fields still refresh | replaced |
+| \`searchable_text\` / \`content_hash\` | kept (thin text can't overwrite the enriched text) | recomputed |
+| \`identity_keys[]\` | kept | written |
+| \`keys[]\`, \`tags\`, \`sources.last_synced_at\`, embeddings | updated normally | updated normally |
+
+The write still happens, so \`--embed\`, profile edits, and the store's un-archive self-heal all keep working on enriched rows. The one thing given up: a field that disappears from the *list* shape upstream no longer disappears from an enriched record, because a merge cannot delete. \`sync run\` reports the count as \`memPreserved\`.
+
+**Known gap:** \`--full-refresh\` does **not** clear \`_enriched_at\`, so it does not re-enrich — and there is currently no way to re-enrich a record whose upstream detail content changed after its first enrichment. Delete the mirror (\`.one/sync/data/<platform>.db\`) to force a full re-enrich.
+
 ## Cross-Platform Identity
 
 Two ways to tag a record with a cross-platform identifier (e.g. email), depending on whether the record IS an entity or INVOLVES many:

--- a/src/lib/memory/backend.ts
+++ b/src/lib/memory/backend.ts
@@ -116,6 +116,14 @@ export interface MemBackend {
   addSource(recordId: string, ref: SourceRefInput): Promise<void>;
   removeSource(recordId: string, sourceKey: string): Promise<boolean>;
   findBySource(sourceKey: string): Promise<MemRecord | null>;
+  /**
+   * Find every record whose `keys[]` array contains ALL of the given keys
+   * (cross-platform identity join, #131). One key → every record carrying it;
+   * multiple keys → the intersection (records carrying all of them). Excludes
+   * archived records unless `status` says otherwise. Results are ordered by
+   * type, then most-recent. Powers `one mem find-by-key`.
+   */
+  findByKeys(keys: string[], opts?: { type?: string; status?: 'active' | 'archived' | 'all'; limit?: number }): Promise<MemRecord[]>;
   listSources(recordId: string): Promise<SourcesMap>;
 
   // Sync state

--- a/src/lib/memory/backend.ts
+++ b/src/lib/memory/backend.ts
@@ -85,6 +85,13 @@ export interface UpsertOptions {
    * memories but wrong for synced rows where memory should track the
    * source exactly. Sync callers pass `replace: true`; interactive
    * callers (mem add, mem update) leave it off.
+   *
+   * `replace` governs `data`, `tags`, `searchable_text` and `identity_keys`.
+   * It does NOT govern `keys[]`, which always unions — dropping a merge key
+   * would orphan the record from the source that wrote it. And even under
+   * `replace: true`, a NULL/undefined `identity_keys` KEEPS the stored value
+   * rather than clearing it; only an explicit `[]` clears. See
+   * `RecordInput.identity_keys` for why that three-state contract exists.
    */
   replace?: boolean;
 }
@@ -138,11 +145,21 @@ export interface MemBackend {
   removeSource(recordId: string, sourceKey: string): Promise<boolean>;
   findBySource(sourceKey: string): Promise<MemRecord | null>;
   /**
-   * Find every record whose `keys[]` array contains ALL of the given keys
-   * (cross-platform identity join, #131). One key → every record carrying it;
-   * multiple keys → the intersection (records carrying all of them). Excludes
-   * archived records unless `status` says otherwise. Results are ordered by
-   * type, then most-recent. Powers `one mem find-by-key`.
+   * Find every record that carries ALL of the given keys across the UNION of
+   * `keys[]` and `identity_keys[]` (cross-platform identity join, #131).
+   * Implementations MUST match both columns, and a single query may be
+   * satisfied by a mix of the two — a record with `keys=['attio:123']` and
+   * `identity_keys=['email:jane@acme.com']` matches a lookup for both.
+   *
+   * `keys[]` holds the merge identifiers (unique across active records);
+   * `identity_keys[]` holds the non-merging participant associations (#128),
+   * which are deliberately exempt from key uniqueness so an N-participant
+   * record stays its own row.
+   *
+   * One key → every record carrying it; multiple keys → the intersection
+   * (records carrying all of them). Excludes archived records unless `status`
+   * says otherwise. Results are ordered by type, then most-recent. Powers
+   * `one mem find-by-key`.
    */
   findByKeys(keys: string[], opts?: { type?: string; status?: 'active' | 'archived' | 'all'; limit?: number }): Promise<MemRecord[]>;
   listSources(recordId: string): Promise<SourcesMap>;

--- a/src/lib/memory/plugins/embedded-postgres/index.ts
+++ b/src/lib/memory/plugins/embedded-postgres/index.ts
@@ -374,6 +374,7 @@ class LazyEmbeddedPostgresBackend implements MemBackend {
   async addSource(...a: Parameters<MemBackend['addSource']>): ReturnType<MemBackend['addSource']> { return (await this.ensure()).addSource(...a); }
   async removeSource(...a: Parameters<MemBackend['removeSource']>): ReturnType<MemBackend['removeSource']> { return (await this.ensure()).removeSource(...a); }
   async findBySource(...a: Parameters<MemBackend['findBySource']>): ReturnType<MemBackend['findBySource']> { return (await this.ensure()).findBySource(...a); }
+  async findByKeys(...a: Parameters<MemBackend['findByKeys']>): ReturnType<MemBackend['findByKeys']> { return (await this.ensure()).findByKeys(...a); }
   async listSources(...a: Parameters<MemBackend['listSources']>): ReturnType<MemBackend['listSources']> { return (await this.ensure()).listSources(...a); }
 
   async getSyncState(...a: Parameters<MemBackend['getSyncState']>): ReturnType<MemBackend['getSyncState']> { return (await this.ensure()).getSyncState(...a); }

--- a/src/lib/memory/plugins/pglite/index.ts
+++ b/src/lib/memory/plugins/pglite/index.ts
@@ -182,6 +182,7 @@ class LazyPgliteBackend implements MemBackend {
   async addSource(...a: Parameters<MemBackend['addSource']>): ReturnType<MemBackend['addSource']> { return (await this.ensure()).addSource(...a); }
   async removeSource(...a: Parameters<MemBackend['removeSource']>): ReturnType<MemBackend['removeSource']> { return (await this.ensure()).removeSource(...a); }
   async findBySource(...a: Parameters<MemBackend['findBySource']>): ReturnType<MemBackend['findBySource']> { return (await this.ensure()).findBySource(...a); }
+  async findByKeys(...a: Parameters<MemBackend['findByKeys']>): ReturnType<MemBackend['findByKeys']> { return (await this.ensure()).findByKeys(...a); }
   async listSources(...a: Parameters<MemBackend['listSources']>): ReturnType<MemBackend['listSources']> { return (await this.ensure()).listSources(...a); }
 
   async getSyncState(...a: Parameters<MemBackend['getSyncState']>): ReturnType<MemBackend['getSyncState']> { return (await this.ensure()).getSyncState(...a); }

--- a/src/lib/memory/plugins/pglite/pglite.test.ts
+++ b/src/lib/memory/plugins/pglite/pglite.test.ts
@@ -33,7 +33,7 @@ describe('PGlite plugin — live integration', () => {
 
   it('reports the schema version after ensureSchema', async () => {
     const v = await backend.getSchemaVersion();
-    assert.equal(v, '2.1.0');
+    assert.equal(v, '2.2.0');
   });
 
   it('advertises capabilities the CoreBackend relies on', () => {
@@ -255,5 +255,62 @@ describe('PGlite plugin — live integration', () => {
     assert.ok(s.recordCount > 0);
     assert.ok(s.activeCount >= 0);
     assert.equal(s.recordCount, s.activeCount + s.archivedCount);
+  });
+
+  // #128/#131: identity_keys[] is a SEPARATE column that must NOT drive the
+  // upsert overlap-merge. This is the regression guard for the bug that
+  // motivated the redesign — participant emails in keys[] collapsed
+  // multi-participant records into each other / into contacts.
+  it('identity_keys do NOT merge records that share one (the #128 fix)', async () => {
+    const attio = await backend.upsertByKeys({
+      type: 'attio/people',
+      data: { name: 'Jane' },
+      keys: ['attio/people:JANE'],
+      identity_keys: ['email:jane@acme.com'],
+      sources: { 'attio/people:JANE': { last_synced_at: new Date().toISOString() } },
+    });
+    const thread = await backend.upsertByKeys({
+      type: 'gmail/gmailThreads',
+      data: { subject: 'hello' },
+      keys: ['gmail/gmailThreads:T1'],
+      identity_keys: ['email:jane@acme.com', 'email:moe@withone.ai'],
+      sources: { 'gmail/gmailThreads:T1': { last_synced_at: new Date().toISOString() } },
+    });
+    assert.notEqual(thread.record.id, attio.record.id, 'thread must NOT merge into the contact');
+    assert.equal(thread.record.type, 'gmail/gmailThreads', 'thread keeps its own type');
+    assert.deepEqual((thread.record.identity_keys ?? []).sort(), ['email:jane@acme.com', 'email:moe@withone.ai'].sort());
+  });
+
+  it('findByKeys joins records across types by a shared identity key (#131)', async () => {
+    const key = 'email:link@acme.com';
+    await backend.upsertByKeys({ type: 'attio/people', data: { name: 'Link Person' }, keys: ['attio/people:LP'], identity_keys: [key], sources: { 'attio/people:LP': { last_synced_at: new Date().toISOString() } } });
+    await backend.upsertByKeys({ type: 'gmail/gmailThreads', data: { subject: 'one' }, keys: ['gmail/gmailThreads:LT1'], identity_keys: [key], sources: { 'gmail/gmailThreads:LT1': { last_synced_at: new Date().toISOString() } } });
+    await backend.upsertByKeys({ type: 'gmail/gmailThreads', data: { subject: 'two' }, keys: ['gmail/gmailThreads:LT2'], identity_keys: [key], sources: { 'gmail/gmailThreads:LT2': { last_synced_at: new Date().toISOString() } } });
+
+    const found = await backend.findByKeys([key]);
+    assert.equal(found.length, 3, 'three records share the identity key');
+    const types = new Set(found.map(r => r.type));
+    assert.ok(types.has('attio/people') && types.has('gmail/gmailThreads'));
+
+    // --type filter
+    const onlyThreads = await backend.findByKeys([key], { type: 'gmail/gmailThreads' });
+    assert.equal(onlyThreads.length, 2);
+  });
+
+  it('findByKeys with two keys returns the intersection (#131)', async () => {
+    await backend.upsertByKeys({ type: 'gmail/gmailThreads', data: { subject: 'jane+bob' }, keys: ['gmail/gmailThreads:IX1'], identity_keys: ['email:jane@acme.com', 'email:bob@acme.com'], sources: { 'gmail/gmailThreads:IX1': { last_synced_at: new Date().toISOString() } } });
+    await backend.upsertByKeys({ type: 'gmail/gmailThreads', data: { subject: 'jane only' }, keys: ['gmail/gmailThreads:IX2'], identity_keys: ['email:jane@acme.com'], sources: { 'gmail/gmailThreads:IX2': { last_synced_at: new Date().toISOString() } } });
+
+    const both = await backend.findByKeys(['email:jane@acme.com', 'email:bob@acme.com']);
+    assert.ok(both.every(r => (r.identity_keys ?? []).includes('email:bob@acme.com')), 'only records with BOTH keys');
+    assert.ok(both.some(r => r.data.subject === 'jane+bob'));
+    assert.ok(!both.some(r => r.data.subject === 'jane only'));
+  });
+
+  it('findByKeys also matches entity keys in keys[] (union of both columns)', async () => {
+    // A contact whose own email is the singular identityKey lands in keys[].
+    await backend.upsertByKeys({ type: 'attio/people', data: { name: 'Entity Keyed' }, keys: ['attio/people:EK', 'email:entity@acme.com'], sources: { 'attio/people:EK': { last_synced_at: new Date().toISOString() } } });
+    const found = await backend.findByKeys(['email:entity@acme.com']);
+    assert.ok(found.some(r => r.data.name === 'Entity Keyed'), 'find-by-key spans keys[] and identity_keys[]');
   });
 });

--- a/src/lib/memory/plugins/pglite/pglite.test.ts
+++ b/src/lib/memory/plugins/pglite/pglite.test.ts
@@ -33,7 +33,11 @@ describe('PGlite plugin — live integration', () => {
 
   it('reports the schema version after ensureSchema', async () => {
     const v = await backend.getSchemaVersion();
-    assert.equal(v, '2.3.0');
+    // Deliberately a literal, not an import of SCHEMA_VERSION — that would be
+    // tautological. This is the canary that forces a conscious decision every
+    // time the schema version moves (a silent 2.2.0 collision between two
+    // branches is exactly how the identity_keys migration got skipped once).
+    assert.equal(v, '2.3.1');
   });
 
   it('advertises capabilities the CoreBackend relies on', () => {
@@ -423,5 +427,85 @@ describe('PGlite plugin — live integration', () => {
     await backend.upsertByKeys({ type: 'attio/people', data: { name: 'Entity Keyed' }, keys: ['attio/people:EK', 'email:entity@acme.com'], sources: { 'attio/people:EK': { last_synced_at: new Date().toISOString() } } });
     const found = await backend.findByKeys(['email:entity@acme.com']);
     assert.ok(found.some(r => r.data.name === 'Entity Keyed'), 'find-by-key spans keys[] and identity_keys[]');
+  });
+
+  it('two ACTIVE records may share an identity key — the uniqueness trigger skips the column', async () => {
+    // The exemption stated in schema.ts, asserted directly rather than
+    // inferred from the merge test. keys[] is unique across active records;
+    // identity_keys[] deliberately is not, because N people are on a thread
+    // and every one of them is on other threads too.
+    const shared = 'email:shared-participant@acme.com';
+    await backend.insert({ type: 'gmail/gmailThreads', data: { subject: 'one' }, keys: ['gmail/gmailThreads:UQ1'], identity_keys: [shared] });
+    await backend.insert({ type: 'gmail/gmailThreads', data: { subject: 'two' }, keys: ['gmail/gmailThreads:UQ2'], identity_keys: [shared] });
+    await backend.insert({ type: 'google-calendar/events', data: { summary: 'sync' }, keys: ['google-calendar/events:UQ3'], identity_keys: [shared] });
+    assert.equal((await backend.findByKeys([shared])).length, 3, 'all three coexist');
+
+    // Contrast: the same value in keys[] on a second ACTIVE record is rejected.
+    await backend.insert({ type: 'person', data: { name: 'Owner' }, keys: ['email:owned@acme.com'] });
+    await assert.rejects(
+      backend.insert({ type: 'person', data: { name: 'Squatter' }, keys: ['email:owned@acme.com'] }),
+      /already exist/i,
+      'keys[] is still the unique column',
+    );
+  });
+
+  // The three-state identity_keys contract under `replace: true`. The writer's
+  // only way to say "keep what's stored" is SQL NULL, so NULL must NOT clear —
+  // sync's unconditional list-phase write sends it on every page of every run,
+  // and clearing on NULL wiped the column on the second sync of every enrich
+  // profile. `'{}'` stays the clear signal so a removed attendee disappears.
+  it('replace + NULL identity_keys KEEPS, replace + [] CLEARS', async () => {
+    const seed = {
+      type: 'google-calendar/events',
+      keys: ['google-calendar/events:TS1'],
+      sources: { 'google-calendar/events:TS1': { last_synced_at: new Date().toISOString() } },
+    };
+    const first = await backend.upsertByKeys(
+      { ...seed, data: { summary: 'standup' }, identity_keys: ['email:a@acme.com', 'email:b@acme.com'] },
+      { replace: true },
+    );
+    assert.deepEqual((first.record.identity_keys ?? []).sort(), ['email:a@acme.com', 'email:b@acme.com']);
+
+    // undefined → SQL NULL → "no opinion". Data still replaces; the column doesn't.
+    const kept = await backend.upsertByKeys(
+      { ...seed, data: { summary: 'standup (renamed)' }, identity_keys: undefined },
+      { replace: true },
+    );
+    assert.equal(kept.record.data.summary, 'standup (renamed)', 'replace still replaces data');
+    assert.deepEqual((kept.record.identity_keys ?? []).sort(), ['email:a@acme.com', 'email:b@acme.com'], 'NULL must keep');
+
+    // A shorter non-empty array replaces wholesale — a removed attendee goes.
+    const shrunk = await backend.upsertByKeys(
+      { ...seed, data: { summary: 'standup' }, identity_keys: ['email:a@acme.com'] },
+      { replace: true },
+    );
+    assert.deepEqual(shrunk.record.identity_keys, ['email:a@acme.com'], 'replace does not union');
+
+    // [] → authoritative zero → clear.
+    const cleared = await backend.upsertByKeys(
+      { ...seed, data: { summary: 'standup' }, identity_keys: [] },
+      { replace: true },
+    );
+    assert.deepEqual(cleared.record.identity_keys ?? [], [], '[] must clear');
+  });
+
+  it('merge mode (replace: false) unions identity_keys and NULL keeps', async () => {
+    // `mem add` / `mem update` are interactive and additive — an omitted
+    // column must never subtract. Notably `mem migrate` upserts with no
+    // identity_keys at all, so this is what stops it eating them.
+    const seed = {
+      type: 'fathom/meetings',
+      keys: ['fathom/meetings:MG1'],
+      sources: { 'fathom/meetings:MG1': { last_synced_at: new Date().toISOString() } },
+    };
+    await backend.upsertByKeys({ ...seed, data: { title: 'kickoff' }, identity_keys: ['email:host@acme.com'] });
+    const unioned = await backend.upsertByKeys({ ...seed, data: {}, identity_keys: ['email:guest@acme.com'] });
+    assert.deepEqual(
+      (unioned.record.identity_keys ?? []).sort(),
+      ['email:guest@acme.com', 'email:host@acme.com'],
+      'merge unions rather than replaces',
+    );
+    const untouched = await backend.upsertByKeys({ ...seed, data: { note: 'x' } });
+    assert.deepEqual((untouched.record.identity_keys ?? []).sort(), ['email:guest@acme.com', 'email:host@acme.com']);
   });
 });

--- a/src/lib/memory/plugins/pglite/schema-upgrade.test.ts
+++ b/src/lib/memory/plugins/pglite/schema-upgrade.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Schema paths no other test in this repo exercises: UPGRADING an existing
+ * store, and the no-pgvector variant of the DDL.
+ *
+ * Every other backend test opens a fresh `:memory:` PGlite and applies the
+ * current schema in one shot, so `ensureSchema()` only ever runs against a
+ * blank slate. That is precisely why two shipped-schema bugs passed CI green:
+ *
+ *   - the 2.2.0 version collision (main's #171 and this branch both stamped
+ *     2.2.0), which made `ensureSchema`'s version fast-path skip the
+ *     identity_keys DDL forever on an already-stamped store; and
+ *   - the stale `mem_upsert_by_keys` overload, because CREATE OR REPLACE
+ *     cannot change a function's argument list — adding `p_identity_keys
+ *     TEXT[] DEFAULT NULL` defined a SECOND function, and an 11-arg call then
+ *     matched both and failed with 42725 "function ... is not unique".
+ *
+ * Neither is reachable from a fresh store. So these tests build a store, then
+ * DEGRADE it back to a pre-#128 shape (drop the column, restamp the version,
+ * reinstall the 11-arg function) and assert `ensureSchema()` heals it.
+ *
+ * Uses a raw PGlite handle rather than the plugin because it needs to run DDL,
+ * and `backend.raw()` is deliberately read-only.
+ *
+ * The second suite covers the OTHER unreachable path: `mem_upsert_by_keys`
+ * exists twice in schema.ts — a no-vector body in FUNCTIONS_SQL and a
+ * vector-aware CREATE OR REPLACE of the same signature in
+ * VECTOR_FUNCTIONS_SQL. Every backend the suite instantiates advertises
+ * `vectorSearch: true`, so the vector body always wins and the no-vector one
+ * has never been executed by a test — including its half of the identity_keys
+ * three-state contract, which has to be edited in both places by hand.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { CoreBackend } from '../postgres-core/index.js';
+import type { PgClient, PgQueryResult } from '../postgres-core/index.js';
+import type { BackendCapabilities } from '../../backend.js';
+import { SCHEMA_VERSION } from '../../schema.js';
+
+// Mirrors the plugin's CAPABILITIES so the DDL path under test is the exact
+// one PGlite users get (vector columns + the vector-variant upsert function).
+const CAPABILITIES: BackendCapabilities = {
+  vectorSearch: true,
+  fullTextSearch: true,
+  partialIndexes: true,
+  jsonPathQuery: true,
+  triggers: true,
+  concurrentWriters: false,
+  maxVectorDims: 2000,
+  rawSql: true,
+};
+
+interface PgliteInstance {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[]; affectedRows?: number }>;
+  exec(text: string): Promise<Array<{ rows?: unknown[]; affectedRows?: number }>>;
+  close(): Promise<void>;
+}
+
+/** Same params→query / no-params→exec routing the plugin's wrapClient does. */
+function wrapClient(db: PgliteInstance): PgClient {
+  async function run<T>(text: string, params?: unknown[]): Promise<PgQueryResult<T>> {
+    if (params && params.length > 0) {
+      const res = await db.query<T>(text, params);
+      return { rows: res.rows, rowCount: res.affectedRows };
+    }
+    const results = await db.exec(text);
+    const last = results.length > 0 ? results[results.length - 1] : undefined;
+    return { rows: ((last?.rows as T[] | undefined) ?? []), rowCount: last?.affectedRows };
+  }
+  const client: PgClient = {
+    query: run,
+    async transaction<T>(fn: (tx: PgClient) => Promise<T>): Promise<T> {
+      await run('BEGIN');
+      try {
+        const result = await fn(client);
+        await run('COMMIT');
+        return result;
+      } catch (err) {
+        try { await run('ROLLBACK'); } catch { /* swallow secondary error */ }
+        throw err;
+      }
+    },
+    async close(): Promise<void> { await db.close(); },
+  };
+  return client;
+}
+
+/**
+ * The pre-#128 11-argument signature. Only the signature matters — the fix
+ * under test is `DROP FUNCTION IF EXISTS mem_upsert_by_keys(<11 args>)` in
+ * FUNCTIONS_SQL, and a stale entry in pg_proc breaks callers regardless of
+ * what its body does. Body kept trivial so the test can't accidentally depend
+ * on old behaviour.
+ */
+const OLD_11_ARG_FUNCTION = `
+CREATE OR REPLACE FUNCTION mem_upsert_by_keys(
+    p_type TEXT, p_data JSONB, p_tags TEXT[], p_keys TEXT[], p_sources JSONB,
+    p_searchable_text TEXT, p_content_hash TEXT, p_weight INTEGER DEFAULT NULL,
+    p_embedding TEXT DEFAULT NULL, p_embedding_model TEXT DEFAULT NULL,
+    p_replace BOOLEAN DEFAULT FALSE
+) RETURNS TABLE (id UUID, action TEXT) LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'stale pre-#128 mem_upsert_by_keys was called';
+END;
+$$;
+`;
+
+describe('schema upgrade — ensureSchema heals a pre-#128 store', () => {
+  let db: PgliteInstance;
+  let client: PgClient;
+  let backend: CoreBackend;
+
+  const sql = async <T = Record<string, unknown>>(text: string, params?: unknown[]): Promise<T[]> =>
+    (await client.query<T>(text, params)).rows;
+
+  /** How many mem_upsert_by_keys overloads pg_proc currently holds. */
+  const overloadCount = async (): Promise<number> => {
+    const rows = await sql<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_proc WHERE proname = 'mem_upsert_by_keys'`,
+    );
+    return Number(rows[0].n);
+  };
+
+  /** Column presence via information_schema, i.e. what a DBA would check. */
+  const hasIdentityKeysColumn = async (): Promise<boolean> => {
+    const rows = await sql(
+      `SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'mem_records' AND column_name = 'identity_keys'`,
+    );
+    return rows.length === 1;
+  };
+
+  before(async () => {
+    const { PGlite } = await import('@electric-sql/pglite');
+    const { vector } = await import('@electric-sql/pglite/vector').catch(() => ({ vector: undefined }));
+    db = (await PGlite.create({ extensions: vector ? { vector } : undefined })) as unknown as PgliteInstance;
+    client = wrapClient(db);
+    backend = new CoreBackend(client, CAPABILITIES);
+    await backend.init();
+  });
+
+  after(async () => {
+    await backend.close();
+  });
+
+  /**
+   * Rebuild a healthy current-schema store before each case, then let the case
+   * degrade it however it likes. Cheaper and clearer than one long sequence
+   * where each assertion depends on the previous case's damage.
+   */
+  beforeEach(async () => {
+    await sql(`DROP TABLE IF EXISTS mem_records, mem_links, mem_sync_state, mem_meta CASCADE`);
+    await sql(`DROP FUNCTION IF EXISTS mem_upsert_by_keys(
+      TEXT, JSONB, TEXT[], TEXT[], JSONB, TEXT, TEXT, INTEGER, TEXT, TEXT, BOOLEAN)`);
+    await sql(`DROP FUNCTION IF EXISTS mem_upsert_by_keys(
+      TEXT, JSONB, TEXT[], TEXT[], JSONB, TEXT, TEXT, INTEGER, TEXT, TEXT, BOOLEAN, TEXT[])`);
+    await backend.ensureSchema();
+  });
+
+  it('a fresh store stamps the current version and exposes exactly one upsert overload', async () => {
+    assert.equal(await backend.getSchemaVersion(), SCHEMA_VERSION);
+    assert.equal(await hasIdentityKeysColumn(), true);
+    assert.equal(await overloadCount(), 1, 'a fresh store must not carry a stale signature');
+  });
+
+  it('restores identity_keys when an OLD version stamp gated it away', async () => {
+    // The ordinary upgrade: a store last touched by a build that predates
+    // identity_keys. Seed a row first so we prove the ALTER is additive and
+    // does not take the data with it.
+    const seeded = await backend.insert({ type: 'note', data: { content: 'pre-upgrade row' } });
+
+    await sql(`ALTER TABLE mem_records DROP COLUMN identity_keys`);
+    await sql(`UPDATE mem_meta SET value = '2.1.0' WHERE key = 'version'`);
+    assert.equal(await hasIdentityKeysColumn(), false, 'precondition: degraded to pre-#128');
+
+    await backend.ensureSchema();
+
+    assert.equal(await hasIdentityKeysColumn(), true, 'ALTER ... ADD COLUMN IF NOT EXISTS must run');
+    assert.equal(await backend.getSchemaVersion(), SCHEMA_VERSION, 'version restamped');
+    assert.ok(await backend.getById(seeded.id), 'existing rows survive the upgrade');
+  });
+
+  it('restores identity_keys even when the version stamp already reads CURRENT', async () => {
+    // The 2.2.0 collision in miniature. Version equality alone must not gate
+    // additive DDL: a forgotten bump — or two branches picking the same
+    // literal — leaves the stamp looking current while the column is missing,
+    // and the old fast path then skipped the DDL forever and failed at query
+    // time instead. The fast path now also probes for the column itself.
+    await sql(`ALTER TABLE mem_records DROP COLUMN identity_keys`);
+    assert.equal(await backend.getSchemaVersion(), SCHEMA_VERSION, 'precondition: stamp still current');
+    assert.equal(await hasIdentityKeysColumn(), false, 'precondition: column gone');
+
+    await backend.ensureSchema();
+
+    assert.equal(await hasIdentityKeysColumn(), true, 'a matching version stamp must not gate the DDL');
+  });
+
+  it('drops the stale 11-arg mem_upsert_by_keys instead of leaving both overloads', async () => {
+    // CREATE OR REPLACE cannot narrow/widen an argument list, so an upgraded
+    // store held both. Because the 12-arg version's trailing param is
+    // defaultable, an 11-arg call matched BOTH → 42725 "is not unique".
+    await sql(OLD_11_ARG_FUNCTION);
+    assert.equal(await overloadCount(), 2, 'precondition: both signatures installed');
+
+    // Sanity: with both present, an 11-arg call is genuinely ambiguous. This is
+    // the failure users hit, and it is what the DROP exists to prevent.
+    await assert.rejects(
+      sql(`SELECT * FROM mem_upsert_by_keys($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+        ['note', { a: 1 }, null, ['probe:ambiguous'], {}, null, null, null, null, null, false]),
+      /not unique/i,
+      'precondition: the ambiguity is real',
+    );
+
+    await sql(`UPDATE mem_meta SET value = '2.1.0' WHERE key = 'version'`);
+    await backend.ensureSchema();
+
+    assert.equal(await overloadCount(), 1, 'exactly one signature must survive');
+    // And the survivor is the NEW one: it accepts a 12th argument, and (since
+    // vectorSearch is on) it is the vector-aware body from VECTOR_FUNCTIONS_SQL
+    // rather than the no-vector variant FUNCTIONS_SQL defines first.
+    const args = await sql<{ args: string }>(
+      `SELECT pg_get_function_arguments(oid) AS args FROM pg_proc WHERE proname = 'mem_upsert_by_keys'`,
+    );
+    assert.match(args[0].args, /p_identity_keys/, 'the surviving signature is the identity_keys-aware one');
+  });
+
+  it('insert and upsertByKeys with identity keys both work after the upgrade', async () => {
+    // The end-to-end point of all of the above: after healing, the two write
+    // paths that touch the new column must round-trip it.
+    await sql(`ALTER TABLE mem_records DROP COLUMN identity_keys`);
+    await sql(OLD_11_ARG_FUNCTION);
+    await sql(`UPDATE mem_meta SET value = '2.1.0' WHERE key = 'version'`);
+
+    await backend.ensureSchema();
+
+    const inserted = await backend.insert({
+      type: 'gmail/gmailThreads',
+      data: { subject: 'after upgrade' },
+      keys: ['gmail/gmailThreads:U1'],
+      identity_keys: ['email:jane@acme.com', 'email:bob@acme.com'],
+    });
+    assert.deepEqual(
+      (inserted.identity_keys ?? []).sort(),
+      ['email:bob@acme.com', 'email:jane@acme.com'],
+    );
+
+    const upserted = await backend.upsertByKeys({
+      type: 'attio/people',
+      data: { name: 'Jane' },
+      keys: ['attio/people:U2'],
+      identity_keys: ['email:jane@acme.com'],
+      sources: { 'attio/people:U2': { last_synced_at: new Date().toISOString() } },
+    });
+    assert.equal(upserted.action, 'inserted');
+    assert.deepEqual(upserted.record.identity_keys, ['email:jane@acme.com']);
+
+    // The GIN index the query path relies on is recreated too, and the shared
+    // participant now joins the two records across types.
+    const found = await backend.findByKeys(['email:jane@acme.com']);
+    assert.equal(found.length, 2, 'find-by-key works against the healed column');
+  });
+});
+
+describe('no-pgvector schema variant — the FUNCTIONS_SQL upsert body', () => {
+  let db: PgliteInstance;
+  let client: PgClient;
+  let backend: CoreBackend;
+
+  before(async () => {
+    const { PGlite } = await import('@electric-sql/pglite');
+    // No `vector` extension and vectorSearch: false — this is the shape a
+    // hosted Postgres without pgvector gets.
+    db = (await PGlite.create()) as unknown as PgliteInstance;
+    client = wrapClient(db);
+    backend = new CoreBackend(client, { ...CAPABILITIES, vectorSearch: false, maxVectorDims: 0 });
+    await backend.init();
+    await backend.ensureSchema();
+  });
+
+  after(async () => {
+    await backend.close();
+  });
+
+  it('applies cleanly without the embedding columns', async () => {
+    const rows = (await client.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM information_schema.columns
+        WHERE table_name = 'mem_records' AND column_name IN ('embedding', 'embedded_at', 'embedding_model')`,
+    )).rows;
+    assert.equal(Number(rows[0].n), 0, 'no vector columns when the capability is off');
+    // …but identity_keys is core, not vector-gated.
+    const idk = (await client.query(
+      `SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'mem_records' AND column_name = 'identity_keys'`,
+    )).rows;
+    assert.equal(idk.length, 1);
+  });
+
+  it('honours the same identity_keys three-state contract as the vector body', async () => {
+    // The two function bodies are maintained by hand and drift silently; this
+    // asserts the no-vector one implements NULL=keep / []=clear / [a,b]=replace
+    // exactly like the vector one (asserted in pglite.test.ts).
+    const seed = {
+      type: 'google-calendar/events',
+      keys: ['google-calendar/events:NV1'],
+      sources: { 'google-calendar/events:NV1': { last_synced_at: new Date().toISOString() } },
+    };
+    await backend.upsertByKeys(
+      { ...seed, data: { summary: 'standup' }, identity_keys: ['email:a@acme.com', 'email:b@acme.com'] },
+      { replace: true },
+    );
+
+    const kept = await backend.upsertByKeys({ ...seed, data: { summary: 'renamed' } }, { replace: true });
+    assert.equal(kept.record.data.summary, 'renamed');
+    assert.deepEqual((kept.record.identity_keys ?? []).sort(), ['email:a@acme.com', 'email:b@acme.com'], 'NULL keeps');
+
+    const cleared = await backend.upsertByKeys({ ...seed, data: {}, identity_keys: [] }, { replace: true });
+    assert.deepEqual(cleared.record.identity_keys ?? [], [], '[] clears');
+
+    const merged = await backend.upsertByKeys({ ...seed, data: {}, identity_keys: ['email:c@acme.com'] });
+    assert.deepEqual(merged.record.identity_keys, ['email:c@acme.com'], 'merge unions onto the cleared column');
+  });
+
+  it('identity_keys still do not drive the merge without pgvector', async () => {
+    const now = new Date().toISOString();
+    const contact = await backend.upsertByKeys({
+      type: 'attio/people', data: { name: 'Jane' }, keys: ['attio/people:NVJ'],
+      identity_keys: ['email:jane@acme.com'], sources: { 'attio/people:NVJ': { last_synced_at: now } },
+    });
+    const thread = await backend.upsertByKeys({
+      type: 'gmail/gmailThreads', data: { subject: 'hi' }, keys: ['gmail/gmailThreads:NVT'],
+      identity_keys: ['email:jane@acme.com'], sources: { 'gmail/gmailThreads:NVT': { last_synced_at: now } },
+    });
+    assert.notEqual(thread.record.id, contact.record.id);
+    assert.equal((await backend.findByKeys(['email:jane@acme.com'])).length, 2);
+  });
+});

--- a/src/lib/memory/plugins/postgres-core/backend.ts
+++ b/src/lib/memory/plugins/postgres-core/backend.ts
@@ -68,6 +68,7 @@ interface RecordRow {
   data: Record<string, unknown>;
   tags: string[] | null;
   keys: string[] | null;
+  identity_keys: string[] | null;
   sources: SourcesMap;
   searchable_text: string | null;
   embedding: unknown;
@@ -90,6 +91,7 @@ function toRecord(row: RecordRow): MemRecord {
     data: row.data,
     tags: row.tags ?? undefined,
     keys: row.keys ?? undefined,
+    identity_keys: row.identity_keys ?? undefined,
     sources: row.sources ?? {},
     searchable_text: row.searchable_text,
     embedded_at: row.embedded_at,
@@ -184,14 +186,14 @@ export class CoreBackend implements MemBackend {
     const embedding = vectorLiteral(row.embedding ?? null);
     const sql = this.caps.vectorSearch
       ? `INSERT INTO mem_records
-          (type, data, tags, keys, sources, searchable_text, content_hash, weight,
+          (type, data, tags, keys, identity_keys, sources, searchable_text, content_hash, weight,
            embedding, embedded_at, embedding_model)
-         VALUES ($1, $2::jsonb, $3::text[], $4::text[], $5::jsonb, $6, $7, $8,
-                 $9::vector, CASE WHEN $9 IS NOT NULL THEN NOW() ELSE NULL END, $10)
+         VALUES ($1, $2::jsonb, $3::text[], $4::text[], $5::text[], $6::jsonb, $7, $8, $9,
+                 $10::vector, CASE WHEN $10 IS NOT NULL THEN NOW() ELSE NULL END, $11)
          RETURNING *`
       : `INSERT INTO mem_records
-          (type, data, tags, keys, sources, searchable_text, content_hash, weight)
-         VALUES ($1, $2::jsonb, $3::text[], $4::text[], $5::jsonb, $6, $7, $8)
+          (type, data, tags, keys, identity_keys, sources, searchable_text, content_hash, weight)
+         VALUES ($1, $2::jsonb, $3::text[], $4::text[], $5::text[], $6::jsonb, $7, $8, $9)
          RETURNING *`;
     const params = this.caps.vectorSearch
       ? [
@@ -199,6 +201,7 @@ export class CoreBackend implements MemBackend {
           JSON.stringify(row.data),
           row.tags ?? null,
           row.keys ?? null,
+          row.identity_keys ?? null,
           JSON.stringify(row.sources ?? {}),
           row.searchable_text ?? null,
           row.content_hash ?? null,
@@ -211,6 +214,7 @@ export class CoreBackend implements MemBackend {
           JSON.stringify(row.data),
           row.tags ?? null,
           row.keys ?? null,
+          row.identity_keys ?? null,
           JSON.stringify(row.sources ?? {}),
           row.searchable_text ?? null,
           row.content_hash ?? null,
@@ -227,7 +231,7 @@ export class CoreBackend implements MemBackend {
     const res = await this.client.query<{ id: string; action: 'inserted' | 'updated' }>(
       `SELECT id, action FROM mem_upsert_by_keys(
           $1::text, $2::jsonb, $3::text[], $4::text[], $5::jsonb, $6::text, $7::text,
-          $8::integer, $9::text, $10::text, $11::boolean
+          $8::integer, $9::text, $10::text, $11::boolean, $12::text[]
        )`,
       [
         row.type,
@@ -241,6 +245,7 @@ export class CoreBackend implements MemBackend {
         embedding,
         embeddingModel,
         opts.replace ?? false,
+        row.identity_keys ?? null,
       ],
     );
     const { id, action } = res.rows[0];
@@ -597,6 +602,37 @@ export class CoreBackend implements MemBackend {
       [sourceKey],
     );
     return res.rows[0] ? toRecord(res.rows[0]) : null;
+  }
+
+  async findByKeys(
+    keys: string[],
+    opts: { type?: string; status?: 'active' | 'archived' | 'all'; limit?: number } = {},
+  ): Promise<MemRecord[]> {
+    if (!keys.length) return [];
+    // A match means the record carries ALL given keys across EITHER column —
+    // `keys[]` (entity/source keys) or `identity_keys[]` (participant
+    // associations, #128). One key → every record carrying it; many → the
+    // intersection. Params only — no string interpolation.
+    const params: unknown[] = [keys];
+    const where: string[] = [`(COALESCE(keys, '{}'::text[]) || COALESCE(identity_keys, '{}'::text[])) @> $1::text[]`];
+    const status = opts.status ?? 'active';
+    if (status !== 'all') {
+      params.push(status);
+      where.push(`status = $${params.length}`);
+    }
+    if (opts.type) {
+      params.push(opts.type);
+      where.push(`type = $${params.length}`);
+    }
+    params.push(Math.min(opts.limit ?? 2000, 5000));
+    const res = await this.client.query<RecordRow>(
+      `SELECT * FROM mem_records
+        WHERE ${where.join(' AND ')}
+        ORDER BY type ASC, updated_at DESC NULLS LAST
+        LIMIT $${params.length}`,
+      params,
+    );
+    return res.rows.map(toRecord);
   }
 
   async listSources(recordId: string): Promise<SourcesMap> {

--- a/src/lib/memory/plugins/postgres-core/backend.ts
+++ b/src/lib/memory/plugins/postgres-core/backend.ts
@@ -151,8 +151,34 @@ export class CoreBackend implements MemBackend {
     // mismatch (fresh DB, or an upgrade that bumped SCHEMA_VERSION) falls
     // through to the locked setup exactly once, then this check short-
     // circuits forever after.
+    //
+    // But the version stamp alone is not trustworthy enough to gate DDL on:
+    // it's a hand-maintained literal, so a PR that forgets to bump it — or
+    // two PRs that independently pick the same number, which is exactly what
+    // happened with 2.2.0 (see schema.ts) — makes every already-stamped store
+    // skip the new DDL forever and fail at query time instead. So the fast
+    // path also requires the schema to actually LOOK current, using the
+    // newest additive column as a sentinel — repoint the sentinel at the new
+    // column whenever another additive migration lands in TABLES_SQL. Still
+    // one query, not two: the version and the sentinel probe are fetched
+    // together, so the hot path costs no more than it did before.
+    //
+    // pg_attribute + to_regclass rather than information_schema.columns
+    // because it resolves through search_path exactly like the unqualified
+    // `mem_records` every other statement here uses, and it's a catalog
+    // lookup rather than a view over several joins.
     try {
-      if ((await this.getSchemaVersion()) === SCHEMA_VERSION) return;
+      const probe = await this.client.query<{ version: string | null; has_sentinel: boolean }>(
+        `SELECT (SELECT value FROM mem_meta WHERE key = 'version') AS version,
+                EXISTS (
+                  SELECT 1 FROM pg_attribute
+                   WHERE attrelid = to_regclass('mem_records')
+                     AND attname = 'identity_keys'
+                     AND NOT attisdropped
+                ) AS has_sentinel`,
+      );
+      const probed = probe.rows[0];
+      if (probed?.version === SCHEMA_VERSION && probed.has_sentinel) return;
     } catch {
       // mem_meta doesn't exist yet (fresh DB) — fall through to full setup.
     }
@@ -804,7 +830,26 @@ export class CoreBackend implements MemBackend {
     // associations, #128). One key → every record carrying it; many → the
     // intersection. Params only — no string interpolation.
     const params: unknown[] = [keys];
-    const where: string[] = [`(COALESCE(keys, '{}'::text[]) || COALESCE(identity_keys, '{}'::text[])) @> $1::text[]`];
+    const where: string[] = [
+      // Index-usable prefilter. The exact predicate below concatenates two
+      // columns, which is an expression neither GIN index can answer — on its
+      // own it plans as a Filter over a full scan, making
+      // idx_records_identity_keys pure write cost. Overlap (`&&`) on the bare
+      // columns IS index-usable and is a valid necessary condition here:
+      // containment of a NON-EMPTY $1 implies every element is present, so at
+      // least one element must overlap one of the two columns ($1 is guarded
+      // non-empty by the early return above). The planner ORs the two bitmap
+      // index scans, then the exact recheck drops rows that only partially
+      // match.
+      //
+      // The columns MUST stay bare. Wrapping either in COALESCE turns it back
+      // into an expression over a non-indexed value and the plan collapses to
+      // a full scan again (measured) — do not "tidy" this into COALESCE for
+      // symmetry with the line below. NULL && anything is NULL → not true,
+      // which is exactly right: a record with no keys can't contain any.
+      `(keys && $1::text[] OR identity_keys && $1::text[])`,
+      `(COALESCE(keys, '{}'::text[]) || COALESCE(identity_keys, '{}'::text[])) @> $1::text[]`,
+    ];
     const status = opts.status ?? 'active';
     if (status !== 'all') {
       params.push(status);

--- a/src/lib/memory/plugins/postgres/index.ts
+++ b/src/lib/memory/plugins/postgres/index.ts
@@ -152,6 +152,7 @@ class LazyPostgresBackend implements MemBackend {
   async addSource(...a: Parameters<MemBackend['addSource']>): ReturnType<MemBackend['addSource']> { return (await this.ensure()).addSource(...a); }
   async removeSource(...a: Parameters<MemBackend['removeSource']>): ReturnType<MemBackend['removeSource']> { return (await this.ensure()).removeSource(...a); }
   async findBySource(...a: Parameters<MemBackend['findBySource']>): ReturnType<MemBackend['findBySource']> { return (await this.ensure()).findBySource(...a); }
+  async findByKeys(...a: Parameters<MemBackend['findByKeys']>): ReturnType<MemBackend['findByKeys']> { return (await this.ensure()).findByKeys(...a); }
   async listSources(...a: Parameters<MemBackend['listSources']>): ReturnType<MemBackend['listSources']> { return (await this.ensure()).listSources(...a); }
 
   async getSyncState(...a: Parameters<MemBackend['getSyncState']>): ReturnType<MemBackend['getSyncState']> { return (await this.ensure()).getSyncState(...a); }

--- a/src/lib/memory/runtime.ts
+++ b/src/lib/memory/runtime.ts
@@ -109,6 +109,23 @@ export interface AddOptions {
    * memory; interactive callers leave it off so patches accumulate.
    */
   replace?: boolean;
+  /**
+   * Suppress the DERIVED `searchable_text` / `content_hash`, sending NULL so
+   * the store's `COALESCE(p_…, r.…)` keeps whatever is already there.
+   *
+   * For a caller that can only see part of a record. Sync's phase-1 list write
+   * is the case this exists for: it holds `{id, snippet}` while the stored row
+   * holds the enriched thread body, so deriving text from what it can see
+   * would overwrite the good FTS content with a thin summary. Without this
+   * flag there is no way to opt out — `prepareRecord` always derives.
+   *
+   * Only meaningful with `replace: false`; under replace the store takes the
+   * incoming value verbatim, NULL included. On a fresh INSERT there is nothing
+   * to preserve, so the row lands with NULL searchable_text until the
+   * authoritative writer fills it in (`mem admin reindex --searchable`
+   * backfills if that never happens).
+   */
+  preserveDerived?: boolean;
 }
 
 /**
@@ -179,10 +196,14 @@ export async function upsertRecord(input: RecordInput, opts: AddOptions = {}): P
   const backend = await getBackend();
   const { searchable_text, content_hash, embedding, embedding_model } = await prepareRecord(input, opts, 'sync');
 
+  // `preserveDerived` sends NULL for the two derived columns so the store's
+  // COALESCE keeps the richer value it already holds. The embedding is still
+  // computed and passed: it is derived from the text this caller CAN see, and
+  // an embedding is never worse than no embedding. See AddOptions.
   const prepared: RecordInput & { embedding?: number[] | null; embedding_model?: string | null } = {
     ...input,
-    searchable_text: input.searchable_text ?? searchable_text,
-    content_hash: input.content_hash ?? content_hash,
+    searchable_text: opts.preserveDerived ? undefined : (input.searchable_text ?? searchable_text),
+    content_hash: opts.preserveDerived ? undefined : (input.content_hash ?? content_hash),
     embedding,
     embedding_model,
   };

--- a/src/lib/memory/schema.ts
+++ b/src/lib/memory/schema.ts
@@ -12,7 +12,7 @@
  * See docs/plans/unified-memory.md §4 for design rationale.
  */
 
-export const SCHEMA_VERSION = '2.1.0';
+export const SCHEMA_VERSION = '2.2.0';
 
 // `pg_trgm` was in the original mem schema but nothing in the unified query
 // layer uses it; dropped to keep optional-extension backends happy. Can be
@@ -42,6 +42,14 @@ CREATE TABLE IF NOT EXISTS mem_records (
     data JSONB NOT NULL,
     tags TEXT[],
     keys TEXT[],
+    -- Cross-platform identity keys (#128): queryable associations like
+    -- email:jane@acme.com for every participant of a record. UNLIKE keys[],
+    -- these are NOT merge identifiers — they are exempt from the
+    -- key-uniqueness trigger and the upsert overlap-merge, so a Gmail thread
+    -- carrying many participant emails stays its own record instead of
+    -- collapsing into a contact (or into every other thread that shares a
+    -- participant). Queried by "mem find-by-key".
+    identity_keys TEXT[],
 
     sources JSONB NOT NULL DEFAULT '{}',
 
@@ -90,6 +98,12 @@ CREATE TABLE IF NOT EXISTS mem_meta (
     value TEXT NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- Additive migration for stores created before identity_keys existed (#128).
+-- Safe to re-run; existing rows get identity_keys populated lazily on their
+-- next sync. CREATE TABLE IF NOT EXISTS above won't add columns to a table
+-- that already exists, so the ALTER is required for upgrades.
+ALTER TABLE mem_records ADD COLUMN IF NOT EXISTS identity_keys TEXT[];
 `;
 
 /**
@@ -110,6 +124,7 @@ export const INDEXES_SQL = `
 CREATE INDEX IF NOT EXISTS idx_records_type         ON mem_records(type);
 CREATE INDEX IF NOT EXISTS idx_records_status       ON mem_records(status);
 CREATE INDEX IF NOT EXISTS idx_records_keys         ON mem_records USING GIN(keys);
+CREATE INDEX IF NOT EXISTS idx_records_identity_keys ON mem_records USING GIN(identity_keys);
 CREATE INDEX IF NOT EXISTS idx_records_tags         ON mem_records USING GIN(tags);
 CREATE INDEX IF NOT EXISTS idx_records_data         ON mem_records USING GIN(data jsonb_path_ops);
 CREATE INDEX IF NOT EXISTS idx_records_sources      ON mem_records USING GIN(sources jsonb_path_ops);
@@ -250,7 +265,8 @@ CREATE OR REPLACE FUNCTION mem_upsert_by_keys(
     p_weight INTEGER DEFAULT NULL,
     p_embedding TEXT DEFAULT NULL,
     p_embedding_model TEXT DEFAULT NULL,
-    p_replace BOOLEAN DEFAULT FALSE
+    p_replace BOOLEAN DEFAULT FALSE,
+    p_identity_keys TEXT[] DEFAULT NULL
 ) RETURNS TABLE (id UUID, action TEXT) LANGUAGE plpgsql AS $$
 DECLARE
     existing_id UUID;
@@ -284,6 +300,12 @@ BEGIN
                 ELSE (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.tags, '{}') || COALESCE(p_tags, '{}'))))
             END,
             keys = (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.keys, '{}') || COALESCE(p_keys, '{}')))),
+            -- identity_keys: replace on a replace-sync, otherwise union (never
+            -- drop an association). NOT part of the overlap-merge above.
+            identity_keys = CASE
+                WHEN p_replace THEN COALESCE(p_identity_keys, '{}'::text[])
+                ELSE (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.identity_keys, '{}') || COALESCE(p_identity_keys, '{}'))))
+            END,
             sources = r.sources || COALESCE(p_sources, '{}'::jsonb),
             searchable_text = CASE
                 WHEN p_replace THEN p_searchable_text
@@ -302,12 +324,13 @@ BEGIN
         result_action := 'updated';
     ELSE
         INSERT INTO mem_records (
-            type, data, tags, keys, sources, searchable_text, content_hash, weight
+            type, data, tags, keys, identity_keys, sources, searchable_text, content_hash, weight
         ) VALUES (
             p_type,
             p_data,
             p_tags,
             p_keys,
+            p_identity_keys,
             COALESCE(p_sources, '{}'::jsonb),
             p_searchable_text,
             p_content_hash,
@@ -342,7 +365,8 @@ CREATE OR REPLACE FUNCTION mem_upsert_by_keys(
     p_weight INTEGER DEFAULT NULL,
     p_embedding TEXT DEFAULT NULL,
     p_embedding_model TEXT DEFAULT NULL,
-    p_replace BOOLEAN DEFAULT FALSE
+    p_replace BOOLEAN DEFAULT FALSE,
+    p_identity_keys TEXT[] DEFAULT NULL
 ) RETURNS TABLE (id UUID, action TEXT) LANGUAGE plpgsql AS $$
 DECLARE
     existing_id UUID;
@@ -371,6 +395,12 @@ BEGIN
                 ELSE (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.tags, '{}') || COALESCE(p_tags, '{}'))))
             END,
             keys = (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.keys, '{}') || COALESCE(p_keys, '{}')))),
+            -- identity_keys: replace on replace-sync, else union. Not part of
+            -- the overlap-merge (see no-vector variant).
+            identity_keys = CASE
+                WHEN p_replace THEN COALESCE(p_identity_keys, '{}'::text[])
+                ELSE (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.identity_keys, '{}') || COALESCE(p_identity_keys, '{}'))))
+            END,
             sources = r.sources || COALESCE(p_sources, '{}'::jsonb),
             searchable_text = CASE
                 WHEN p_replace THEN p_searchable_text
@@ -392,13 +422,14 @@ BEGIN
         result_action := 'updated';
     ELSE
         INSERT INTO mem_records (
-            type, data, tags, keys, sources, searchable_text, content_hash,
+            type, data, tags, keys, identity_keys, sources, searchable_text, content_hash,
             weight, embedding, embedded_at, embedding_model
         ) VALUES (
             p_type,
             p_data,
             p_tags,
             p_keys,
+            p_identity_keys,
             COALESCE(p_sources, '{}'::jsonb),
             p_searchable_text,
             p_content_hash,

--- a/src/lib/memory/schema.ts
+++ b/src/lib/memory/schema.ts
@@ -17,7 +17,13 @@
 // identity_keys. Both sides wrote the same literal, so the merge produced no
 // conflict — and `ensureSchema`'s version fast-path below would then skip the
 // identity_keys DDL entirely on any store already stamped 2.2.0 by v1.49/1.50.
-export const SCHEMA_VERSION = '2.3.0';
+//
+// 2.3.1: `mem_upsert_by_keys`'s BODY changed (NULL p_identity_keys now keeps
+// the stored value instead of clearing it). ensureSchema's sentinel probe only
+// checks that the identity_keys COLUMN exists, which a stale function body
+// passes — so the version is the only thing that re-runs FUNCTIONS_SQL. Bump
+// this on any function-body change, not just on column changes.
+export const SCHEMA_VERSION = '2.3.1';
 
 // `pg_trgm` was in the original mem schema but nothing in the unified query
 // layer uses it; dropped to keep optional-extension backends happy. Can be
@@ -160,6 +166,25 @@ END $$;
 `;
 
 export const FUNCTIONS_SQL = `
+-- Drop the pre-#128 11-argument mem_upsert_by_keys (no p_identity_keys).
+--
+-- CREATE OR REPLACE cannot change a function's argument list — adding
+-- \`p_identity_keys TEXT[] DEFAULT NULL\` defines a SECOND function rather
+-- than replacing the old one. An upgraded store would then hold both
+-- overloads in pg_proc, and because the 12-arg version's trailing param is
+-- defaultable, an 11-arg call matches BOTH and fails with 42725
+-- "function mem_upsert_by_keys(...) is not unique". Verified on PGlite.
+--
+-- The explicit argument list makes this unambiguous (no 42725 on the DROP
+-- itself) and leaves the 12-arg version untouched, so re-running the block
+-- is a no-op. Only needed here, not in VECTOR_FUNCTIONS_SQL: the vector
+-- variant is a same-signature CREATE OR REPLACE that always runs AFTER this
+-- block (ensureSchema and getFullSchemaSQL both order core functions before
+-- vector functions), so by the time it runs the stale 11-arg entry — whether
+-- it was last written by the core or the vector block — is already gone.
+DROP FUNCTION IF EXISTS mem_upsert_by_keys(
+  TEXT, JSONB, TEXT[], TEXT[], JSONB, TEXT, TEXT, INTEGER, TEXT, TEXT, BOOLEAN);
+
 -- Enforce uniqueness of the "keys" array across ACTIVE records only.
 --
 -- Scoping to active is deliberate: an archived record must not squat on a
@@ -320,8 +345,19 @@ BEGIN
             keys = (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.keys, '{}') || COALESCE(p_keys, '{}')))),
             -- identity_keys: replace on a replace-sync, otherwise union (never
             -- drop an association). NOT part of the overlap-merge above.
+            -- Three states, and NULL is NOT the same as '{}' here:
+            --   NULL  → caller has no opinion (profile declares no
+            --           identityKeys, or the record is still the pre-enrich
+            --           shape whose participant fields haven't been fetched
+            --           yet) → KEEP what's stored. Clearing on NULL made
+            --           every sync after the first wipe the column, because
+            --           the unconditional list-phase write resolves nothing
+            --           and enrich only revisits _enriched_at IS NULL rows.
+            --   '{}'  → caller authoritatively resolved zero participants
+            --           → clear, so a removed attendee really disappears.
+            --   {a,b} → replace with exactly these.
             identity_keys = CASE
-                WHEN p_replace THEN COALESCE(p_identity_keys, '{}'::text[])
+                WHEN p_replace THEN COALESCE(p_identity_keys, r.identity_keys)
                 ELSE (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.identity_keys, '{}') || COALESCE(p_identity_keys, '{}'))))
             END,
             sources = r.sources || COALESCE(p_sources, '{}'::jsonb),
@@ -370,6 +406,10 @@ $$;
  * signature, embedding-aware body. p_embedding is TEXT in both
  * variants (callers send '[0.1,0.2,...]' literals); the cast to
  * vector happens inside this body via `::vector`.
+ *
+ * If you ever change this signature, change FUNCTIONS_SQL's signature and
+ * its DROP FUNCTION line in the same commit — the two must stay identical or
+ * Postgres ends up with two overloads and every call becomes ambiguous.
  */
 export const VECTOR_FUNCTIONS_SQL = `
 CREATE OR REPLACE FUNCTION mem_upsert_by_keys(
@@ -414,9 +454,10 @@ BEGIN
             END,
             keys = (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.keys, '{}') || COALESCE(p_keys, '{}')))),
             -- identity_keys: replace on replace-sync, else union. Not part of
-            -- the overlap-merge (see no-vector variant).
+            -- the overlap-merge. NULL keeps, '{}' clears, non-empty replaces —
+            -- see the no-vector variant for why NULL must not clear.
             identity_keys = CASE
-                WHEN p_replace THEN COALESCE(p_identity_keys, '{}'::text[])
+                WHEN p_replace THEN COALESCE(p_identity_keys, r.identity_keys)
                 ELSE (SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(COALESCE(r.identity_keys, '{}') || COALESCE(p_identity_keys, '{}'))))
             END,
             sources = r.sources || COALESCE(p_sources, '{}'::jsonb),

--- a/src/lib/memory/sync/enrich-preserve.test.ts
+++ b/src/lib/memory/sync/enrich-preserve.test.ts
@@ -1,0 +1,550 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { writePageToMemory } from './mem-writer.js';
+import { findEnrichedIds } from './enrich.js';
+import { syncModel } from './runner.js';
+import { openDatabase } from './db.js';
+import { loadSqlite } from './sqlite-loader.js';
+import type { SyncProfile } from './types.js';
+import { updateMemoryConfig, DEFAULT_MEMORY_CONFIG } from '../config.js';
+import { writeConfig } from '../../config.js';
+import { getBackend, resetBackendSingleton } from '../runtime.js';
+import { registerBackend } from '../plugins.js';
+import { pglitePlugin } from '../plugins/pglite/index.js';
+
+/**
+ * A PRE-ENRICH WRITE MAY CREATE AND REFRESH, BUT IT MUST NEVER DEGRADE.
+ *
+ * Sync has two phases for a profile that declares `enrich`. Phase 1 writes
+ * every list-shape record from the API page into memory with `replace: true`;
+ * phase 2 fetches the detail endpoint for rows `WHERE "_enriched_at" IS NULL`,
+ * writes the MERGED record, and stamps the timestamp. Left unguarded those two
+ * facts destroy data on the SECOND run: phase 1 replaces `data` with the thin
+ * list shape (`{id, snippet, historyId}`) and phase 2 no longer revisits the
+ * row, so the thread bodies / transcripts are gone and never come back.
+ *
+ * These tests pin the guard at all three levels — the SQL lookup that answers
+ * "already enriched?", the writer contract that acts on it, and a real
+ * two-run `syncModel` sequence that proves the whole thing composes.
+ */
+
+let sqliteAvailable = true;
+try {
+  await loadSqlite();
+} catch {
+  sqliteAvailable = false;
+}
+
+let tmpHome: string;
+let originalCwd: string;
+let workDir: string;
+
+before(async () => {
+  originalCwd = process.cwd();
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'enrich-preserve-test-'));
+  process.env.HOME = tmpHome;
+  // Silences the runner's progress/warning writes to stderr.
+  process.env.ONE_AGENT = '1';
+  fs.mkdirSync(path.join(tmpHome, '.one'), { mode: 0o700 });
+  writeConfig({
+    apiKey: 'sk_test_dummy',
+    installedAgents: [],
+    createdAt: new Date().toISOString(),
+  });
+  registerBackend(pglitePlugin);
+  updateMemoryConfig({
+    ...DEFAULT_MEMORY_CONFIG,
+    backend: 'pglite',
+    pglite: { dbPath: path.join(tmpHome, 'mem.pglite') },
+  });
+  resetBackendSingleton();
+  await getBackend();
+
+  // The runner resolves `.one/sync/{data,state,locks}` relative to CWD, so
+  // run the whole file from a scratch dir. node's test runner gives each test
+  // FILE its own process, so this chdir can't leak into another suite.
+  workDir = path.join(tmpHome, 'work');
+  fs.mkdirSync(workDir, { recursive: true });
+  process.chdir(workDir);
+});
+
+after(async () => {
+  process.chdir(originalCwd);
+  const backend = await getBackend();
+  await backend.close();
+  resetBackendSingleton();
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. The writer contract
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('writePageToMemory — alreadyEnrichedIds must not degrade the stored record', () => {
+  const profile: SyncProfile = {
+    platform: 'gmailpv',
+    model: 'threads',
+    connectionKey: 'live::gmailpv::default::abc',
+    actionId: 'conn_mod_def::list',
+    resultsPath: 'threads',
+    idField: 'id',
+    pagination: { type: 'none' },
+    enrich: { actionId: 'conn_mod_def::detail' },
+    memory: { searchable: ['messages[].snippet'] },
+  };
+
+  /** The fat shape phase 2 writes back (list fields + detail fields + stamp). */
+  const enrichedRecord = (id: string) => ({
+    id,
+    snippet: `thin ${id}`,
+    historyId: '111',
+    messages: [{ id: `${id}-m1`, snippet: `FULL BODY of ${id}` }],
+    _enriched_at: '2026-07-01T00:00:00.000Z',
+  });
+  /** The thin shape `threads.list` returns on every subsequent run. */
+  const listRecord = (id: string) => ({ id, snippet: `thin ${id}`, historyId: '222' });
+
+  it('keeps data AND searchable_text when the id is already enriched', async () => {
+    const backend = await getBackend();
+    await writePageToMemory(profile, [enrichedRecord('P1')]);
+    const afterEnrich = await backend.findBySource('gmailpv/threads:P1');
+    assert.equal((afterEnrich!.data as any).messages[0].snippet, 'FULL BODY of P1');
+    assert.equal(afterEnrich!.searchable_text, 'FULL BODY of P1');
+
+    // Run 2, phase 1. Pre-fix this replaced `data` with the list shape and
+    // blanked searchable_text (the profile's paths resolve to nothing on the
+    // thin shape), and phase 2 never revisits a stamped row to repair it.
+    const report = await writePageToMemory(profile, [listRecord('P1')], {
+      alreadyEnrichedIds: new Set(['P1']),
+    });
+
+    const after = await backend.findBySource('gmailpv/threads:P1');
+    assert.equal(
+      (after!.data as any).messages?.[0]?.snippet, 'FULL BODY of P1',
+      'the enriched payload must survive the pre-enrich write',
+    );
+    assert.equal(
+      after!.searchable_text, 'FULL BODY of P1',
+      'searchable_text is the half `replace: false` alone would NOT have saved — COALESCE ' +
+      'only skips NULL, and upsertRecord derives a text from the thin data unless ' +
+      '`preserveDerived` suppresses it',
+    );
+    assert.equal(report.preserved, 1);
+    assert.equal(report.attempted, 1);
+    // The write DOES happen — it is merely non-authoritative. Skipping it
+    // instead would strand any record whose memory row had been lost or
+    // archived, because phase 2 will not revisit a stamped row either.
+    assert.equal(report.updated, 1, 'the row is still upserted, just non-authoritatively');
+  });
+
+  it('RE-CREATES the record when the memory row is gone but the mirror says enriched', async () => {
+    // The mirror is cwd-relative while the store lives under $HOME, so they
+    // drift apart for ordinary reasons (backend switch, corruption recovery).
+    // A skip-based guard would leave this record unreachable forever: phase 1
+    // declines to write, phase 2 declines to revisit.
+    const backend = await getBackend();
+    // Never seeded into memory — but the mirror insists it is enriched.
+    assert.equal(await backend.findBySource('gmailpv/threads:P9'), null, 'no row to begin with');
+
+    await writePageToMemory(profile, [listRecord('P9')], { alreadyEnrichedIds: new Set(['P9']) });
+
+    const revived = await backend.findBySource('gmailpv/threads:P9');
+    assert.ok(revived, 'the record must come back rather than be stranded');
+    assert.equal((revived!.data as any).id, 'P9');
+  });
+
+  it('UN-ARCHIVES an already-enriched row (the upsert self-heal must still run)', async () => {
+    // schema.ts calls the unarchive-on-upsert the self-heal primitive for a
+    // buggy --full-refresh reconcile. Skipping the write bypasses it and the
+    // row stays dead permanently.
+    const backend = await getBackend();
+    await writePageToMemory(profile, [enrichedRecord('P8')]);
+    const rec = await backend.findBySource('gmailpv/threads:P8');
+    await backend.archive(rec!.id, 'reconcile');
+    assert.equal((await backend.getById(rec!.id))!.status, 'archived');
+
+    await writePageToMemory(profile, [listRecord('P8')], { alreadyEnrichedIds: new Set(['P8']) });
+
+    assert.equal((await backend.getById(rec!.id))!.status, 'active', 'upsert must resurrect it');
+    assert.equal(
+      ((await backend.getById(rec!.id))!.data as any).messages?.[0]?.snippet, 'FULL BODY of P8',
+      'and resurrecting it must not have thinned it',
+    );
+  });
+
+  it('a preserved record is NOT counted as skipped (broken-idField warning)', async () => {
+    // `skipped` means "the writer REJECTED this row" and drives the runner's
+    // "most rows were rejected — likely a broken idField" warning. A healthy
+    // enrich profile preserves 100% of its page on every run after the first,
+    // so folding these into `skipped` would fire that warning forever.
+    await writePageToMemory(profile, [enrichedRecord('P2')]);
+    const report = await writePageToMemory(profile, [listRecord('P2')], {
+      alreadyEnrichedIds: new Set(['P2']),
+    });
+    assert.equal(report.skipped, 0);
+    assert.equal(report.preserved, 1);
+  });
+
+  it('a preserved record still reports its source key as SEEN', async () => {
+    // `--full-refresh` archives every row whose source key didn't come back
+    // this run (runner.ts reconcile). If the skip path dropped the key, a
+    // full refresh would mass-archive exactly the enriched records the guard
+    // exists to protect. See the end-to-end suite for the live proof.
+    await writePageToMemory(profile, [enrichedRecord('P3')]);
+    const report = await writePageToMemory(profile, [listRecord('P3')], {
+      alreadyEnrichedIds: new Set(['P3']),
+    });
+    assert.deepEqual(report.sourceKeysSeen, ['gmailpv/threads:P3']);
+  });
+
+  it('a record NOT in the set is written exactly as before (must not over-skip)', async () => {
+    const backend = await getBackend();
+    // P4 has never been enriched, so phase 1 is the ONLY thing that will make
+    // it exist and be searchable before phase 2 picks it up.
+    const report = await writePageToMemory(profile, [listRecord('P4')], {
+      alreadyEnrichedIds: new Set(['P1', 'P2', 'P3']),
+    });
+    assert.equal(report.preserved, 0);
+    assert.equal(report.inserted, 1);
+    const rec = await backend.findBySource('gmailpv/threads:P4');
+    assert.equal((rec!.data as any).snippet, 'thin P4');
+  });
+
+  it('no alreadyEnrichedIds → the historical replace behaviour is untouched', async () => {
+    // The fallback every failure mode of findEnrichedIds degrades to, and the
+    // behaviour every non-enrich profile keeps.
+    const backend = await getBackend();
+    await writePageToMemory(profile, [enrichedRecord('P5')]);
+    await writePageToMemory(profile, [listRecord('P5')]);
+    const rec = await backend.findBySource('gmailpv/threads:P5');
+    assert.equal(
+      (rec!.data as any).messages, undefined,
+      'without the signal the writer still replaces — the guard is opt-in, not implicit',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. The SQL lookup that produces the signal
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('findEnrichedIds — the mirror of enrich\'s `WHERE ts IS NULL` query', () => {
+  const enrich = { actionId: 'conn_mod_def::detail' };
+
+  async function makeTable(model: string, cols: string, rows: Array<[string, string | null]>) {
+    const db = await openDatabase('findenriched');
+    db.exec(`DROP TABLE IF EXISTS "${model}"`);
+    db.exec(`CREATE TABLE "${model}" (${cols})`);
+    const stmt = db.prepare(`INSERT INTO "${model}" (id, "_enriched_at") VALUES (?, ?)`);
+    for (const [id, ts] of rows) stmt.run(id, ts);
+    return db;
+  }
+
+  it('returns only the ids whose timestamp is stamped', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const db = await makeTable('t_basic', 'id TEXT, "_enriched_at" TEXT', [
+      ['A', '2026-07-01T00:00:00.000Z'],
+      ['B', null],
+      ['C', '2026-07-01T00:00:00.000Z'],
+    ]);
+    const got = findEnrichedIds(db, 't_basic', 'id', enrich, [{ id: 'A' }, { id: 'B' }, { id: 'C' }, { id: 'D' }], true);
+    assert.deepEqual([...got].sort(), ['A', 'C']);
+    db.close();
+  });
+
+  it('honours a profile\'s custom timestampField', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const db = await openDatabase('findenriched');
+    db.exec(`DROP TABLE IF EXISTS t_custom`);
+    db.exec(`CREATE TABLE t_custom (id TEXT, "_detail_at" TEXT, "_enriched_at" TEXT)`);
+    db.prepare(`INSERT INTO t_custom (id, "_detail_at", "_enriched_at") VALUES (?, ?, ?)`).run('A', '2026-07-01', null);
+    const got = findEnrichedIds(
+      db, 't_custom', 'id',
+      { actionId: 'x', timestampField: '_detail_at' },
+      [{ id: 'A' }], true,
+    );
+    assert.deepEqual([...got], ['A'], 'must read the profile\'s field, not hardcode _enriched_at');
+    db.close();
+  });
+
+  it('stringifies ids so INTEGER columns still match', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const db = await openDatabase('findenriched');
+    db.exec(`DROP TABLE IF EXISTS t_int`);
+    db.exec(`CREATE TABLE t_int (id INTEGER, "_enriched_at" TEXT)`);
+    db.prepare(`INSERT INTO t_int (id, "_enriched_at") VALUES (?, ?)`).run(7, '2026-07-01');
+    const got = findEnrichedIds(db, 't_int', 'id', enrich, [{ id: 7 }], true);
+    assert.deepEqual([...got], ['7'], 'writer compares String(externalId)');
+    db.close();
+  });
+
+  // ── every failure mode degrades to "write everything" (current behaviour) ──
+
+  it('empty when the table has not been created yet (first page of run 1)', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const db = await makeTable('t_new', 'id TEXT, "_enriched_at" TEXT', []);
+    assert.equal(findEnrichedIds(db, 't_new', 'id', enrich, [{ id: 'A' }], false).size, 0);
+    db.close();
+  });
+
+  it('empty when the timestamp column does not exist yet', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    // Phase 2 ALTERs the column in on demand, so its absence is the normal
+    // never-enriched state — not an error, and definitely not a reason to skip.
+    const db = await openDatabase('findenriched');
+    db.exec(`DROP TABLE IF EXISTS t_nots`);
+    db.exec(`CREATE TABLE t_nots (id TEXT, snippet TEXT)`);
+    db.prepare(`INSERT INTO t_nots (id, snippet) VALUES (?, ?)`).run('A', 'x');
+    assert.equal(findEnrichedIds(db, 't_nots', 'id', enrich, [{ id: 'A' }], true).size, 0);
+    db.close();
+  });
+
+  it('empty for a dotted idField (the flat SQLite mirror cannot answer)', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const db = await makeTable('t_dotted', 'id TEXT, "_enriched_at" TEXT', [['A', '2026-07-01']]);
+    const got = findEnrichedIds(db, 't_dotted', 'id.record_id', enrich, [{ id: { record_id: 'A' } }], true);
+    assert.equal(got.size, 0, 'cannot answer → must not guess → write everything');
+    db.close();
+  });
+
+  it('empty (never throws) when the table is missing entirely', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const db = await openDatabase('findenriched');
+    db.exec(`DROP TABLE IF EXISTS t_gone`);
+    assert.doesNotThrow(() => findEnrichedIds(db, 't_gone', 'id', enrich, [{ id: 'A' }], true));
+    assert.equal(findEnrichedIds(db, 't_gone', 'id', enrich, [{ id: 'A' }], true).size, 0);
+    db.close();
+  });
+
+  it('empty for an empty page', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const db = await makeTable('t_empty', 'id TEXT, "_enriched_at" TEXT', [['A', '2026-07-01']]);
+    assert.equal(findEnrichedIds(db, 't_empty', 'id', enrich, [], true).size, 0);
+    db.close();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. The whole thing, through the real runner
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('syncModel — a second run must not thin out the enriched memory record', () => {
+  const LIST = 'conn_mod_def::list::e2e';
+  const DETAIL = 'conn_mod_def::get::e2e';
+
+  const actionDetails = (id: string, p: string) => ({
+    _id: id, title: id, path: p, method: 'GET',
+    tags: ['passthrough'], knowledge: '', connectionPlatform: 'gmaile2e',
+  });
+
+  function makeApi(state: { listIds: string[]; detailCalls: string[] }): any {
+    return {
+      async getActionDetailsWithMeta(actionId: string) {
+        return {
+          data: actionId === LIST ? actionDetails(LIST, '/threads') : actionDetails(DETAIL, '/threads/{{id}}'),
+          etag: undefined,
+          status: 200,
+        };
+      },
+      async executePassthroughRequest(req: any) {
+        if (req.actionId === LIST) {
+          // What `threads.list` actually returns: no bodies, no participants.
+          return {
+            responseData: {
+              threads: state.listIds.map(id => ({ id, snippet: `thin ${id}`, historyId: '111' })),
+            },
+          };
+        }
+        const id = req.pathVariables?.id as string;
+        state.detailCalls.push(id);
+        return {
+          responseData: {
+            id,
+            historyId: '999',
+            messages: [{
+              id: `${id}-m1`,
+              snippet: `FULL BODY of ${id}`,
+              payload: { headers: [{ name: 'From', value: `Sender <s-${id}@acme.com>` }] },
+            }],
+          },
+        };
+      },
+    };
+  }
+
+  const profile: SyncProfile = {
+    platform: 'gmaile2e',
+    model: 'threads',
+    connectionKey: 'live::gmaile2e::default::abc',
+    actionId: LIST,
+    resultsPath: 'threads',
+    idField: 'id',
+    pagination: { type: 'none' },
+    identityKeys: [{ prefix: 'email', path: 'messages[].payload.headers[name=From].value' }],
+    memory: { searchable: ['messages[].snippet'] },
+    enrich: { actionId: DETAIL, pathVars: { id: '{id}' }, concurrency: 2, delayMs: 0 },
+  };
+
+  async function stored(id: string) {
+    const backend = await getBackend();
+    return backend.findBySource(`gmaile2e/threads:${id}`);
+  }
+
+  it('run 1 enriches, run 2 preserves, and a new record still gets picked up', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const state = { listIds: ['T1', 'T2'], detailCalls: [] as string[] };
+    const api = makeApi(state);
+
+    // ── run 1: list write + enrich ──
+    const r1 = await syncModel(api, profile, { toMemory: true });
+    assert.equal(r1.enriched, 2);
+    const t1 = await stored('T1');
+    assert.equal((t1!.data as any).messages[0].snippet, 'FULL BODY of T1');
+    assert.equal(t1!.searchable_text, 'FULL BODY of T1');
+    assert.deepEqual(t1!.identity_keys, ['email:s-t1@acme.com']);
+
+    // ── run 2: same page comes back; phase 2 will NOT revisit (ts stamped) ──
+    state.detailCalls = [];
+    const r2 = await syncModel(api, profile, { toMemory: true, force: true });
+    assert.equal(r2.enriched, 0, 'enrich only visits ts IS NULL — it cannot repair a thinned row');
+    assert.deepEqual(state.detailCalls, [], 'and it makes no detail calls to do so');
+
+    const after = await stored('T1');
+    assert.equal(
+      (after!.data as any).messages?.[0]?.snippet, 'FULL BODY of T1',
+      'run 2 must not replace the enriched payload with the list shape',
+    );
+    assert.equal(after!.searchable_text, 'FULL BODY of T1');
+    // A field present in BOTH shapes takes the LIST value: it is the fresher
+    // of the two (the enriched copy is frozen at run 1). Merging is what keeps
+    // list fields live; only enrich-ONLY fields are protected from the thin write.
+    assert.equal((after!.data as any).historyId, '111', 'list fields still refresh');
+
+    // ── run 3: a brand new thread joins. It has never been enriched, so it
+    // must be written by phase 1 AND enriched by phase 2 — the guard must not
+    // freeze the collection. ──
+    state.listIds = ['T1', 'T2', 'T3'];
+    state.detailCalls = [];
+    const r3 = await syncModel(api, profile, { toMemory: true, force: true });
+    assert.equal(r3.enriched, 1);
+    assert.deepEqual(state.detailCalls, ['T3'], 'only the new record costs a detail call');
+    assert.equal(((await stored('T3'))!.data as any).messages[0].snippet, 'FULL BODY of T3');
+    // …and the old ones are still fat.
+    assert.equal(((await stored('T2'))!.data as any).messages[0].snippet, 'FULL BODY of T2');
+  });
+
+  it('--full-refresh does not archive the records phase 1 preserved', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    // Reconcile-by-absence archives every row whose source key didn't come
+    // back this run. A skipped write that forgot to report its key as SEEN
+    // would therefore archive the entire already-enriched collection — a
+    // strictly worse bug than the one being fixed.
+    //
+    // The page MUST be mixed (T9 is brand new, T1-T3 are preserved). With an
+    // all-preserved page the reconcile bails early on `seenSourceKeys.size
+    // === 0` and the test passes even when the skip path drops its keys — a
+    // mutation of exactly that line proved this test vacuous until T9 was
+    // added.
+    const state = { listIds: ['T1', 'T2', 'T3', 'T9'], detailCalls: [] as string[] };
+    const backend = await getBackend();
+
+    await syncModel(makeApi(state), profile, { toMemory: true, fullRefresh: true });
+
+    assert.equal(await backend.count('gmaile2e/threads', { status: 'archived' }), 0);
+    assert.equal(await backend.count('gmaile2e/threads', { status: 'active' }), 4);
+    assert.equal(
+      ((await stored('T1'))!.data as any).messages?.[0]?.snippet, 'FULL BODY of T1',
+      'and the payload is still there afterwards',
+    );
+  });
+
+  it('--no-memory: phase 1 writes nothing, and the enriched rows are untouched', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    const backend = await getBackend();
+    const before = await backend.count('gmaile2e/threads', { status: 'active' });
+    // Everything in this page is already enriched, so phase 2 has no work and
+    // the ONLY thing that could touch memory is phase 1 — which `--no-memory`
+    // switches off before the guard is ever consulted.
+    const state = { listIds: ['T1', 'T2', 'T3'], detailCalls: [] as string[] };
+    await syncModel(makeApi(state), profile, { toMemory: false, force: true });
+    assert.equal(await backend.count('gmaile2e/threads', { status: 'active' }), before);
+    assert.equal(((await stored('T1'))!.data as any).messages?.[0]?.snippet, 'FULL BODY of T1');
+  });
+
+  it('a row that is IN sqlite but still unenriched keeps getting refreshed', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    // The other half of the rule: a pre-enrich write may CREATE AND REFRESH.
+    // Over-skipping is the mirror-image data loss — a row that phase 2 never
+    // manages to enrich (detail endpoint 404s, run killed mid-enrichment, a
+    // transform that drops it) would be frozen out of memory forever, holding
+    // whatever the first run happened to store. Only `_enriched_at IS NOT
+    // NULL` may suppress the write; merely existing in the mirror may not.
+    //
+    // S2 is kept permanently unenriched by a transform that drops it once it
+    // has detail fields — enrich.ts then leaves the row's timestamp NULL.
+    // (Phase 1's records have no `messages`, so phase 1 passes through.)
+    const dropS2AtEnrich =
+      `node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{` +
+      `const r=JSON.parse(s);` +
+      `process.stdout.write(JSON.stringify(r.filter(x=>!(x.messages&&x.id==="S2"))))})'`;
+
+    const halfProfile: SyncProfile = {
+      ...profile, platform: 'gmailhalf',
+      connectionKey: 'live::gmailhalf::default::abc',
+      transform: dropS2AtEnrich,
+    };
+    const halfApi = (snippet: string): any => ({
+      async getActionDetailsWithMeta(actionId: string) {
+        return {
+          data: actionId === LIST ? actionDetails(LIST, '/threads') : actionDetails(DETAIL, '/t/{{id}}'),
+          etag: undefined, status: 200,
+        };
+      },
+      async executePassthroughRequest(req: any) {
+        if (req.actionId === LIST) {
+          return { responseData: { threads: ['S1', 'S2'].map(id => ({ id, snippet: `${snippet} ${id}` })) } };
+        }
+        const id = req.pathVariables?.id as string;
+        return { responseData: { id, messages: [{ id: `${id}-m1`, snippet: `FULL BODY of ${id}` }] } };
+      },
+    });
+    const backend = await getBackend();
+    const half = (id: string) => backend.findBySource(`gmailhalf/threads:${id}`);
+
+    await syncModel(halfApi('v1'), halfProfile, { toMemory: true });
+    assert.equal(((await half('S1'))!.data as any).messages[0].snippet, 'FULL BODY of S1');
+    assert.equal(((await half('S2'))!.data as any).messages, undefined, 'S2 never got enriched');
+    assert.equal(((await half('S2'))!.data as any).snippet, 'v1 S2');
+
+    // Run 2: the upstream snippet moved. S2 is in the mirror but unenriched,
+    // so phase 1 owns it and must write the new value through.
+    await syncModel(halfApi('v2'), halfProfile, { toMemory: true, force: true });
+    assert.equal(
+      ((await half('S2'))!.data as any).snippet, 'v2 S2',
+      'an unenriched row must still be refreshed by phase 1',
+    );
+    assert.equal(
+      ((await half('S1'))!.data as any).messages[0].snippet, 'FULL BODY of S1',
+      'while its enriched neighbour on the same page is left alone',
+    );
+  });
+
+  it('PRE-EXISTING GAP: --no-memory does not stop phase 2 mirroring into memory', async (t) => {
+    if (!sqliteAvailable) return t.skip('better-sqlite3 unavailable');
+    // Documenting, not endorsing. The runner passes `profile` into the enrich
+    // context unconditionally, and enrich.ts mirrors every merged batch into
+    // memory whenever that profile is present — it never consults
+    // `options.toMemory`. So a NEW record still lands in memory under
+    // `--no-memory`. Untouched by this change (the guard only ever REMOVES
+    // writes), and left alone on purpose so the fix stays scoped; pinned here
+    // so it can't regress silently in either direction.
+    const state = { listIds: ['T1', 'T2', 'T3', 'T4'], detailCalls: [] as string[] };
+    await syncModel(makeApi(state), profile, { toMemory: false, force: true });
+    const t4 = await stored('T4');
+    assert.ok(t4, 'phase 2 wrote it despite --no-memory');
+    assert.equal((t4!.data as any).messages[0].snippet, 'FULL BODY of T4');
+  });
+});

--- a/src/lib/memory/sync/enrich.ts
+++ b/src/lib/memory/sync/enrich.ts
@@ -149,6 +149,83 @@ export interface EnrichResult {
 }
 
 /**
+ * Which of these records has phase 2 ALREADY enriched?
+ *
+ * The exact mirror of the `WHERE "<tsField>" IS NULL` query `enrichPhase`
+ * runs below, and it lives here so the two halves of the `_enriched_at`
+ * contract stay in one file.
+ *
+ * It exists because phase 1's memory write is unconditional — it runs for
+ * every record on every page of every run — while phase 2 never revisits a
+ * row whose timestamp is already stamped. So on run 2 the thin list shape
+ * (`{id, snippet, historyId}` for gmail) would REPLACE the enriched payload
+ * in memory (mem-writer sends `replace: true`), and nothing would ever put
+ * the thread bodies back. Phase 1 asks this question first and then leaves
+ * those records alone; see the call site in runner.ts for the rule.
+ *
+ * Returns STRINGIFIED ids so the caller can compare against whatever its
+ * idField resolved to without caring about SQLite's INTEGER/TEXT affinity.
+ *
+ * Every failure mode degrades to an EMPTY set — i.e. to the historical
+ * "write everything" behaviour — because a wrong answer here loses data in
+ * one direction only: writing when we needn't is a no-op refresh, skipping
+ * when we shouldn't leaves a record missing from memory. Deliberately
+ * empty for: table not created yet (first page of the first run), the
+ * timestamp column not added yet (phase 2 ALTERs it in on demand, so its
+ * absence is the normal never-enriched state), an idField with no matching
+ * SQLite column (a dotted idField — the flat SQLite mirror can't represent
+ * one, so we can't answer and must not guess), and any SQL error at all.
+ */
+export function findEnrichedIds(
+  db: Database.Database,
+  model: string,
+  idField: string,
+  config: EnrichConfig,
+  records: Array<Record<string, unknown>>,
+  tableCreated: boolean,
+): Set<string> {
+  const enriched = new Set<string>();
+  if (!tableCreated || records.length === 0) return enriched;
+
+  const tsField = config.timestampField ?? '_enriched_at';
+  const safeTable = model.replace(/[^a-zA-Z0-9_]/g, '_');
+  const safeIdField = idField.replace(/"/g, '""');
+  const safeTsField = tsField.replace(/"/g, '""');
+
+  try {
+    const cols = (db.prepare(`PRAGMA table_info("${safeTable}")`).all() as Array<{ name: string }>)
+      .map(c => c.name);
+    if (!cols.includes(tsField) || !cols.includes(idField)) return enriched;
+
+    // `records` uses the flat top-level key, matching how `upsertRecords` and
+    // `classifyRecords` address the SQLite mirror's id column.
+    const ids = records
+      .map(r => r[idField])
+      .filter((id): id is string | number => typeof id === 'string' || typeof id === 'number');
+    if (ids.length === 0) return enriched;
+
+    // Chunk the IN clause to stay under SQLite's variable limit, same as
+    // classifyRecords.
+    const CHUNK = 500;
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      const chunk = ids.slice(i, i + CHUNK);
+      const placeholders = chunk.map(() => '?').join(',');
+      const rows = db.prepare(
+        `SELECT "${safeIdField}" AS id FROM "${safeTable}" ` +
+        `WHERE "${safeTsField}" IS NOT NULL AND "${safeIdField}" IN (${placeholders})`
+      ).all(...chunk) as Array<{ id: string | number }>;
+      for (const row of rows) enriched.add(String(row.id));
+    }
+  } catch {
+    // Corrupt mirror, renamed column, whatever — never crash a sync over an
+    // optimisation. Fall back to writing every record, as we always did.
+    return new Set();
+  }
+
+  return enriched;
+}
+
+/**
  * Profile-level hooks/transforms that must be applied to each enriched row
  * before it's written back to SQL. Mirrors the Phase 1 pipeline so that
  * rows produced by enrichment end up with the same columns, identity, and

--- a/src/lib/memory/sync/enrich.ts
+++ b/src/lib/memory/sync/enrich.ts
@@ -4,7 +4,7 @@ import { resolveActionDetails } from '../../action-details.js';
 import { isAgentMode } from '../../output.js';
 import type { EnrichConfig, SyncProfile } from './types.js';
 import type { ActionDetails } from '../../types.js';
-import { writePageToMemory } from './mem-writer.js';
+import { writePageToMemory, resolveEntityIdentity } from './mem-writer.js';
 import type Database from 'better-sqlite3';
 import { transformRecords } from './transform.js';
 import { fireHooks, type ChangeEvent } from './hooks.js';
@@ -327,9 +327,13 @@ export async function enrichPhase(
         stripExcludedFields(merged, ctx.exclude);
       }
       if (ctx.identityKey) {
-        const raw = getByDotPath(merged, ctx.identityKey);
-        if (raw !== null && raw !== undefined) {
-          merged._identity = String(raw).toLowerCase().trim();
+        // Same resolver the sync runner and the memory writer use — enrichment
+        // recomputes `_identity` from the merged record, and if it normalized
+        // differently from the list phase the row's identity would flip on
+        // every enrich pass.
+        const identity = resolveEntityIdentity(merged, ctx.identityKey);
+        if (identity?.value) {
+          merged._identity = identity.value;
         }
       }
 

--- a/src/lib/memory/sync/identity-keys.test.ts
+++ b/src/lib/memory/sync/identity-keys.test.ts
@@ -1,0 +1,215 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { collectIdentityKeys } from './mem-writer.js';
+import { loadBuiltinProfile } from './builtin-profiles.js';
+import type { SyncProfile } from './types.js';
+
+// #128: identityKeys (plural) — multiple cross-platform identity keys per
+// record, with [] wildcard fan-out, normalization, and dedupe. The singular
+// identityKey must keep its original scalar behavior (backwards compatible).
+
+type IdProfile = Pick<SyncProfile, 'identityKey' | 'identityKeys'>;
+
+describe('collectIdentityKeys — singular identityKey (backwards compatible) (#128)', () => {
+  it('extracts a scalar identity key, lowercased + trimmed, with derived prefix', () => {
+    const keys = collectIdentityKeys({ email: '  Jane@Acme.COM ' }, { identityKey: 'email' } as IdProfile);
+    assert.deepEqual(keys, ['email:jane@acme.com']);
+  });
+
+  it('derives prefix from the path (email/phone/domain/id)', () => {
+    assert.deepEqual(collectIdentityKeys({ work_phone: '+1-555' }, { identityKey: 'work_phone' } as IdProfile), ['phone:+1-555']);
+    assert.deepEqual(collectIdentityKeys({ company_domain: 'Acme.com' }, { identityKey: 'company_domain' } as IdProfile), ['domain:acme.com']);
+    assert.deepEqual(collectIdentityKeys({ ref: 'ABC' }, { identityKey: 'ref' } as IdProfile), ['id:abc']);
+  });
+
+  it('resolves dotted + numeric-index paths', () => {
+    const rec = { email_addresses: [{ email_address: 'a@b.com' }] };
+    assert.deepEqual(collectIdentityKeys(rec, { identityKey: 'email_addresses[0].email_address' } as IdProfile), ['email:a@b.com']);
+  });
+
+  it('produces no key when the value is missing/empty/object', () => {
+    assert.deepEqual(collectIdentityKeys({}, { identityKey: 'email' } as IdProfile), []);
+    assert.deepEqual(collectIdentityKeys({ email: '' }, { identityKey: 'email' } as IdProfile), []);
+    assert.deepEqual(collectIdentityKeys({ email: { nested: 1 } }, { identityKey: 'email' } as IdProfile), []);
+  });
+
+  it('returns [] when no identity config is set', () => {
+    assert.deepEqual(collectIdentityKeys({ email: 'a@b.com' }, {} as IdProfile), []);
+  });
+});
+
+describe('collectIdentityKeys — plural identityKeys with [] wildcard (#128)', () => {
+  it('fans out a [] wildcard path to one key per element', () => {
+    const rec = { attendees: [{ email: 'A@x.com' }, { email: 'b@x.com' }, { email: 'c@x.com' }] };
+    const keys = collectIdentityKeys(rec, { identityKeys: [{ prefix: 'email', path: 'attendees[].email' }] } as IdProfile);
+    assert.deepEqual(keys, ['email:a@x.com', 'email:b@x.com', 'email:c@x.com']);
+  });
+
+  it('handles nested [] wildcards (messages[].headers[].value)', () => {
+    const rec = {
+      messages: [
+        { headers: [{ value: 'one@x.com' }, { value: 'two@x.com' }] },
+        { headers: [{ value: 'three@x.com' }] },
+      ],
+    };
+    const keys = collectIdentityKeys(rec, { identityKeys: [{ prefix: 'email', path: 'messages[].headers[].value' }] } as IdProfile);
+    assert.deepEqual(keys, ['email:one@x.com', 'email:two@x.com', 'email:three@x.com']);
+  });
+
+  it('dedupes repeats within and across entries (order-preserving)', () => {
+    const rec = {
+      organizer: { email: 'host@x.com' },
+      attendees: [{ email: 'host@x.com' }, { email: 'guest@x.com' }, { email: 'GUEST@x.com' }],
+    };
+    const keys = collectIdentityKeys(rec, {
+      identityKeys: [
+        { prefix: 'email', path: 'organizer.email' },
+        { prefix: 'email', path: 'attendees[].email' },
+      ],
+    } as IdProfile);
+    assert.deepEqual(keys, ['email:host@x.com', 'email:guest@x.com']);
+  });
+
+  it('respects each entry\'s prefix', () => {
+    const rec = { primary: 'a@x.com', site: 'acme.com' };
+    const keys = collectIdentityKeys(rec, {
+      identityKeys: [
+        { prefix: 'email', path: 'primary' },
+        { prefix: 'domain', path: 'site' },
+      ],
+    } as IdProfile);
+    assert.deepEqual(keys, ['email:a@x.com', 'domain:acme.com']);
+  });
+
+  it('skips null/empty elements in a wildcard array', () => {
+    const rec = { attendees: [{ email: 'a@x.com' }, { email: '' }, { email: null }, { other: 1 }, { email: 'b@x.com' }] };
+    const keys = collectIdentityKeys(rec, { identityKeys: [{ prefix: 'email', path: 'attendees[].email' }] } as IdProfile);
+    assert.deepEqual(keys, ['email:a@x.com', 'email:b@x.com']);
+  });
+
+  it('ignores malformed entries (missing prefix or path)', () => {
+    const rec = { email: 'a@x.com' };
+    const keys = collectIdentityKeys(rec, {
+      identityKeys: [
+        { prefix: '', path: 'email' } as any,
+        { prefix: 'email', path: '' } as any,
+        { prefix: 'email', path: 'email' },
+      ],
+    } as IdProfile);
+    assert.deepEqual(keys, ['email:a@x.com']);
+  });
+});
+
+describe('collectIdentityKeys — email extraction from header values (#129)', () => {
+  it('strips display names and lowercases', () => {
+    const rec = { from: 'Jane Smith <Jane@Acme.com>' };
+    const keys = collectIdentityKeys(rec, { identityKeys: [{ prefix: 'email', path: 'from' }] } as IdProfile);
+    assert.deepEqual(keys, ['email:jane@acme.com']);
+  });
+
+  it('extracts every address from a comma-list (To/Cc)', () => {
+    const rec = { to: 'a@x.com, Bob <b@y.com>, c@z.com' };
+    const keys = collectIdentityKeys(rec, { identityKeys: [{ prefix: 'email', path: 'to' }] } as IdProfile);
+    assert.deepEqual(keys, ['email:a@x.com', 'email:b@y.com', 'email:c@z.com']);
+  });
+
+  it('passes already-clean emails through unchanged (gcal attendees — #130)', () => {
+    const rec = { attendees: [{ email: 'jane@acme.com' }, { email: 'BOB@acme.com' }] };
+    const keys = collectIdentityKeys(rec, { identityKeys: [{ prefix: 'email', path: 'attendees[].email' }] } as IdProfile);
+    assert.deepEqual(keys, ['email:jane@acme.com', 'email:bob@acme.com']);
+  });
+
+  it('yields nothing for an email-prefixed value with no address', () => {
+    const rec = { from: 'mailer-daemon (no address)' };
+    assert.deepEqual(collectIdentityKeys(rec, { identityKeys: [{ prefix: 'email', path: 'from' }] } as IdProfile), []);
+  });
+});
+
+describe('collectIdentityKeys — [name=From] header filter (#129 Gmail shape)', () => {
+  const thread = {
+    messages: [
+      { payload: { headers: [
+        { name: 'From', value: 'Moe <moe@withone.ai>' },
+        { name: 'To', value: 'anish@intently.ai, jane@acme.com' },
+        { name: 'Subject', value: 'pricing for vip@whale.com' }, // must NOT leak
+        { name: 'Received', value: 'by mail-server@google.com' }, // must NOT leak
+      ] } },
+      { payload: { headers: [
+        { name: 'From', value: 'anish@intently.ai' },
+        { name: 'Cc', value: 'Boss <boss@acme.com>' },
+      ] } },
+    ],
+  };
+
+  it('extracts From/To/Cc participants across all messages, ignoring other headers', () => {
+    const keys = collectIdentityKeys(thread, {
+      identityKeys: [
+        { prefix: 'email', path: "messages[].payload.headers[name=From].value" },
+        { prefix: 'email', path: "messages[].payload.headers[name=To].value" },
+        { prefix: 'email', path: "messages[].payload.headers[name=Cc].value" },
+      ],
+    } as IdProfile);
+    assert.deepEqual(keys, [
+      'email:moe@withone.ai',
+      'email:anish@intently.ai',
+      'email:jane@acme.com',
+      'email:boss@acme.com',
+    ]);
+    // Subject/Received emails must be absent
+    assert.ok(!keys.includes('email:vip@whale.com'));
+    assert.ok(!keys.includes('email:mail-server@google.com'));
+  });
+
+  it('filter is case-insensitive on the field value', () => {
+    const rec = { headers: [{ name: 'from', value: 'x@y.com' }] };
+    const keys = collectIdentityKeys(rec, { identityKeys: [{ prefix: 'email', path: 'headers[name=From].value' }] } as IdProfile);
+    assert.deepEqual(keys, ['email:x@y.com']);
+  });
+});
+
+describe('built-in profiles declare working identity keys (#129/#130)', () => {
+  it('gmail/gmailThreads resolves From/To/Cc participants across the thread', () => {
+    const profile = loadBuiltinProfile('gmail', 'gmailThreads') as unknown as SyncProfile;
+    assert.ok(profile?.identityKeys?.length, 'gmail profile declares identityKeys');
+    const thread = {
+      messages: [
+        { payload: { headers: [
+          { name: 'From', value: 'Moe <moe@withone.ai>' },
+          { name: 'To', value: 'anish@intently.ai, jane@acme.com' },
+          { name: 'Subject', value: 'note to self@nope.com' },
+        ] } },
+        { payload: { headers: [{ name: 'Cc', value: 'Boss <boss@acme.com>' }] } },
+      ],
+    };
+    const keys = collectIdentityKeys(thread, profile);
+    assert.deepEqual(keys.sort(), ['email:anish@intently.ai', 'email:boss@acme.com', 'email:jane@acme.com', 'email:moe@withone.ai'].sort());
+    assert.ok(!keys.includes('email:self@nope.com'), 'Subject email must not leak');
+  });
+
+  it('google-calendar/events resolves organizer + attendees', () => {
+    const profile = loadBuiltinProfile('google-calendar', 'events') as unknown as SyncProfile;
+    assert.ok(profile?.identityKeys?.length, 'gcal profile declares identityKeys');
+    const event = { organizer: { email: 'Host@acme.com' }, attendees: [{ email: 'a@x.com' }, { email: 'b@y.com' }] };
+    assert.deepEqual(collectIdentityKeys(event, profile).sort(), ['email:a@x.com', 'email:b@y.com', 'email:host@acme.com'].sort());
+  });
+
+  it('fathom/meetings resolves host + calendar invitees', () => {
+    const profile = loadBuiltinProfile('fathom', 'meetings') as unknown as SyncProfile;
+    assert.ok(profile?.identityKeys?.length, 'fathom profile declares identityKeys');
+    const meeting = { recorded_by: { email: 'rec@acme.com' }, calendar_invitees: [{ email: 'x@y.com' }] };
+    assert.deepEqual(collectIdentityKeys(meeting, profile).sort(), ['email:rec@acme.com', 'email:x@y.com'].sort());
+  });
+});
+
+describe('collectIdentityKeys — singular + plural combined (#128)', () => {
+  it('merges both sources and dedupes the overlap (prefix from singular path name)', () => {
+    // Singular `from_email` derives the `email` prefix (path name contains
+    // "email"), so it dedupes against the plural `email:` keys.
+    const rec = { from_email: 'me@x.com', to: [{ email: 'me@x.com' }, { email: 'you@x.com' }] };
+    const keys = collectIdentityKeys(rec, {
+      identityKey: 'from_email',
+      identityKeys: [{ prefix: 'email', path: 'to[].email' }],
+    } as IdProfile);
+    assert.deepEqual(keys, ['email:me@x.com', 'email:you@x.com']);
+  });
+});

--- a/src/lib/memory/sync/identity-keys.test.ts
+++ b/src/lib/memory/sync/identity-keys.test.ts
@@ -1,7 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { collectIdentityKeys } from './mem-writer.js';
+import {
+  collectIdentityKeys,
+  collectEntityKeys,
+  collectAssociationKeys,
+  resolveEntityIdentity,
+} from './mem-writer.js';
 import { loadBuiltinProfile } from './builtin-profiles.js';
+import { buildIdentityKeysPreview } from './test.js';
 import type { SyncProfile } from './types.js';
 
 // #128: identityKeys (plural) — multiple cross-platform identity keys per
@@ -211,5 +217,199 @@ describe('collectIdentityKeys — singular + plural combined (#128)', () => {
       identityKeys: [{ prefix: 'email', path: 'to[].email' }],
     } as IdProfile);
     assert.deepEqual(keys, ['email:me@x.com', 'email:you@x.com']);
+  });
+});
+
+/**
+ * `collectIdentityKeys` above is the UNION helper — it exists for `sync test`
+ * previews, and nothing in the write path calls it. The writer uses
+ * `collectEntityKeys` (→ `keys[]`) and `collectAssociationKeys` (→
+ * `identity_keys[]`) and the SPLIT between them is the #128 fix. Test them
+ * directly, or a writer that shoves everything back into `keys[]` still looks
+ * green here.
+ */
+describe('collectEntityKeys / collectAssociationKeys — the two columns are separate (#128)', () => {
+  const rec = {
+    id: 'T1',
+    email: 'owner@acme.com',
+    participants: [{ email: 'a@x.com' }, { email: 'b@x.com' }],
+  };
+  const both = {
+    identityKey: 'email',
+    identityKeys: [{ prefix: 'email', path: 'participants[].email' }],
+  } as IdProfile;
+
+  it('the singular key is an ENTITY key and never appears in the association set', () => {
+    assert.deepEqual(collectEntityKeys(rec, both), ['email:owner@acme.com']);
+    assert.deepEqual(collectAssociationKeys(rec, both), ['email:a@x.com', 'email:b@x.com']);
+  });
+
+  it('the plural keys are ASSOCIATIONS and never leak into the entity set', () => {
+    // A thread-shaped profile: participants only, no entity identity of its own.
+    const threadish = { identityKeys: both.identityKeys } as IdProfile;
+    assert.deepEqual(collectEntityKeys(rec, threadish), [], 'no singular key → no entity key');
+    assert.equal(collectAssociationKeys(rec, threadish).length, 2);
+  });
+
+  it('an association prefix is normalized, and an unusable one is dropped entirely', () => {
+    // A namespace is compared as literal text by find-by-key and the uniqueness
+    // trigger, so `"Email"` must land on `email:`…
+    assert.deepEqual(
+      collectAssociationKeys({ e: 'A@x.com' }, { identityKeys: [{ prefix: ' Email ', path: 'e' }] } as IdProfile),
+      ['email:a@x.com'],
+    );
+    // …and a prefix containing the `:` separator (or a space) would make the
+    // key unparseable, so the entry is dropped rather than written as garbage.
+    assert.deepEqual(
+      collectAssociationKeys({ e: 'a@x.com' }, { identityKeys: [{ prefix: 'we:ird', path: 'e' }] } as IdProfile),
+      [],
+    );
+  });
+});
+
+/**
+ * `keys[]` is the MERGE + uniqueness column, so the singular `identityKey` may
+ * contribute AT MOST ONE key. A path that fans out would hand one record
+ * several entity identities; combined with sync's `replace: true` that either
+ * overwrites an unrelated entity's row wholesale or trips 23505. Ambiguous
+ * must therefore resolve to nothing at all — not to a first-match guess.
+ */
+describe('singular identityKey fan-out guard — at most one merge key (#128)', () => {
+  it('a comma-list value produces NO entity key (ambiguous, not first-match)', () => {
+    const rec = { email: 'a@x.com, Bob <b@y.com>' };
+    assert.deepEqual(collectEntityKeys(rec, { identityKey: 'email' } as IdProfile), []);
+    // The candidates are still exposed so `sync test` can tell the profile
+    // author exactly why their key vanished.
+    const identity = resolveEntityIdentity(rec, 'email');
+    assert.deepEqual(identity!.values, ['a@x.com', 'b@y.com']);
+    assert.equal(identity!.value, null);
+    assert.equal(identity!.key, null);
+  });
+
+  it('a [] wildcard path produces NO entity key even though it resolves', () => {
+    const rec = { emails: [{ address: 'a@x.com' }, { address: 'b@x.com' }] };
+    assert.deepEqual(collectEntityKeys(rec, { identityKey: 'emails[].address' } as IdProfile), []);
+    // Pinning the index makes it unambiguous again — the documented fix.
+    assert.deepEqual(collectEntityKeys(rec, { identityKey: 'emails[0].address' } as IdProfile), ['email:a@x.com']);
+  });
+
+  it('a fan-out that collapses to ONE distinct value is still fine', () => {
+    // Duplicates are deduped before the ambiguity check, so a repeated address
+    // is not punished.
+    const rec = { emails: [{ address: 'Same@x.com' }, { address: 'same@X.com' }] };
+    assert.deepEqual(collectEntityKeys(rec, { identityKey: 'emails[].address' } as IdProfile), ['email:same@x.com']);
+  });
+
+  it('non-email prefixes fan out too, and are guarded the same way', () => {
+    const rec = { domains: ['acme.com', 'acme.io'] };
+    assert.deepEqual(collectEntityKeys(rec, { identityKey: 'domains[]' } as IdProfile), []);
+    assert.deepEqual(collectEntityKeys({ domains: ['acme.com'] }, { identityKey: 'domains[]' } as IdProfile), ['domain:acme.com']);
+  });
+
+  it('the shipped entity profiles each produce exactly ONE merge key', () => {
+    // These three are the profiles whose records ARE entities (a person, a
+    // company, a customer). Their `keys[]` contribution must stay singular no
+    // matter what the payload looks like, or a sync merges two real people.
+    const cases: Array<{ platform: string; model: string; record: Record<string, unknown>; expected: string }> = [
+      {
+        platform: 'attio', model: 'attioPeople',
+        record: {
+          values: {
+            email_addresses: [
+              { email_address: 'Jane@Acme.com' },
+              // A second address must NOT create a second merge key — the
+              // profile pins [0] precisely to avoid the fan-out above.
+              { email_address: 'jane.smith@acme.com' },
+            ],
+          },
+        },
+        expected: 'email:jane@acme.com',
+      },
+      {
+        platform: 'attio', model: 'attioCompanies',
+        record: { values: { domains: [{ domain: 'Acme.com' }, { domain: 'acme.io' }] } },
+        expected: 'domain:acme.com',
+      },
+      {
+        platform: 'stripe', model: 'customers',
+        record: { email: 'Cust@Acme.com' },
+        expected: 'email:cust@acme.com',
+      },
+    ];
+
+    for (const c of cases) {
+      const profile = loadBuiltinProfile(c.platform, c.model) as unknown as SyncProfile;
+      assert.ok(profile, `${c.platform}/${c.model} profile loads`);
+      assert.ok(profile.identityKey, `${c.platform}/${c.model} declares a singular identityKey`);
+      const keys = collectEntityKeys(c.record, profile);
+      assert.deepEqual(keys, [c.expected], `${c.platform}/${c.model} must yield exactly one merge key`);
+      // And none of them declares plural identityKeys — an entity profile has
+      // no participants, so nothing should land in identity_keys[].
+      assert.deepEqual(collectAssociationKeys(c.record, profile), [], `${c.platform}/${c.model} has no associations`);
+    }
+  });
+
+  it('the shipped PARTICIPANT profiles contribute nothing to keys[]', () => {
+    // The mirror image: gmail threads / calendar events / fathom meetings are
+    // not entities, so they must add zero merge keys and leave `keys[]` as just
+    // the source key. If one of these ever grew a singular identityKey, every
+    // record sharing that value would collapse — the #128 bug all over again.
+    for (const [platform, model] of [['gmail', 'gmailThreads'], ['google-calendar', 'events'], ['fathom', 'meetings']]) {
+      const profile = loadBuiltinProfile(platform, model) as unknown as SyncProfile;
+      assert.ok(profile, `${platform}/${model} profile loads`);
+      assert.equal(profile.identityKey, undefined, `${platform}/${model} must NOT declare a singular identityKey`);
+      assert.ok(profile.identityKeys?.length, `${platform}/${model} declares plural identityKeys`);
+    }
+  });
+});
+
+describe('sync test preview surfaces the two silent-looking cases (#128)', () => {
+  it('flags a singular identityKey that fans out, with the values it saw', () => {
+    const preview = buildIdentityKeysPreview(
+      [
+        { email: 'jane@acme.com' },
+        { email: 'a@x.com, b@y.com' },
+        { email: 'Solo@Acme.com' },
+      ],
+      { identityKey: 'email' } as SyncProfile,
+    );
+    assert.ok(preview);
+    // Only the comma-list record fans out; the other two resolve cleanly.
+    assert.equal(preview!.entityFanOut?.count, 1);
+    assert.deepEqual(preview!.entityFanOut?.sampleValues, ['email:a@x.com', 'email:b@y.com']);
+    // And that record contributed no key at all — the guard, seen from outside.
+    assert.deepEqual(preview!.perRecord, [1, 0, 1]);
+  });
+
+  it('does not flag a fan-out that collapses to one distinct value', () => {
+    const preview = buildIdentityKeysPreview(
+      [{ email: 'jane@acme.com, Jane@ACME.com' }],
+      { identityKey: 'email' } as SyncProfile,
+    );
+    assert.equal(preview!.entityFanOut, undefined);
+    assert.deepEqual(preview!.perRecord, [1]);
+  });
+
+  it('marks an enriching profile so zero keys is not reported as a broken path', () => {
+    const gmail = loadBuiltinProfile('gmail', 'gmailThreads') as unknown as SyncProfile;
+    // The list shape: what threads.list actually returns, before enrichment.
+    const preview = buildIdentityKeysPreview(
+      [{ id: 'T1', snippet: 'hello', historyId: '99' }],
+      gmail,
+    );
+    assert.deepEqual(preview!.perRecord, [0]);
+    assert.equal(preview!.resolvesAfterEnrich, true);
+  });
+
+  it('leaves resolvesAfterEnrich unset for a non-enriching participant profile', () => {
+    const gcal = loadBuiltinProfile('google-calendar', 'events') as unknown as SyncProfile;
+    assert.equal(gcal.enrich, undefined);
+    const preview = buildIdentityKeysPreview([{ organizer: { email: 'me@acme.com' } }], gcal);
+    assert.equal(preview!.resolvesAfterEnrich, undefined);
+    assert.deepEqual(preview!.perRecord, [1]);
+  });
+
+  it('returns undefined when the profile declares no identity config', () => {
+    assert.equal(buildIdentityKeysPreview([{ email: 'a@b.com' }], {} as SyncProfile), undefined);
   });
 });

--- a/src/lib/memory/sync/index.ts
+++ b/src/lib/memory/sync/index.ts
@@ -478,6 +478,21 @@ async function syncTestCommand(
     }
   }
 
+  if (report.identityKeysPreview) {
+    const { perRecord, sampleKeys } = report.identityKeysPreview;
+    const total = perRecord.reduce((a, b) => a + b, 0);
+    const min = perRecord.length ? Math.min(...perRecord) : 0;
+    const max = perRecord.length ? Math.max(...perRecord) : 0;
+    const mark = total === 0 ? pc.yellow('~') : pc.green('✓');
+    console.log(`\n  ${pc.bold('Identity keys')} ${pc.dim(`(cross-platform — #128)`)}`);
+    console.log(`    ${mark} ${perRecord.length} sample${perRecord.length === 1 ? '' : 's'}, ${min}–${max} key${max === 1 ? '' : 's'} per record`);
+    if (sampleKeys.length > 0) {
+      console.log(`    ${pc.dim('e.g.')} ${sampleKeys.slice(0, 8).map(k => pc.cyan(k)).join(', ')}`);
+    } else {
+      console.log(`    ${pc.yellow('note:')} no identity keys resolved on these samples — check the identityKey/identityKeys paths.`);
+    }
+  }
+
   if (searchablePreview) {
     console.log(`\n  ${pc.bold('Searchable preview')} ${pc.dim(`(${searchablePreview.mode}, ${searchablePreview.sampledRecords} sample${searchablePreview.sampledRecords === 1 ? '' : 's'})`)}`);
     console.log(`    ${pc.dim('length:')}  ${searchablePreview.length} chars (first sample)`);

--- a/src/lib/memory/sync/index.ts
+++ b/src/lib/memory/sync/index.ts
@@ -479,17 +479,36 @@ async function syncTestCommand(
   }
 
   if (report.identityKeysPreview) {
-    const { perRecord, sampleKeys } = report.identityKeysPreview;
+    const { perRecord, sampleKeys, entityFanOut, resolvesAfterEnrich } = report.identityKeysPreview;
     const total = perRecord.reduce((a, b) => a + b, 0);
     const min = perRecord.length ? Math.min(...perRecord) : 0;
     const max = perRecord.length ? Math.max(...perRecord) : 0;
     const mark = total === 0 ? pc.yellow('~') : pc.green('✓');
-    console.log(`\n  ${pc.bold('Identity keys')} ${pc.dim(`(cross-platform — #128)`)}`);
+    // "Merge + identity keys", not "Identity keys": the count below is
+    // collectIdentityKeys = entity keys (singular `identityKey` → keys[]) UNION
+    // association keys (plural `identityKeys` → identity_keys[]). Calling it
+    // "identity keys" would claim everything counted lands in the non-merging
+    // column, which is the one confusion this feature has to avoid.
+    console.log(`\n  ${pc.bold('Merge + identity keys')} ${pc.dim(`(cross-platform — #128)`)}`);
     console.log(`    ${mark} ${perRecord.length} sample${perRecord.length === 1 ? '' : 's'}, ${min}–${max} key${max === 1 ? '' : 's'} per record`);
     if (sampleKeys.length > 0) {
       console.log(`    ${pc.dim('e.g.')} ${sampleKeys.slice(0, 8).map(k => pc.cyan(k)).join(', ')}`);
+    } else if (resolvesAfterEnrich) {
+      // Not a misconfiguration: this profile's participant paths read fields
+      // that only the enrich call fetches, so the list-shape samples shown
+      // here genuinely can't resolve them. Saying "check your paths" would
+      // send the author chasing a bug that isn't there.
+      console.log(`    ${pc.dim('note:')} 0 on these list-shape samples — this profile enriches, and its identityKeys paths resolve in the enrich phase.`);
     } else {
       console.log(`    ${pc.yellow('note:')} no identity keys resolved on these samples — check the identityKey/identityKeys paths.`);
+    }
+    if (entityFanOut) {
+      // Loud, because the failure is otherwise invisible: the profile syncs
+      // fine, it just quietly stops merging across platforms forever.
+      console.log(`    ${pc.yellow('warn:')} identityKey resolved to MULTIPLE values on ${entityFanOut.count} of ${perRecord.length} samples — those records get NO merge key.`);
+      console.log(`          ${pc.dim('saw:')} ${entityFanOut.sampleValues.map(v => pc.cyan(v)).join(', ')}`);
+      console.log(`          ${pc.dim('A singular identityKey means "this record IS this entity", so a fan-out has no safe answer.')}`);
+      console.log(`          ${pc.dim('Point it at a single-valued path, or move it to identityKeys[] for participant associations.')}`);
     }
   }
 

--- a/src/lib/memory/sync/mem-writer.test.ts
+++ b/src/lib/memory/sync/mem-writer.test.ts
@@ -126,6 +126,200 @@ describe('sync mem-writer — dual-write into the unified memory store', () => {
     assert.equal(carol!.data._synced_at, undefined);
     assert.equal(carol!.data._enriched_at, undefined);
   });
+
+  // ─── #128 routing: which COLUMN each kind of key lands in ────────────────
+  //
+  // These guard the actual bug this branch exists to fix. Everything else
+  // that touches identity keys tests either the pure helpers
+  // (identity-keys.test.ts → collectIdentityKeys, the UNION used only by
+  // `sync test` previews) or the SQL with hand-written arrays
+  // (pglite.test.ts → upsertByKeys). Neither observes the WRITER's split, so
+  // both of these mutations used to pass the whole suite green:
+  //   1. `const keys = [sourceKey, ...collectIdentityKeys(record, profile)]`
+  //      — the #128 bug verbatim: participants back in the MERGING keys[].
+  //   2. `identity_keys: undefined` unconditionally — column never populated.
+  // Assert at the writer boundary (write a page, read the row back) so the
+  // routing itself is covered, not the helpers it happens to call.
+  const threadProfile: SyncProfile = {
+    platform: 'gmailtest',
+    model: 'threads',
+    connectionKey: 'live::gmail::default::abc',
+    actionId: 'conn_mod_def::xxx::yyy',
+    resultsPath: 'data',
+    idField: 'id',
+    pagination: { type: 'cursor' },
+    // Plural = ASSOCIATIONS. No singular identityKey: a thread is not a person,
+    // so it has no entity identity of its own.
+    identityKeys: [{ prefix: 'email', path: 'participants[].email' }],
+  };
+
+  it('routes participants to identity_keys[] and keeps keys[] to the source key alone (#128)', async () => {
+    const report = await writePageToMemory(threadProfile, [
+      {
+        id: 'T1',
+        subject: 'Q2 pricing',
+        participants: [{ email: 'Jane@Acme.com' }, { email: 'moe@withone.ai' }],
+      },
+    ]);
+    assert.equal(report.inserted, 1);
+
+    const backend = await getBackend();
+    const thread = await backend.findBySource('gmailtest/threads:T1');
+    assert.ok(thread, 'thread should be found by its source key');
+
+    // (a) keys[] holds ONLY the source key. Any participant email here is the
+    // #128 bug: keys[] drives both the uniqueness trigger and the upsert
+    // overlap-merge, so a participant in it makes the thread collide with the
+    // contact record for that person.
+    assert.deepEqual(thread!.keys, ['gmailtest/threads:T1']);
+
+    // (b) identity_keys[] holds both participants, normalized (lowercased).
+    assert.deepEqual(
+      (thread!.identity_keys ?? []).sort(),
+      ['email:jane@acme.com', 'email:moe@withone.ai'].sort(),
+    );
+  });
+
+  it('two threads sharing a participant stay DISTINCT records (#128)', async () => {
+    await writePageToMemory(threadProfile, [
+      { id: 'T2', subject: 'first', participants: [{ email: 'shared@acme.com' }, { email: 'a@x.com' }] },
+      { id: 'T3', subject: 'second', participants: [{ email: 'shared@acme.com' }, { email: 'b@x.com' }] },
+    ]);
+
+    const backend = await getBackend();
+    const t2 = await backend.findBySource('gmailtest/threads:T2');
+    const t3 = await backend.findBySource('gmailtest/threads:T3');
+    assert.ok(t2 && t3, 'both threads should exist');
+    assert.notEqual(t2!.id, t3!.id, 'sharing a participant must NOT collapse the two threads');
+    assert.equal(t2!.data.subject, 'first');
+    assert.equal(t3!.data.subject, 'second');
+    // Each keeps its own participant set — no cross-contamination from a merge.
+    assert.ok((t2!.identity_keys ?? []).includes('email:a@x.com'));
+    assert.ok(!(t2!.identity_keys ?? []).includes('email:b@x.com'));
+
+    // And the shared participant joins them: find-by-key is the whole point.
+    const joined = await backend.findByKeys(['email:shared@acme.com']);
+    assert.equal(joined.length, 2, 'both threads reachable by the shared participant');
+  });
+
+  it('a thread does NOT merge into the contact that shares its participant (#128)', async () => {
+    // `profile` (attio/people) puts the person's own email in keys[] via the
+    // singular identityKey — the entity identity. The thread carries the same
+    // address as an ASSOCIATION. Different columns → no merge.
+    await writePageToMemory(profile, [{ id: 'p42', name: 'Dana', email: 'dana@acme.com' }]);
+    await writePageToMemory(threadProfile, [
+      { id: 'T4', subject: 'with dana', participants: [{ email: 'dana@acme.com' }] },
+    ]);
+
+    const backend = await getBackend();
+    const dana = await backend.findBySource('attio/people:p42');
+    const t4 = await backend.findBySource('gmailtest/threads:T4');
+    assert.ok(dana && t4);
+    assert.notEqual(t4!.id, dana!.id, 'thread must not collapse into the contact');
+    assert.equal(t4!.type, 'gmailtest/threads', 'thread keeps its own type');
+    assert.equal(dana!.type, 'attio/people');
+    // The contact's entity key is in keys[]; the thread's association is not.
+    assert.ok((dana!.keys ?? []).includes('email:dana@acme.com'));
+    assert.ok(!(t4!.keys ?? []).includes('email:dana@acme.com'));
+  });
+
+  // ─── three-state identity_keys contract (NULL keeps / [] clears) ─────────
+  //
+  // Sync always writes with `replace: true`, so the writer's only way to say
+  // "keep what's stored" is to send SQL NULL (`undefined`). Getting this wrong
+  // is not cosmetic: the phase-1 (list-shape) write runs unconditionally on
+  // every page of every run, so a writer that reported `[]` there wiped the
+  // column on run 2 and enrich could never restore it (it only revisits
+  // `_enriched_at IS NULL` rows).
+  it('a profile with NO identityKeys never clears keys someone else wrote', async () => {
+    const backend = await getBackend();
+    // Stand in for `mem migrate --identity` / a hand-written `mem add`.
+    await backend.upsertByKeys({
+      type: 'attio/people',
+      data: { name: 'Preserve Me' },
+      keys: ['attio/people:p77'],
+      identity_keys: ['email:preserve@acme.com'],
+      sources: { 'attio/people:p77': { last_synced_at: new Date().toISOString() } },
+    });
+
+    // `profile` declares only the singular identityKey — no opinion on
+    // associations, so it must send NULL rather than [].
+    await writePageToMemory(profile, [{ id: 'p77', name: 'Preserve Me', email: 'preserve@acme.com' }]);
+
+    const after = await backend.findBySource('attio/people:p77');
+    assert.deepEqual(after!.identity_keys, ['email:preserve@acme.com'], 'must survive an unrelated sync');
+  });
+
+  it('an authoritative empty resolution CLEARS identity_keys (removed attendee)', async () => {
+    await writePageToMemory(threadProfile, [
+      { id: 'T5', subject: 'had two', participants: [{ email: 'x@acme.com' }, { email: 'y@acme.com' }] },
+    ]);
+    const backend = await getBackend();
+    assert.equal((await backend.findBySource('gmailtest/threads:T5'))!.identity_keys?.length, 2);
+
+    // y leaves the thread → the column must shrink, not union.
+    await writePageToMemory(threadProfile, [
+      { id: 'T5', subject: 'had two', participants: [{ email: 'x@acme.com' }] },
+    ]);
+    assert.deepEqual((await backend.findBySource('gmailtest/threads:T5'))!.identity_keys, ['email:x@acme.com']);
+
+    // Everyone leaves → [] is authoritative "zero participants", so clear.
+    await writePageToMemory(threadProfile, [{ id: 'T5', subject: 'had two', participants: [] }]);
+    const cleared = (await backend.findBySource('gmailtest/threads:T5'))!.identity_keys ?? [];
+    assert.deepEqual(cleared, [], 'an authoritative empty resolution clears the column');
+  });
+
+  it('an enrich profile stays silent on the pre-enrich (list) shape', async () => {
+    // gmail/gmailThreads resolves its participants out of
+    // `messages[].payload.headers[...]`, which only the enrich phase fetches —
+    // `threads.list` returns `{id, snippet, historyId}`. Phase 1 must NOT
+    // report `[]` for that shape or every run after the first wipes the column.
+    const enrichProfile: SyncProfile = {
+      ...threadProfile,
+      model: 'enrichedThreads',
+      enrich: { actionId: 'conn_mod_def::detail' },
+    };
+    const backend = await getBackend();
+
+    // Phase 2 shape: carries the enrich timestamp → authoritative.
+    await writePageToMemory(enrichProfile, [
+      { id: 'E1', subject: 'enriched', participants: [{ email: 'e1@acme.com' }], _enriched_at: '2026-07-01' },
+    ]);
+    assert.deepEqual(
+      (await backend.findBySource('gmailtest/enrichedThreads:E1'))!.identity_keys,
+      ['email:e1@acme.com'],
+    );
+
+    // Run 2, phase 1: the list shape has no participants and no timestamp.
+    // Pre-fix this wrote `[]` and destroyed the enriched associations.
+    await writePageToMemory(enrichProfile, [{ id: 'E1', subject: 'enriched' }]);
+    assert.deepEqual(
+      (await backend.findBySource('gmailtest/enrichedThreads:E1'))!.identity_keys,
+      ['email:e1@acme.com'],
+      'the list-shape write must not clobber what enrichment resolved',
+    );
+
+    // A profile can rename the timestamp field; the writer must read the
+    // profile's own override rather than hardcoding `_enriched_at`.
+    const renamed: SyncProfile = {
+      ...enrichProfile,
+      model: 'renamedTs',
+      enrich: { actionId: 'conn_mod_def::detail', timestampField: '_detail_at' },
+    };
+    await writePageToMemory(renamed, [
+      { id: 'R1', participants: [{ email: 'r1@acme.com' }], _detail_at: '2026-07-01' },
+    ]);
+    assert.deepEqual(
+      (await backend.findBySource('gmailtest/renamedTs:R1'))!.identity_keys,
+      ['email:r1@acme.com'],
+    );
+    await writePageToMemory(renamed, [{ id: 'R1' }]);
+    assert.deepEqual(
+      (await backend.findBySource('gmailtest/renamedTs:R1'))!.identity_keys,
+      ['email:r1@acme.com'],
+      'the override field must gate the same way `_enriched_at` does',
+    );
+  });
 });
 
 describe('extractSearchableFromPaths — wildcard + numeric + plain paths', () => {

--- a/src/lib/memory/sync/mem-writer.ts
+++ b/src/lib/memory/sync/mem-writer.ts
@@ -166,7 +166,6 @@ export async function writePageToMemory(
     updates: [],
   };
   const type = `${profile.platform}/${profile.model}`;
-  const identityKey = profile.identityKey;
   // `--embed` on `sync run` wins over the profile's memory.embed flag.
   // Lets users flip on embeddings for one run (e.g. backfilling after
   // a first sync done with embedOnSync: false) without editing the
@@ -194,14 +193,12 @@ export async function writePageToMemory(
     }
 
     const sourceKey = `${type}:${String(externalId)}`;
-    const keys = [sourceKey];
-
-    if (identityKey) {
-      const raw = getByDotPath(record, identityKey);
-      if (raw !== null && raw !== undefined && raw !== '') {
-        keys.push(`${deriveIdentityPrefix(identityKey)}:${String(raw).toLowerCase().trim()}`);
-      }
-    }
+    // keys[] = entity/merge identifiers (source key + singular identityKey).
+    // identity_keys[] = participant associations (plural identityKeys, #128) —
+    // a SEPARATE column that never triggers merge, so a Gmail thread carrying
+    // many participant emails stays its own record. See schema.ts.
+    const keys = [sourceKey, ...collectEntityKeys(record, profile)];
+    const identityKeys = collectAssociationKeys(record, profile);
 
     // Strip sync-internal bookkeeping from the payload
     const data = { ...record };
@@ -222,6 +219,7 @@ export async function writePageToMemory(
           type,
           data,
           keys,
+          identity_keys: identityKeys.length ? identityKeys : undefined,
           searchable_text,
           sources: {
             [sourceKey]: {
@@ -264,4 +262,165 @@ function deriveIdentityPrefix(dotPath: string): string {
   if (lower.includes('phone')) return 'phone';
   if (lower.includes('domain')) return 'domain';
   return 'id';
+}
+
+// Liberal email matcher — used to pull addresses out of mail-header values like
+// `"Jane Smith <jane@acme.com>"` or comma-lists `"a@x.com, Bob <b@y.com>"` (#129).
+const EMAIL_RE = /[A-Za-z0-9._%+'-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+
+/**
+ * Turn one resolved raw value into zero or more normalized key values for the
+ * given prefix. For `email` keys we extract every email address found in the
+ * value (so display-name headers and comma-lists work, and already-clean
+ * emails pass through unchanged). For every other prefix we lowercase/trim the
+ * whole scalar value. Objects/arrays/empties yield nothing.
+ */
+function identityValuesFor(prefix: string, raw: unknown): string[] {
+  if (raw === null || raw === undefined || typeof raw === 'object') return [];
+  const s = String(raw);
+  if (prefix === 'email') {
+    return (s.match(EMAIL_RE) ?? []).map(e => e.toLowerCase());
+  }
+  const v = s.toLowerCase().trim();
+  return v ? [v] : [];
+}
+
+type PathToken =
+  | { type: 'field'; name: string }
+  | { type: 'index'; i: number }
+  | { type: 'wild' }
+  | { type: 'filter'; field: string; value: string };
+
+/**
+ * Tokenize an identity dot-path. Beyond plain fields it supports:
+ *   `[]`            array wildcard (fan out over every element)
+ *   `[0]`           numeric index
+ *   `[name=From]`   equality filter — keep array elements whose `name` field
+ *                   equals `From` (case-insensitive; quotes optional). Needed
+ *                   for Gmail headers (#129): `payload.headers[name=From].value`.
+ */
+function tokenizeIdentityPath(path: string): PathToken[] {
+  const tokens: PathToken[] = [];
+  const re = /([^.[\]]+)|\[([^\]]*)\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(path)) !== null) {
+    if (m[1] !== undefined) {
+      tokens.push({ type: 'field', name: m[1] });
+    } else {
+      const inner = m[2];
+      if (inner === '') tokens.push({ type: 'wild' });
+      else if (/^\d+$/.test(inner)) tokens.push({ type: 'index', i: Number(inner) });
+      else {
+        const eq = inner.indexOf('=');
+        if (eq > 0) {
+          const field = inner.slice(0, eq).trim();
+          const value = inner.slice(eq + 1).trim().replace(/^['"]|['"]$/g, '');
+          tokens.push({ type: 'filter', field, value });
+        }
+        // Unknown bracket content is ignored (no match → no keys).
+      }
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Resolve an identity path against a record, returning a flat list of leaf
+ * values. Walks a "frontier" of values so `[]` wildcards and `[name=From]`
+ * filters fan out naturally. Superset of the plain dot-path / `[]` resolver.
+ */
+function resolveIdentityPath(root: unknown, path: string): unknown[] {
+  let frontier: unknown[] = [root];
+  for (const tok of tokenizeIdentityPath(path)) {
+    const next: unknown[] = [];
+    for (const cur of frontier) {
+      if (cur === null || cur === undefined) continue;
+      if (tok.type === 'field') {
+        if (typeof cur === 'object' && !Array.isArray(cur)) next.push((cur as Record<string, unknown>)[tok.name]);
+      } else if (tok.type === 'index') {
+        if (Array.isArray(cur)) next.push(cur[tok.i]);
+      } else if (tok.type === 'wild') {
+        if (Array.isArray(cur)) next.push(...cur);
+      } else { // filter
+        if (Array.isArray(cur)) {
+          for (const el of cur) {
+            if (el && typeof el === 'object' &&
+                String((el as Record<string, unknown>)[tok.field] ?? '').toLowerCase() === tok.value.toLowerCase()) {
+              next.push(el);
+            }
+          }
+        }
+      }
+    }
+    frontier = next;
+  }
+  return frontier;
+}
+
+/** Resolve one {prefix, path} entry to its (possibly many) prefixed keys. */
+function keysForEntry(record: Record<string, unknown>, prefix: string, path: string): string[] {
+  if (!prefix || !path) return [];
+  const out: string[] = [];
+  for (const raw of resolveIdentityPath(record, path)) {
+    for (const value of identityValuesFor(prefix, raw)) out.push(`${prefix}:${value}`);
+  }
+  return out;
+}
+
+function dedupe(keys: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const k of keys) {
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(k);
+  }
+  return out;
+}
+
+/**
+ * ENTITY keys — from a profile's singular `identityKey`. These mean "this
+ * record IS this entity" and go into `keys[]`, where the store uses them to
+ * merge cross-platform records for the same entity (Attio + HubSpot for the
+ * same person). Scalar/dot-path resolve, `email`-aware extraction. Deduped.
+ */
+export function collectEntityKeys(
+  record: Record<string, unknown>,
+  profile: Pick<SyncProfile, 'identityKey'>,
+): string[] {
+  if (!profile.identityKey) return [];
+  return dedupe(keysForEntry(record, deriveIdentityPrefix(profile.identityKey), profile.identityKey));
+}
+
+/**
+ * ASSOCIATION keys — from a profile's plural `identityKeys` (#128). These mean
+ * "this record INVOLVES these people" (thread participants, event attendees)
+ * and go into the separate `identity_keys[]` column, which does NOT drive
+ * merge/uniqueness — so a many-participant record keeps its own identity.
+ * Each entry's `path` supports `[]` wildcard + `[name=From]` filter fan-out;
+ * `email`-prefixed values are email-extracted (handles `"Jane <j@x.com>"` and
+ * comma-lists). Deduped, first-seen order preserved.
+ */
+export function collectAssociationKeys(
+  record: Record<string, unknown>,
+  profile: Pick<SyncProfile, 'identityKeys'>,
+): string[] {
+  const out: string[] = [];
+  for (const entry of profile.identityKeys ?? []) {
+    if (!entry || !entry.path || !entry.prefix) continue;
+    out.push(...keysForEntry(record, entry.prefix, entry.path));
+  }
+  return dedupe(out);
+}
+
+/**
+ * All cross-platform identity keys for a record (entity ∪ association),
+ * deduped. Used by `sync test` previews and tests; the writer routes the two
+ * kinds into their separate columns via the functions above.
+ */
+export function collectIdentityKeys(
+  record: Record<string, unknown>,
+  profile: Pick<SyncProfile, 'identityKey' | 'identityKeys'>,
+): string[] {
+  return dedupe([...collectEntityKeys(record, profile), ...collectAssociationKeys(record, profile)]);
 }

--- a/src/lib/memory/sync/mem-writer.ts
+++ b/src/lib/memory/sync/mem-writer.ts
@@ -21,6 +21,16 @@ export interface MemWriteReport {
   updated: number;
   skipped: number;
   /**
+   * Records left untouched because phase 2 had already enriched them and the
+   * caller asked us not to degrade them (`alreadyEnrichedIds`). Deliberately
+   * NOT folded into `skipped`: `skipped` means "the writer REJECTED this row"
+   * and drives the runner's "most rows were rejected — likely a broken
+   * idField" warning. Every run after the first of a healthy enrich profile
+   * preserves 100% of its page, which would otherwise fire that warning on
+   * every single sync.
+   */
+  preserved: number;
+  /**
    * Source keys (`<platform>/<model>:<id>`) that landed during this page.
    * Used by `--full-refresh` to reconcile against memory records whose
    * source didn't appear this run (those get archived).
@@ -154,13 +164,24 @@ export function getSearchablePaths(profile: SyncProfile): string[] | undefined {
 export async function writePageToMemory(
   profile: SyncProfile,
   records: Array<Record<string, unknown>>,
-  opts: { capturePerAction?: boolean; embedOverride?: boolean } = {},
+  opts: {
+    capturePerAction?: boolean;
+    embedOverride?: boolean;
+    /**
+     * Ids (stringified) that phase 2 has ALREADY enriched, as read from the
+     * SQLite mirror by `findEnrichedIds`. Only the phase-1 (list-shape) write
+     * passes this; phase 2's own write-back never does, because it IS the
+     * authority. See the guard in the loop for the rule it encodes.
+     */
+    alreadyEnrichedIds?: ReadonlySet<string>;
+  } = {},
 ): Promise<MemWriteReport> {
   const report: MemWriteReport = {
     attempted: 0,
     inserted: 0,
     updated: 0,
     skipped: 0,
+    preserved: 0,
     sourceKeysSeen: [],
     inserts: [],
     updates: [],
@@ -204,6 +225,52 @@ export async function writePageToMemory(
     }
 
     const sourceKey = `${type}:${String(externalId)}`;
+
+    // A PRE-ENRICH WRITE MAY CREATE AND REFRESH, BUT IT MUST NEVER DEGRADE.
+    //
+    // We're holding the thin list shape (gmail: `{id, snippet, historyId}`)
+    // while this record has already been through phase 2, so the stored row is
+    // the merged, strictly-richer payload — full thread bodies, meeting
+    // transcripts. An authoritative write would REPLACE that with the list
+    // shape, and phase 2 would never repair it: enrich only visits rows
+    // `WHERE "<tsField>" IS NULL`, and this row's is stamped. Enriched after
+    // run 1, thin forever after run 2.
+    //
+    // So the write still happens — it is just NON-AUTHORITATIVE:
+    //   replace: false        → `data` MERGES (`r.data || p_data`), so the
+    //                           enriched fields survive while list fields
+    //                           (snippet, historyId, labels) still refresh.
+    //   preserveDerived: true → `searchable_text` / `content_hash` go as NULL
+    //                           so `COALESCE(p_…, r.…)` keeps the enriched FTS
+    //                           text instead of a thin summary of `{id,
+    //                           snippet}`. Without this the merge alone is not
+    //                           enough — `upsertRecord` always derives a text
+    //                           when the caller supplies none.
+    //   identity_keys         → already `undefined` via `preEnrichShape` below.
+    //
+    // Writing rather than SKIPPING is deliberate, and the difference is not
+    // cosmetic. Skipping looks safer but strands the record: the upsert is
+    // also the store's self-heal primitive (it flips `status` back to
+    // 'active', see schema.ts) and the only path that re-creates a row whose
+    // memory record was lost while the SQLite mirror survived — the mirror is
+    // cwd-relative and the store is under $HOME, so they drift apart for
+    // ordinary reasons (backend switch, corruption recovery, `mem archive`).
+    // With a skip, phase 1 declines to write and phase 2 declines to revisit,
+    // and the record is unreachable forever. Writing also keeps `--embed`,
+    // profile edits (`keys[]`, `tags`), and `sources.last_synced_at` working
+    // on enriched rows.
+    //
+    // The one thing we give up: a field that vanishes from the LIST shape
+    // upstream no longer vanishes here, because merges cannot delete. That is
+    // the right trade for an enrich profile, where the stored record is a
+    // merge of both shapes by construction and phase 2 is the authority on
+    // what the record contains.
+    //
+    // Records NOT yet enriched fall through and are written exactly as before,
+    // so they exist, are searchable, and get upgraded by phase 2.
+    const alreadyEnriched = opts.alreadyEnrichedIds?.has(String(externalId)) ?? false;
+    if (alreadyEnriched) report.preserved++;
+
     // keys[] = entity/merge identifiers (source key + singular identityKey).
     // identity_keys[] = participant associations (plural identityKeys, #128) —
     // a SEPARATE column that never triggers merge, so a Gmail thread carrying
@@ -266,7 +333,13 @@ export async function writePageToMemory(
         // number removed, Gmail thread archived) it must also vanish
         // from memory. The default merge behaviour is correct for
         // interactive `mem add` / `mem update`, wrong for sync.
-        { embed: embedFlag, replace: true },
+        //
+        // ...unless this row is already enriched, in which case we are the
+        // thin half of the record and must not speak for the whole of it.
+        // See the "NEVER DEGRADE" comment above.
+        alreadyEnriched
+          ? { embed: embedFlag, replace: false, preserveDerived: true }
+          : { embed: embedFlag, replace: true },
       );
       report.sourceKeysSeen.push(sourceKey);
       if (res.action === 'inserted') {

--- a/src/lib/memory/sync/mem-writer.ts
+++ b/src/lib/memory/sync/mem-writer.ts
@@ -172,6 +172,17 @@ export async function writePageToMemory(
   // profile. No override → profile's choice → config default.
   const embedFlag = opts.embedOverride ?? deriveEmbedFlag(profile);
   const searchablePaths = getSearchablePaths(profile);
+  // Does this profile have anything to say about identity_keys at all? A
+  // profile without `identityKeys` must send NULL (= "no opinion"), never `[]`
+  // (= "clear"), or a sync of an unrelated model that happens to merge into the
+  // same record would wipe association keys written by another profile's sync
+  // or restored by `mem import`.
+  const declaresIdentityKeys = (profile.identityKeys?.length ?? 0) > 0;
+  // Enrich stamps this field on the merged record before writing it back
+  // (enrich.ts sets `merged[tsField] = now`), so its presence is how the
+  // writer tells the enriched shape from the list shape. See the
+  // `preEnrichShape` comment below for why that distinction matters.
+  const enrichTimestampField = profile.enrich?.timestampField ?? '_enriched_at';
 
   for (const record of records) {
     report.attempted++;
@@ -198,7 +209,28 @@ export async function writePageToMemory(
     // a SEPARATE column that never triggers merge, so a Gmail thread carrying
     // many participant emails stays its own record. See schema.ts.
     const keys = [sourceKey, ...collectEntityKeys(record, profile)];
-    const identityKeys = collectAssociationKeys(record, profile);
+
+    // Three-state contract for identity_keys, mirrored by mem_upsert_by_keys
+    // (schema.ts) — under `replace: true`, NULL keeps and non-NULL replaces:
+    //   undefined → "I have no opinion, keep what's stored"
+    //   []        → "I authoritatively resolved zero participants, clear it"
+    //   [a, b]    → "these exactly"
+    //
+    // The pre-enrich shape is the whole reason the first state exists. A
+    // profile like gmail/gmailThreads resolves its identity keys out of
+    // fields that only enrichment fetches (`messages[].payload.headers[...]`)
+    // while `threads.list` returns `{id, snippet, historyId}`. Phase 1 runs
+    // unconditionally on every page of every run (runner.ts), so if it
+    // reported `[]` here it would clear the column — and phase 2 could not
+    // put it back, because enrich only visits rows with `_enriched_at IS
+    // NULL`. Result: keys present after the first sync, gone after the
+    // second. So while an enrich profile's record is still the list shape we
+    // stay silent and let the enriched write be the authority.
+    const preEnrichShape = !!profile.enrich && record[enrichTimestampField] == null;
+    const identityKeys =
+      !declaresIdentityKeys || preEnrichShape
+        ? undefined
+        : collectAssociationKeys(record, profile);
 
     // Strip sync-internal bookkeeping from the payload
     const data = { ...record };
@@ -219,7 +251,7 @@ export async function writePageToMemory(
           type,
           data,
           keys,
-          identity_keys: identityKeys.length ? identityKeys : undefined,
+          identity_keys: identityKeys,
           searchable_text,
           sources: {
             [sourceKey]: {
@@ -256,7 +288,17 @@ function deriveEmbedFlag(profile: SyncProfile): boolean {
   return false;
 }
 
-function deriveIdentityPrefix(dotPath: string): string {
+/**
+ * Prefix heuristic for the SINGULAR `identityKey` — the path name decides the
+ * namespace. Order matters and must not change: `email` is checked first, so
+ * `emailDomain` derives `email:` (as it has since the feature shipped).
+ * Re-prioritising would silently re-namespace every existing profile's keys
+ * and break the merge they already perform.
+ *
+ * Exported so `sync test` / migrate never re-implement it (they used to, and
+ * the copies drifted).
+ */
+export function deriveIdentityPrefix(dotPath: string): string {
   const lower = dotPath.toLowerCase();
   if (lower.includes('email')) return 'email';
   if (lower.includes('phone')) return 'phone';
@@ -274,12 +316,28 @@ const EMAIL_RE = /[A-Za-z0-9._%+'-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
  * value (so display-name headers and comma-lists work, and already-clean
  * emails pass through unchanged). For every other prefix we lowercase/trim the
  * whole scalar value. Objects/arrays/empties yield nothing.
+ *
+ * `fallbackToScalar` makes email extraction ADDITIVE rather than replacing:
+ * when the regex finds no address we fall back to the plain lowercase/trim
+ * scalar. Only the singular `identityKey` sets it, and it has to — the prefix
+ * is derived from the path name, so `identityKey: "emailDomain"` (`acme.com`),
+ * `"email_id"` (`abc123`), or a non-RFC address (`josé@acme.com`,
+ * `jane@localhost`) all get the `email` prefix while carrying no matchable
+ * address. Without the fallback those profiles would silently stop emitting
+ * the entity key they have always emitted. The plural `identityKeys` path
+ * deliberately does NOT fall back: a `To:` header with no address must
+ * contribute nothing rather than dump the whole header into `identity_keys[]`.
  */
-function identityValuesFor(prefix: string, raw: unknown): string[] {
+function identityValuesFor(
+  prefix: string,
+  raw: unknown,
+  opts: { fallbackToScalar?: boolean } = {},
+): string[] {
   if (raw === null || raw === undefined || typeof raw === 'object') return [];
   const s = String(raw);
   if (prefix === 'email') {
-    return (s.match(EMAIL_RE) ?? []).map(e => e.toLowerCase());
+    const found = (s.match(EMAIL_RE) ?? []).map(e => e.toLowerCase());
+    if (found.length > 0 || !opts.fallbackToScalar) return found;
   }
   const v = s.toLowerCase().trim();
   return v ? [v] : [];
@@ -336,7 +394,15 @@ function resolveIdentityPath(root: unknown, path: string): unknown[] {
     for (const cur of frontier) {
       if (cur === null || cur === undefined) continue;
       if (tok.type === 'field') {
-        if (typeof cur === 'object' && !Array.isArray(cur)) next.push((cur as Record<string, unknown>)[tok.name]);
+        // A numeric segment reached with a dot (`ids.0`, `contact.emails.0.address`)
+        // indexes into an array — `getByDotPath` has always done this, and this
+        // resolver must stay a strict superset of it or profiles written against
+        // the old dot-only syntax silently stop producing keys.
+        if (Array.isArray(cur)) {
+          if (/^\d+$/.test(tok.name)) next.push(cur[Number(tok.name)]);
+        } else if (typeof cur === 'object') {
+          next.push((cur as Record<string, unknown>)[tok.name]);
+        }
       } else if (tok.type === 'index') {
         if (Array.isArray(cur)) next.push(cur[tok.i]);
       } else if (tok.type === 'wild') {
@@ -367,6 +433,18 @@ function keysForEntry(record: Record<string, unknown>, prefix: string, path: str
   return out;
 }
 
+/**
+ * A prefix is a key namespace, so it has to be literal: `find-by-key` and the
+ * uniqueness trigger both compare `prefix:value` as plain text. Lowercase +
+ * trim so `"Email"` and `" email "` land on the documented `email:` namespace,
+ * and reject anything that isn't `[a-z0-9_]` (spaces / colons would make the
+ * key unparseable, since `:` is the prefix separator).
+ */
+function normalizePrefix(prefix: string): string | null {
+  const p = prefix.trim().toLowerCase();
+  return /^[a-z0-9_]+$/.test(p) ? p : null;
+}
+
 function dedupe(keys: string[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
@@ -379,17 +457,71 @@ function dedupe(keys: string[]): string[] {
 }
 
 /**
+ * The ONE place the singular `identityKey` is turned into an identity. Every
+ * caller that used to inline `String(getByDotPath(rec, identityKey)).toLowerCase().trim()`
+ * (sync runner's `_identity`, enrich's `_identity`, `mem migrate`'s identity
+ * pre-pass) goes through this, otherwise the same record gets `email:jane@acme.com` from
+ * one code path and `email:jane smith <jane@acme.com>` from another and the
+ * two never merge.
+ *
+ * `value` / `key` are only set when the path resolves to EXACTLY ONE candidate.
+ * That guard is the whole point of the type: `keys[]` is the merge + uniqueness
+ * column, so a path that fans out (a comma-list of addresses, an `emails[].v`
+ * wildcard) would hand one record several entity identities. With sync's
+ * `replace: true` that either overwrites another entity's row wholesale or
+ * trips `unique_violation`. Ambiguous → emit nothing and let the profile
+ * author fix the path (`values` is exposed so `sync test` can say so loudly).
+ */
+export interface EntityIdentity {
+  /** Namespace derived from the path (`email` / `phone` / `domain` / `id`). */
+  prefix: string;
+  /** Every distinct normalized candidate the path resolved to. */
+  values: string[];
+  /** The single normalized value, or null when the path is empty/ambiguous. */
+  value: string | null;
+  /** `prefix:value` for `keys[]`, or null when the path is empty/ambiguous. */
+  key: string | null;
+}
+
+export function resolveEntityIdentity(
+  record: Record<string, unknown>,
+  identityKey: string | undefined,
+): EntityIdentity | null {
+  if (!identityKey) return null;
+  const prefix = deriveIdentityPrefix(identityKey);
+  const values = dedupe(
+    resolveIdentityPath(record, identityKey)
+      .flatMap(raw => identityValuesFor(prefix, raw, { fallbackToScalar: true })),
+  );
+  const value = values.length === 1 ? values[0] : null;
+  return { prefix, values, value, key: value ? `${prefix}:${value}` : null };
+}
+
+/**
+ * Normalize a single already-resolved raw identity value the same way
+ * `resolveEntityIdentity` would. For callers that read the value out-of-band
+ * (e.g. `mem migrate`'s SQL pre-pass, which extracts the identity with a JSONB
+ * expression instead of walking the record) and must land on the identical
+ * string or the merge lookup misses.
+ */
+export function normalizeEntityIdentityValue(identityKey: string, raw: unknown): string | null {
+  const values = dedupe(identityValuesFor(deriveIdentityPrefix(identityKey), raw, { fallbackToScalar: true }));
+  return values.length === 1 ? values[0] : null;
+}
+
+/**
  * ENTITY keys — from a profile's singular `identityKey`. These mean "this
  * record IS this entity" and go into `keys[]`, where the store uses them to
  * merge cross-platform records for the same entity (Attio + HubSpot for the
- * same person). Scalar/dot-path resolve, `email`-aware extraction. Deduped.
+ * same person). AT MOST ONE key: see `EntityIdentity` for why a fan-out path
+ * must yield zero rather than several (or a first-match guess).
  */
 export function collectEntityKeys(
   record: Record<string, unknown>,
   profile: Pick<SyncProfile, 'identityKey'>,
 ): string[] {
-  if (!profile.identityKey) return [];
-  return dedupe(keysForEntry(record, deriveIdentityPrefix(profile.identityKey), profile.identityKey));
+  const identity = resolveEntityIdentity(record, profile.identityKey);
+  return identity?.key ? [identity.key] : [];
 }
 
 /**
@@ -399,7 +531,9 @@ export function collectEntityKeys(
  * merge/uniqueness — so a many-participant record keeps its own identity.
  * Each entry's `path` supports `[]` wildcard + `[name=From]` filter fan-out;
  * `email`-prefixed values are email-extracted (handles `"Jane <j@x.com>"` and
- * comma-lists). Deduped, first-seen order preserved.
+ * comma-lists). Prefixes are normalized (`"Email"` → `email`) and validated,
+ * so an entry can't strand its keys in a namespace `mem find-by-key email:…`
+ * will never look in. Deduped, first-seen order preserved.
  */
 export function collectAssociationKeys(
   record: Record<string, unknown>,
@@ -408,7 +542,9 @@ export function collectAssociationKeys(
   const out: string[] = [];
   for (const entry of profile.identityKeys ?? []) {
     if (!entry || !entry.path || !entry.prefix) continue;
-    out.push(...keysForEntry(record, entry.prefix, entry.path));
+    const prefix = normalizePrefix(entry.prefix);
+    if (!prefix) continue; // unusable namespace — drop the entry rather than write garbage keys
+    out.push(...keysForEntry(record, prefix, entry.path));
   }
   return dedupe(out);
 }

--- a/src/lib/memory/sync/runner.ts
+++ b/src/lib/memory/sync/runner.ts
@@ -9,7 +9,7 @@ import { getModelState, updateModelState } from './state.js';
 import { openDatabase, ensureTable, rebuildFtsIndex, evolveSchema, upsertRecords, tableExists, countRecords, deleteRecords, sanitizeTableName } from './db.js';
 import { acquireSyncLock } from './lock.js';
 import { classifyRecords, fireHooks, type ChangeEvent } from './hooks.js';
-import { writePageToMemory } from './mem-writer.js';
+import { writePageToMemory, resolveEntityIdentity } from './mem-writer.js';
 import { enrichPhase, type EnrichResult } from './enrich.js';
 import { transformRecords } from './transform.js';
 import { extractRecords } from './extract.js';
@@ -468,12 +468,16 @@ export async function syncModel(
         }
       }
 
-      // Extract cross-platform identity key if configured
+      // Extract cross-platform identity key if configured. Shares
+      // `resolveEntityIdentity` with the memory writer so the legacy SQLite
+      // `_identity` column holds the exact same normalized value that lands in
+      // the memory row's `keys[]` — the two used to be computed independently
+      // and drifted apart on any value that needed email extraction.
       if (profile.identityKey) {
         for (const record of records as Record<string, unknown>[]) {
-          const raw = getByDotPath(record, profile.identityKey);
-          if (raw !== null && raw !== undefined) {
-            (record as Record<string, unknown>)._identity = String(raw).toLowerCase().trim();
+          const identity = resolveEntityIdentity(record, profile.identityKey);
+          if (identity?.value) {
+            (record as Record<string, unknown>)._identity = identity.value;
           }
         }
       }

--- a/src/lib/memory/sync/runner.ts
+++ b/src/lib/memory/sync/runner.ts
@@ -10,7 +10,7 @@ import { openDatabase, ensureTable, rebuildFtsIndex, evolveSchema, upsertRecords
 import { acquireSyncLock } from './lock.js';
 import { classifyRecords, fireHooks, type ChangeEvent } from './hooks.js';
 import { writePageToMemory, resolveEntityIdentity } from './mem-writer.js';
-import { enrichPhase, type EnrichResult } from './enrich.js';
+import { enrichPhase, findEnrichedIds, type EnrichResult } from './enrich.js';
 import { transformRecords } from './transform.js';
 import { extractRecords } from './extract.js';
 import { resolveProfileConnectionKey } from './profile.js';
@@ -245,6 +245,11 @@ export async function syncModel(
   let enrichedTotal = 0;
   let enrichSkipped = 0;
   let enrichRateLimited = 0;
+  // Records whose memory row phase 1 left alone because phase 2 had already
+  // enriched them. Diagnostic only — reported on stderr so a user watching a
+  // steady-state gmail sync can see that "0 written to memory" is the healthy
+  // outcome, not a silent failure.
+  let memPreserved = 0;
 
   try {
     if (needsSqlite) db = await openDatabase(platform);
@@ -514,9 +519,32 @@ export async function syncModel(
 
       // Primary write: unified memory store. Every sync lands here.
       // Behavior controlled by options.toMemory (--no-memory flips it off).
-      let pageReport: { inserted: number; updated: number; skipped: number } | null = null;
+      let pageReport: { inserted: number; updated: number; skipped: number; preserved: number } | null = null;
       if (options.toMemory !== false) {
         try {
+          // Which of this page's records has phase 2 already enriched?
+          //
+          // Whenever `enrich` is configured we hold the SQLite mirror (see
+          // `needsSqlite` above) and that mirror carries `_enriched_at` per
+          // row — so phase 1 can know, BEFORE it writes, which records phase 2
+          // will consequently NOT revisit. The write below then preserves them
+          // instead of overwriting the enriched payload with the list shape
+          // (mem-writer.ts spells out why that overwrite is unrecoverable).
+          //
+          // The answer is stable for the whole run: nothing stamps
+          // `_enriched_at` until phase 2, which starts only after this
+          // pagination loop has finished. So a row reads as enriched here iff
+          // a PREVIOUS run enriched it — exactly the population phase 2 is
+          // about to pass over. Same SQLite-lookup-before-write shape that
+          // hooks already use for `classifyRecords` above.
+          const alreadyEnrichedIds =
+            profile.enrich && db
+              ? findEnrichedIds(
+                  db, model, profile.idField, profile.enrich,
+                  records as Record<string, unknown>[], tableCreated,
+                )
+              : undefined;
+
           const report = await writePageToMemory(
             profile,
             records as Record<string, unknown>[],
@@ -526,9 +554,11 @@ export async function syncModel(
               // per-run override so you can backfill embeddings on a
               // first-synced-without-embed platform in one shot.
               embedOverride: options.embed,
+              alreadyEnrichedIds,
             },
           );
           pageReport = report;
+          memPreserved += report.preserved;
           for (const key of report.sourceKeysSeen) seenSourceKeys.add(key);
           if (hasHooks && !db) {
             inserts = report.inserts;
@@ -731,6 +761,12 @@ export async function syncModel(
     if (!isAgentMode() && pagesProcessed > 0) {
       process.stderr.write(`Syncing ${platform}/${model}... page ${pagesProcessed} (${totalRecords} records) done\n`);
     }
+    if (!isAgentMode() && memPreserved > 0) {
+      process.stderr.write(
+        `  Kept ${memPreserved} already-enriched record(s) in memory ` +
+        `(the list shape would have replaced the enriched payload).\n`
+      );
+    }
 
     // Phase 2: Enrich unenriched rows (runs after list sync completes).
     // Queries _enriched_at IS NULL so it's inherently resumable — if the
@@ -831,7 +867,14 @@ export async function syncModel(
       ...(reconcileSkipped ? { reconcileSkipped } : {}),
       ...(statusCounts ? { statusCounts } : {}),
       ...(hasHooks ? { hooksInserted, hooksUpdated } : {}),
-      ...(profile.enrich ? { enriched: enrichedTotal, enrichSkipped, enrichRateLimited } : {}),
+      // `memPreserved` counts already-enriched rows this run wrote
+      // non-authoritatively (enriched payload kept, list fields refreshed).
+      // Reported to agents too — the human path only gets a stderr line, and
+      // an agent seeing `recordsSynced: 200, enriched: 0` otherwise has no way
+      // to tell "nothing needed enriching" from "enrich is broken".
+      ...(profile.enrich
+        ? { enriched: enrichedTotal, enrichSkipped, enrichRateLimited, ...(memPreserved > 0 ? { memPreserved } : {}) }
+        : {}),
     };
 
   } catch (err) {

--- a/src/lib/memory/sync/test.ts
+++ b/src/lib/memory/sync/test.ts
@@ -6,6 +6,7 @@ import { getNextPageParams } from './pagination.js';
 import type { SyncProfile } from './types.js';
 import { extractRecords, isRootPath } from './extract.js';
 import { resolveProfileConnectionKey } from './profile.js';
+import { collectIdentityKeys } from './mem-writer.js';
 
 export interface SyncTestCheck {
   name: string;
@@ -30,6 +31,15 @@ export interface SyncTestReport {
   paginationPreview?: Record<string, unknown>;
   /** Fields that sync test auto-fixed from the real response (e.g. resultsPath). */
   autoFixed?: Record<string, string>;
+  /**
+   * Resolved cross-platform identity keys across the sampled records (#128):
+   * how many keys each sampled record produced, and a few example values. Only
+   * present when the profile declares `identityKey` and/or `identityKeys`.
+   */
+  identityKeysPreview?: {
+    perRecord: number[];
+    sampleKeys: string[];
+  };
 }
 
 /** How many records --show-searchable averages over when reporting hit rates. */
@@ -319,6 +329,23 @@ export async function testSyncProfile(api: OneApi, profile: SyncProfile): Promis
   }));
   report.sample = first;
   report.samples = (records as Record<string, unknown>[]).slice(0, SEARCHABLE_SAMPLE_SIZE);
+
+  // Preview resolved cross-platform identity keys (#128) so authors can see
+  // how many keys each record yields (e.g. all thread participants) and a few
+  // sample values, without running a real sync.
+  if (profile.identityKey || (profile.identityKeys && profile.identityKeys.length > 0)) {
+    const perRecord: number[] = [];
+    const sampleKeys = new Set<string>();
+    for (const rec of report.samples) {
+      const keys = collectIdentityKeys(rec, profile);
+      perRecord.push(keys.length);
+      for (const k of keys) {
+        if (sampleKeys.size < 8) sampleKeys.add(k);
+      }
+    }
+    report.identityKeysPreview = { perRecord, sampleKeys: [...sampleKeys] };
+  }
+
   report.ok = checks.every(c => c.ok);
 
   return report;

--- a/src/lib/memory/sync/test.ts
+++ b/src/lib/memory/sync/test.ts
@@ -6,7 +6,7 @@ import { getNextPageParams } from './pagination.js';
 import type { SyncProfile } from './types.js';
 import { extractRecords, isRootPath } from './extract.js';
 import { resolveProfileConnectionKey } from './profile.js';
-import { collectIdentityKeys } from './mem-writer.js';
+import { collectIdentityKeys, resolveEntityIdentity } from './mem-writer.js';
 
 export interface SyncTestCheck {
   name: string;
@@ -39,11 +39,77 @@ export interface SyncTestReport {
   identityKeysPreview?: {
     perRecord: number[];
     sampleKeys: string[];
+    /**
+     * Sample values where the SINGULAR `identityKey` resolved to more than one
+     * candidate. Such a record gets NO entity key at all — a singular key means
+     * "this record IS this entity", so a fan-out has no safe answer (picking
+     * the first would merge two different people's records together). Surfaced
+     * here because the alternative is a profile that silently stops merging.
+     */
+    entityFanOut?: { count: number; sampleValues: string[] };
+    /**
+     * True when the profile enriches and its participant paths therefore
+     * cannot resolve on list-shape samples. Distinguishes "your paths are
+     * wrong" from "these resolve one phase later".
+     */
+    resolvesAfterEnrich?: boolean;
   };
 }
 
 /** How many records --show-searchable averages over when reporting hit rates. */
 export const SEARCHABLE_SAMPLE_SIZE = 5;
+
+/**
+ * Preview the cross-platform identity keys (#128) a profile resolves, so an
+ * author can see what a real sync would write without running one. Returns
+ * undefined when the profile declares no identity config at all.
+ *
+ * Beyond the counts, this surfaces the two ways the resolution can look wrong
+ * to a human but be correct (or vice versa):
+ *   - `entityFanOut` — a SINGULAR `identityKey` that resolved to several
+ *     candidates. Those records get NO merge key, because "this record IS this
+ *     entity" has no safe answer when the path yields two entities. Silent
+ *     otherwise: the profile syncs fine and just stops merging forever.
+ *   - `resolvesAfterEnrich` — the profile enriches, so its participant paths
+ *     read fields absent from these list-shape samples. Zero keys here is
+ *     expected, and telling the author to "check the paths" would be wrong.
+ *
+ * Exported (rather than inlined into testSyncProfile) so both branches can be
+ * tested without standing up an API client.
+ */
+export function buildIdentityKeysPreview(
+  samples: Record<string, unknown>[],
+  profile: Pick<SyncProfile, 'identityKey' | 'identityKeys' | 'enrich'>,
+): SyncTestReport['identityKeysPreview'] {
+  if (!profile.identityKey && !(profile.identityKeys && profile.identityKeys.length > 0)) return undefined;
+
+  const perRecord: number[] = [];
+  const sampleKeys = new Set<string>();
+  const fanOutValues = new Set<string>();
+  let fanOutCount = 0;
+
+  for (const rec of samples) {
+    const keys = collectIdentityKeys(rec, profile);
+    perRecord.push(keys.length);
+    for (const k of keys) {
+      if (sampleKeys.size < 8) sampleKeys.add(k);
+    }
+    const identity = resolveEntityIdentity(rec, profile.identityKey);
+    if (identity && identity.values.length > 1) {
+      fanOutCount++;
+      for (const v of identity.values) {
+        if (fanOutValues.size < 4) fanOutValues.add(`${identity.prefix}:${v}`);
+      }
+    }
+  }
+
+  return {
+    perRecord,
+    sampleKeys: [...sampleKeys],
+    ...(fanOutCount > 0 ? { entityFanOut: { count: fanOutCount, sampleValues: [...fanOutValues] } } : {}),
+    ...(profile.enrich && (profile.identityKeys?.length ?? 0) > 0 ? { resolvesAfterEnrich: true } : {}),
+  };
+}
 
 function detectColumnType(value: unknown): string {
   if (value === null || value === undefined) return 'TEXT';
@@ -330,21 +396,7 @@ export async function testSyncProfile(api: OneApi, profile: SyncProfile): Promis
   report.sample = first;
   report.samples = (records as Record<string, unknown>[]).slice(0, SEARCHABLE_SAMPLE_SIZE);
 
-  // Preview resolved cross-platform identity keys (#128) so authors can see
-  // how many keys each record yields (e.g. all thread participants) and a few
-  // sample values, without running a real sync.
-  if (profile.identityKey || (profile.identityKeys && profile.identityKeys.length > 0)) {
-    const perRecord: number[] = [];
-    const sampleKeys = new Set<string>();
-    for (const rec of report.samples) {
-      const keys = collectIdentityKeys(rec, profile);
-      perRecord.push(keys.length);
-      for (const k of keys) {
-        if (sampleKeys.size < 8) sampleKeys.add(k);
-      }
-    }
-    report.identityKeysPreview = { perRecord, sampleKeys: [...sampleKeys] };
-  }
+  report.identityKeysPreview = buildIdentityKeysPreview(report.samples, profile);
 
   report.ok = checks.every(c => c.ok);
 

--- a/src/lib/memory/sync/types.ts
+++ b/src/lib/memory/sync/types.ts
@@ -68,12 +68,27 @@ export interface SyncProfile {
   limitLocation?: 'query' | 'body';
   /**
    * Dot-path to a field that identifies this record across platforms.
-   * The value is extracted, lowercased, and stored as `_identity` on every
-   * record. Use a stable cross-platform identifier like email address.
+   * The value is extracted, lowercased, and stored as a prefixed entry in the
+   * record's `keys[]` array (e.g. `email:jane@acme.com`). Use a stable
+   * cross-platform identifier like email address.
    *
    * Example: "properties.email", "email", "email_addresses[0].email_address"
    */
   identityKey?: string;
+  /**
+   * Multiple cross-platform identity keys per record (issue #128). Use for
+   * records with N participants — a Gmail thread's From/To/Cc, calendar
+   * attendees, meeting invitees — where a single `identityKey` can't capture
+   * everyone. Each entry's `path` resolves via the dot-path walker, with `[]`
+   * wildcards expanding to ONE key per array element; each resolved value is
+   * lowercased/trimmed and emitted as `${prefix}:${value}` into the record's
+   * `keys[]` array (deduped). Combine freely with `identityKey`.
+   *
+   * Example:
+   *   [{ "prefix": "email", "path": "attendees[].email" },
+   *    { "prefix": "email", "path": "organizer.email" }]
+   */
+  identityKeys?: Array<{ prefix: string; path: string }>;
   /**
    * Dot-path field names to strip from each record before storing.
    * Supports array notation: "messages[].body" strips `body` from each

--- a/src/lib/memory/sync/types.ts
+++ b/src/lib/memory/sync/types.ts
@@ -67,22 +67,38 @@ export interface SyncProfile {
   /** Where to send the limit param: "query" (default) or "body" */
   limitLocation?: 'query' | 'body';
   /**
-   * Dot-path to a field that identifies this record across platforms.
-   * The value is extracted, lowercased, and stored as a prefixed entry in the
-   * record's `keys[]` array (e.g. `email:jane@acme.com`). Use a stable
-   * cross-platform identifier like email address.
+   * Dot-path to a field that identifies this record across platforms — i.e.
+   * "this record IS this entity". The value is extracted, lowercased, and
+   * stored as a prefixed entry in the record's `keys[]` array (e.g.
+   * `email:jane@acme.com`). `keys[]` drives upsert-merge and key uniqueness,
+   * so records from Attio / HubSpot / Stripe about the same person collapse
+   * into one memory row. Use a stable cross-platform identifier like an email
+   * address, and make sure the path resolves to exactly ONE value per record —
+   * a path that fans out is ambiguous (which entity is this row?) and is
+   * dropped rather than merged into the wrong entity.
    *
    * Example: "properties.email", "email", "email_addresses[0].email_address"
    */
   identityKey?: string;
   /**
-   * Multiple cross-platform identity keys per record (issue #128). Use for
-   * records with N participants — a Gmail thread's From/To/Cc, calendar
-   * attendees, meeting invitees — where a single `identityKey` can't capture
-   * everyone. Each entry's `path` resolves via the dot-path walker, with `[]`
-   * wildcards expanding to ONE key per array element; each resolved value is
-   * lowercased/trimmed and emitted as `${prefix}:${value}` into the record's
-   * `keys[]` array (deduped). Combine freely with `identityKey`.
+   * Cross-platform *participant associations* — "this record INVOLVES these
+   * people" (issue #128). Use for records with N participants: a Gmail
+   * thread's From/To/Cc, calendar attendees, meeting invitees — where a single
+   * `identityKey` can't capture everyone. Each entry's `path` resolves via the
+   * identity-path walker, with `[]` wildcards expanding to ONE key per array
+   * element; each resolved value is lowercased/trimmed (email-prefixed values
+   * get their address extracted out of `"Jane <jane@acme.com>"` headers and
+   * comma-lists) and emitted as `${prefix}:${value}`. `prefix` is normalized
+   * to lowercase and must match `[a-z0-9_]+`; entries with any other prefix
+   * are skipped.
+   *
+   * These values land in the record's separate `identity_keys[]` column
+   * (deduped), NOT in `keys[]`. That separation is the entire reason the field
+   * exists: unlike `identityKey`, association keys never drive upsert-merge or
+   * key uniqueness, so a 30-participant thread stays its own record instead of
+   * collapsing into (or colliding with) 30 contact records. Query them with
+   * `one mem find-by-key email:jane@acme.com`. Combine freely with
+   * `identityKey`.
    *
    * Example:
    *   [{ "prefix": "email", "path": "attendees[].email" },

--- a/src/lib/memory/types.ts
+++ b/src/lib/memory/types.ts
@@ -32,6 +32,8 @@ export interface MemRecord {
   data: Record<string, unknown>;
   tags?: string[];
   keys?: string[];
+  /** Cross-platform identity associations (#128) — see RecordInput.identity_keys. */
+  identity_keys?: string[];
   sources: SourcesMap;
 
   searchable_text?: string | null;
@@ -98,6 +100,13 @@ export interface RecordInput {
   data: Record<string, unknown>;
   tags?: string[];
   keys?: string[];
+  /**
+   * Cross-platform identity associations (#128) — e.g. `email:jane@acme.com`
+   * for each participant. Stored in the separate `identity_keys[]` column,
+   * which (unlike `keys[]`) does NOT drive upsert-merge or key uniqueness, so a
+   * record can carry many without collapsing into other records.
+   */
+  identity_keys?: string[];
   sources?: SourcesMap;
   searchable_text?: string | null;
   content_hash?: string | null;

--- a/src/lib/memory/types.ts
+++ b/src/lib/memory/types.ts
@@ -105,6 +105,17 @@ export interface RecordInput {
    * for each participant. Stored in the separate `identity_keys[]` column,
    * which (unlike `keys[]`) does NOT drive upsert-merge or key uniqueness, so a
    * record can carry many without collapsing into other records.
+   *
+   * THREE-STATE on upsert, and the distinction is load-bearing:
+   *   - `undefined` → "no opinion": keep whatever is already stored.
+   *   - `[]`        → "I authoritatively resolved zero": clear the column.
+   *   - non-empty   → replace (under `replace: true`) / union (under `false`).
+   * A caller that cannot see the fields the keys come from — e.g. a sync
+   * profile's list phase, before enrichment has fetched the participant
+   * headers — MUST send `undefined`, not `[]`, or every re-sync erases the
+   * associations a later phase resolved. Backends must therefore preserve the
+   * empty-array-vs-null difference all the way into SQL rather than
+   * normalizing `[]` to NULL.
    */
   identity_keys?: string[];
   sources?: SourcesMap;


### PR DESCRIPTION
Implements the cross-platform identity-key chain: **#128** (identityKeys), **#129** (gmail), **#130** (gcal/fathom), **#131** (query surface). Closes #128, #129, #130, #131.

The demo it unlocks: `one mem find-by-key email:jane@acme.com` → every record about Jane (her contact, the threads she's in, the meetings she attended), grouped by type.

---

## ⚠️ Read first: what the issues asked for vs. what this builds

**What the issues proposed:** add `identityKeys` and write each resolved value (every participant email) into the existing **`keys[]`** array.

**Why that corrupts data:** `keys[]` is not a tag set — it is the store's **merge-identifier** set. A DB trigger rejects any record whose `keys[]` overlaps another's, and `upsertByKeys` *merges* two records that share a key (that's how Attio + HubSpot records for the same person unify). So a Gmail thread writing `email:jane@acme.com` into `keys[]` merges into Jane's contact. At scale it's worse: thread(jane,moe) shares *moe* with thread(moe,bob), which shares *bob* with thread(bob,carol) — every thread sharing any participant transitively collapses into one record.

#131's own spec confirms the fix: `mem linked email:jane` should return *"gmail/threads — 14 records"*. That's only possible if those threads stay **separate records that reference** Jane — i.e. identity keys are **associations**, not merge keys.

**What this builds:** a separate **`identity_keys[]`** column, exempt from the uniqueness trigger and from upsert-merge.

| Field | Means | Column | Merges? |
|---|---|---|---|
| `identityKey` (singular) | "this record **is** this entity" | `keys[]` | yes — entity resolution |
| `identityKeys` (plural, #128) | "this record **involves** these people" | **`identity_keys[]`** | **no** |

`mem find-by-key` queries the **union** of both, so it finds the merged contact *and* the separate threads.

---

## What's in it

**#128 — engine.** New `identity_keys TEXT[]` column (GIN-indexed), additive `ALTER … IF NOT EXISTS`, `SCHEMA_VERSION` → **2.3.1**. Threaded through both `mem_upsert_by_keys` variants — the overlap-merge lookup still reads `keys` only, so `identity_keys` never triggers a merge. Resolver supports `[]` wildcards and a `[name=From]` filter; `email`-prefixed values are email-extracted.

**#129 / #130 — built-in profiles.** `gmail/gmailThreads` (every From/To/Cc across the thread), `google-calendar/events` (organizer + attendees), `fathom/meetings` (host + invitees).

**#131 — `one mem find-by-key <key> [secondKey]`.** Records sharing an identity key, grouped by type. `--type`, `--limit`, agent JSON `{keys, total, truncated, fetchCap, perTypeLimit, byType}`. Two keys → intersection. Named `find-by-key` (mirrors `find-by-source`) because **`mem linked` is already taken** by the relation-graph command.

---

## Review round — what changed since the first push

@moekatib's review found 4 issues; all 4 were confirmed, and verifying them surfaced more. Full detail is in the resolved threads.

**Blockers fixed**
- **Committed conflict markers** in `package.json`/`package-lock.json` made both invalid JSON. Resolved to **1.51.0** — *not* the suggested 1.47.12, which is behind main's published 1.50.0 and would have moved npm's `latest` tag backwards past the v1.48/1.49/1.50 fixes.
- **`SCHEMA_VERSION` collided with main's `2.2.0`.** Both branches picked the same literal for different schemas, so git auto-merged it with **no conflict marker**, and #171's version-equality fast path would then skip the `identity_keys` DDL on every v1.49/v1.50 store — failing *every* memory write with `column "identity_keys" does not exist` while `mem doctor` reported healthy. Now 2.3.1, and the fast path also probes for the column so a forgotten bump can't skip additive DDL again.
- **`identity_keys` were wiped on every sync after the first.** gmail resolves participants from enrich-only fields, but the list phase writes unconditionally with `replace: true` and NULL meant "clear"; enrich only revisits `_enriched_at IS NULL` rows. Now three-state: **NULL keeps, `[]` clears, non-empty replaces**.
- **The same list-phase write also reverted `data`** from the enriched shape to the thin list shape — pre-existing on main, fixed here. A pre-enrich write is now non-authoritative: `data` merges, `searchable_text`/`content_hash` are preserved. It still *writes* rather than skipping, deliberately — the upsert is also the un-archive self-heal and the only path that re-creates a row whose memory record was lost while the SQLite mirror survived.

**Correctness**
- **Singular `identityKey` fanned out into multiple merge keys** (comma-list email, `[]` path). Overlapping one row overwrote its `data`; overlapping two raised `unique_violation` that the writer's bare `catch` swallowed into `skipped`. Now at most one key, **zero on a fan-out** (first-match still destroys the first-matched entity), and `sync test` warns loudly.
- Email extraction is **additive** again — `emailDomain`, `email_id`, `jane@localhost` no longer vanish. Dot-numeric paths resolve again.
- The old scalar rule was inlined in **four** places, so `mem migrate` wrote `email:jane smith <j@x.com>` where sync wrote `email:j@x.com` and the two never merged. All four share one helper now.
- **`CREATE OR REPLACE` can't change an argument list**, so adding `p_identity_keys` created a *second* `mem_upsert_by_keys`; upgraded stores held both and 11-arg calls failed `42725`. The old signature is dropped first.
- **`findByKeys` could use neither GIN index** — added a bare-column `&&` prefilter AND-ed with the exact recheck (~34x on 40k rows).
- **`mem import` silently dropped `identity_keys`** — destructive on restore into an empty store, which is what the guide recommends export/import for.
- **`find-by-key` never forwarded a limit**, so the 2000 cap applied globally after `ORDER BY type` and whole types vanished silently. Now reports `truncated`/`fetchCap`. Query keys are lowercased to match how they're written.
- `identityKeys` prefixes are normalized/validated so `Email` can't strand keys in a namespace lookup never searches.

**Naming.** `mem key` edits `keys[]` but was described as managing "identity keys" — now the opposite of what that phrase means. An agent following that would attach a participant to the merge column and collapse the record. `keys[]` is **"merge keys"** everywhere now.

**Docs.** README and `skills/one/SKILL.md` were untouched by the original push; both now document `find-by-key` and `identityKeys`, as does `guide memory` (the first push had only updated `guide sync`). Agent-mode JSON shape documented and verified against the implementation.

---

## Tests

**358 → 378**, typecheck + build clean, `npm ci` clean.

The previous suite was **mutation-proven inadequate**: re-introducing the literal #128 bug (participant emails back into `keys[]`) left all 320 tests green, and no test anywhere exercised an *upgrade* — every one started from a fresh store, which is exactly why the schema-version collision would have shipped. Added: writer-level column-routing, a schema upgrade-path test, export/import round-trip, fan-out guards, and the enrich-preservation suite (mutation-checked three ways).

Also adds `tsx` to devDependencies — `npm test` invoked `tsx --test` without declaring it, so the suite couldn't run from a clean clone.

## Verified on a real store

Built a genuine **v1.50.0** `embedded-postgres` store, then upgraded in place: `2.2.0 → 2.3.1`, `identity_keys` added, exactly **1** `mem_upsert_by_keys` overload, pre-existing rows intact, `mem doctor` green. Confirmed the two-run enrich sequence preserves both `identity_keys` and the enriched `data`, and that export → fresh store → import round-trips. The headline property, end to end:

```
type: gmail/gmailThreads   keys: [gmail/gmailThreads:T1]   identity_keys: [jane, bob]
type: note                 keys: [email:bob@acme.com]      identity_keys: null
```

Two records sharing `email:bob@acme.com` that did **not** merge — and `find-by-key` returns both.

## Known gaps (pre-existing, now documented)

- `--full-refresh` does not clear `_enriched_at`, so it never re-enriches; there is no way to refresh a record whose upstream *detail* content changed. Clearing the stamp re-fans-out the whole detail endpoint, so it isn't a safe drive-by — worth its own issue.
- `--no-memory` doesn't stop the enrich phase from mirroring into memory. Pinned by a test named `PRE-EXISTING GAP: …` so it can't drift unnoticed.
- No non-PGlite backend has automated coverage; `embedded-postgres` and `postgres` share all this SQL via `CoreBackend` but have no tests of their own. The upgrade path above was exercised by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
