### PR TITLE
feat: one listen — stream webhooks to a local endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,18 @@ one relay deliveries --endpoint-id <id>    # Check delivery status
 
 Start with `one relay platforms` to discover which platforms support relay at all, then drill into `event-types <platform>` for the specific events. Run `one guide relay` for the full reference including `--metadata` requirements per platform.
 
+### `one listen`
+
+Stream webhook events straight to a local endpoint while you develop — like `stripe listen`, but for every platform One relays plus One's own subscription events. No public URL or tunnel needed: the CLI holds the connection and forwards to your machine, so nothing on the server ever reaches `localhost`.
+
+```bash
+one listen --forward-to http://localhost:4242/webhook          # relay + subscription events
+one listen --forward-to http://localhost:4242/webhook --source relay
+one listen --forward-to http://localhost:4242/webhook --events customer.created,invoice.paid
+```
+
+Each event is POSTed to your endpoint with its **original raw body and headers** (including the signature), so your handler verifies exactly as it would in production. Delivery is best-effort — if the CLI isn't running the event isn't forwarded (your durable webhook endpoints are unaffected) — so it's a dev tool, never a production consumer.
+
 ### `one guide [topic]`
 
 Get the full CLI usage guide, designed for AI agents that only have the binary (no MCP, no IDE skills).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "@withone/cli",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.48.0",
+      "version": "1.49.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",
         "open": "^10.1.0",
         "pgserve": "2.2.3",
         "picocolors": "^1.1.1",
-        "smol-toml": "^1.6.0"
+        "smol-toml": "^1.6.0",
+        "ws": "^8.18.0"
       },
       "bin": {
         "one": "bin/cli.js"
@@ -22,6 +23,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.13.1",
         "@types/pg": "^8.20.0",
+        "@types/ws": "^8.5.13",
         "tsup": "^8.3.6",
         "typescript": "^5.7.3"
       },
@@ -1154,6 +1156,16 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/acorn": {
@@ -2683,6 +2695,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [
@@ -32,7 +32,8 @@
     "open": "^10.1.0",
     "pgserve": "2.2.3",
     "picocolors": "^1.1.1",
-    "smol-toml": "^1.6.0"
+    "smol-toml": "^1.6.0",
+    "ws": "^8.18.0"
   },
   "optionalDependencies": {
     "@electric-sql/pglite": "^0.2.17",
@@ -43,6 +44,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.13.1",
     "@types/pg": "^8.20.0",
+    "@types/ws": "^8.5.13",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3"
   },

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -126,6 +126,17 @@ one --agent actions execute --parallel \
 
 All segments are validated before any execution. Failed actions don't block others. Use `--max-concurrency <n>` (default 5) to control batching. Agent-mode output: `{"parallel":true,"results":[...],"succeeded":N,"failed":N,"totalDurationMs":N}`. Each result carries `"_preflight":{"cache":"hit"|"miss"}` showing whether that action's details were served from cache.
 
+## Local webhook testing (`one listen`)
+
+Stream webhook events to a local endpoint while developing, like `stripe listen`:
+
+```bash
+one listen --forward-to http://localhost:4242/webhook            # relay + subscription events
+one listen --forward-to http://localhost:4242/webhook --source relay --events customer.created,invoice.paid
+```
+
+Events POST to the local URL with their original raw body + headers (signature intact), so a handler verifies as in production. Best-effort (no retries) — a dev tool, not a durable consumer. `--agent` emits one JSON line per event/status/error.
+
 ## Error Handling
 
 All errors return JSON: `{"error": "message"}`. Parse output as JSON and check for the `error` key.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,7 @@ import { guideCommand } from './commands/guide.js';
 import { onboardCommand } from './commands/onboard.js';
 import { loginCommand } from './commands/login.js';
 import { logoutCommand } from './commands/logout.js';
+import { listenCommand } from './commands/listen.js';
 import { updateCommand, checkLatestVersionCached, getCurrentVersion, isNewerVersion, autoUpdate } from './commands/update.js';
 import { closeBackendIfCached } from './lib/memory/runtime.js';
 import { setAgentMode, isAgentMode, json as outputJson, error as outputError, silenceWarningsInAgentMode } from './lib/output.js';
@@ -127,6 +128,7 @@ program
     one relay event-types <platform>      List supported event types
     one relay events                      List received webhook events
     one relay deliveries                  List delivery attempts
+    one listen --forward-to <url>         Stream webhook events to a local endpoint (like \`stripe listen\`)
 
   Example — send an email through Gmail:
     $ one list
@@ -224,6 +226,16 @@ program
   .description('Clear local credentials')
   .action(async () => {
     await logoutCommand();
+  });
+
+program
+  .command('listen')
+  .description('Stream webhook events to a local endpoint (like `stripe listen`)')
+  .requiredOption('--forward-to <url>', 'Local URL to POST events to (e.g. http://localhost:4242/webhook)')
+  .option('--source <source>', 'Which events to stream: relay, subscriptions, or both', 'both')
+  .option('--events <types>', 'Comma-separated event-type filter (e.g. customer.created,invoice.paid)')
+  .action(async (options: { forwardTo: string; source?: string; events?: string }) => {
+    await listenCommand(options);
   });
 
 const config = program

--- a/src/commands/listen.ts
+++ b/src/commands/listen.ts
@@ -1,0 +1,90 @@
+import pc from 'picocolors';
+import { getApiBase, getApiKey } from '../lib/config.js';
+import { ListenClient, type ListenStatus } from '../lib/listen-client.js';
+import { resolveListenTarget } from '../lib/listen.js';
+import { createOneSocketFactory } from '../lib/listen-socket.js';
+import * as output from '../lib/output.js';
+
+export async function listenCommand(options: {
+  forwardTo?: string;
+  source?: string;
+  events?: string;
+}): Promise<void> {
+  const apiKey = getApiKey();
+  const resolved = resolveListenTarget(options, { apiKey, apiBase: getApiBase() });
+  if (!resolved.ok) {
+    output.error(resolved.error);
+  }
+  const { url, forwardTo, source } = resolved.target;
+
+  const agent = output.isAgentMode();
+
+  let resolveDone: () => void = () => {};
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const client = new ListenClient({
+    url,
+    forwardTo,
+    createSocket: createOneSocketFactory(apiKey as string),
+    onStatus: (status: ListenStatus) => {
+      if (status === 'closed') resolveDone();
+      if (agent) {
+        output.json({ event: 'status', status });
+        return;
+      }
+      if (status === 'open') {
+        console.log(pc.green(`  Ready — forwarding ${source} events to ${forwardTo}\n`));
+      } else if (status === 'reconnecting') {
+        console.log(pc.yellow('  Connection lost — reconnecting…'));
+      }
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (agent) {
+        output.json({ event: 'error', message });
+      } else {
+        console.log(pc.red(`  Connection error: ${message}`));
+      }
+    },
+    onReady: (sessionId, scope) => {
+      if (agent) {
+        output.json({ event: 'ready', sessionId, scope });
+      } else {
+        console.log(pc.dim(`  Session ${sessionId}${scope ? ` · ${scope}` : ''}`));
+      }
+    },
+    onEvent: (event, response) => {
+      if (agent) {
+        output.json({ event: 'forwarded', id: event.id, type: event.eventType, source: event.source, status: response.status });
+        return;
+      }
+      const label = event.platform ? `${event.platform} ${event.eventType ?? ''}`.trim() : event.eventType ?? event.source;
+      const code =
+        response.status === 0
+          ? pc.red('unreachable')
+          : response.status < 400
+            ? pc.green(String(response.status))
+            : pc.red(String(response.status));
+      console.log(`  ${pc.dim(new Date().toLocaleTimeString())}  ${pc.cyan(label)}  →  ${code}`);
+    },
+  });
+
+  if (!agent) {
+    output.intro('one listen');
+    console.log(pc.dim(`  Streaming ${source} events → ${forwardTo}`));
+    console.log(pc.dim('  Local delivery is best-effort (no retries); Press Ctrl-C to stop.\n'));
+  }
+
+  const shutdown = () => {
+    client.stop();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  client.start();
+  await done;
+  output.error('Listen connection closed — check your API key and that the listen endpoint is reachable.');
+}

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -111,6 +111,13 @@ one --agent relay deliveries --endpoint-id <id>                 # Check delivery
 - \`--create-webhook\` auto-registers the webhook URL with the source platform
 - Use \`actions knowledge\` to learn both the incoming payload shape AND the destination API shape before building templates
 
+**Test webhooks locally (\`one listen\`):** stream events to a local endpoint while developing, like \`stripe listen\` — no public URL or tunnel.
+\`\`\`bash
+one listen --forward-to http://localhost:4242/webhook            # relay + subscription events
+one listen --forward-to http://localhost:4242/webhook --source relay --events customer.created
+\`\`\`
+Events arrive with their original raw body + headers (signature intact). Best-effort only — a dev tool, not a production consumer.
+
 ### 4. Memory + Sync — Unified store with hybrid FTS + semantic search
 One ships a local memory store (a real Postgres process bootstrapped on demand via the bundled \`embedded-postgres\` plugin, with a \`postgres\` plugin for remote/self-hosted) that backs both user-authored notes (\`one mem add\`) and synced platform data (\`one sync run\`). Auto-initializes on first use — no separate install step. Run \`one guide memory\` and \`one guide sync\` for the full references.
 

--- a/src/lib/listen-client.test.ts
+++ b/src/lib/listen-client.test.ts
@@ -1,0 +1,218 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ListenClient, computeBackoff, type Socket } from './listen-client.js';
+
+class FakeSocket implements Socket {
+  sent: string[] = [];
+  closed = false;
+  failSend = false;
+  private handlers: Record<string, ((arg?: any) => void) | undefined> = {};
+  send(data: string) {
+    if (this.failSend) throw new Error('WebSocket is not open');
+    this.sent.push(data);
+  }
+  close() {
+    this.closed = true;
+    this.handlers.close?.();
+  }
+  onOpen(h: () => void) {
+    this.handlers.open = h;
+  }
+  onMessage(h: (d: string) => void) {
+    this.handlers.message = h;
+  }
+  onClose(h: () => void) {
+    this.handlers.close = h;
+  }
+  onError(h: (e: unknown) => void) {
+    this.handlers.error = h;
+  }
+  emitOpen() {
+    this.handlers.open?.();
+  }
+  async emitMessage(d: string) {
+    await this.handlers.message?.(d);
+  }
+  emitClose() {
+    this.handlers.close?.();
+  }
+  emitError(error: unknown) {
+    this.handlers.error?.(error);
+  }
+}
+
+const okFetch = (async () =>
+  ({ status: 200, text: async () => 'ok', headers: new Headers() }) as unknown as Response) as typeof fetch;
+
+const eventMessage = JSON.stringify({
+  type: 'event',
+  conversationId: 'c1',
+  event: {
+    source: 'relay',
+    id: 'evt_1',
+    eventType: 'customer.created',
+    platform: 'stripe',
+    timestamp: '2026-07-05T00:00:00Z',
+    body: '{"a":1}',
+    headers: {},
+  },
+});
+
+describe('ListenClient', () => {
+  it('reports status transitions from connecting to open', () => {
+    const statuses: string[] = [];
+    const socket = new FakeSocket();
+    const client = new ListenClient({
+      url: 'wss://x',
+      forwardTo: 'http://localhost/x',
+      createSocket: () => socket,
+      onStatus: (s) => statuses.push(s),
+    });
+    client.start();
+    assert.deepEqual(statuses, ['connecting']);
+    socket.emitOpen();
+    assert.deepEqual(statuses, ['connecting', 'open']);
+  });
+
+  it('forwards an event message and sends response then ack over the socket', async () => {
+    const socket = new FakeSocket();
+    const client = new ListenClient({
+      url: 'wss://x',
+      forwardTo: 'http://localhost/x',
+      createSocket: () => socket,
+      fetchImpl: okFetch,
+    });
+    client.start();
+    socket.emitOpen();
+    await socket.emitMessage(eventMessage);
+    assert.equal(socket.sent.length, 2);
+    assert.equal(JSON.parse(socket.sent[0]).type, 'response');
+    assert.equal(JSON.parse(socket.sent[1]).type, 'event_ack');
+  });
+
+  it('reconnects after an unexpected close', async () => {
+    let created = 0;
+    const client = new ListenClient({
+      url: 'wss://x',
+      forwardTo: 'http://localhost/x',
+      reconnectDelayMs: 0,
+      createSocket: () => {
+        created++;
+        return new FakeSocket();
+      },
+    });
+    client.start();
+    assert.equal(created, 1);
+    const socket = (client as unknown as { socket: FakeSocket }).socket;
+    socket.emitOpen();
+    socket.emitClose();
+    await new Promise((r) => setTimeout(r, 5));
+    assert.equal(created, 2);
+  });
+
+  it('surfaces the error and stops (no reconnect loop) when the handshake fails', async () => {
+    let created = 0;
+    const statuses: string[] = [];
+    const errors: unknown[] = [];
+    const client = new ListenClient({
+      url: 'wss://x',
+      forwardTo: 'http://localhost/x',
+      reconnectDelayMs: 0,
+      createSocket: () => {
+        created++;
+        return new FakeSocket();
+      },
+      onStatus: (s) => statuses.push(s),
+      onError: (e) => errors.push(e),
+    });
+    client.start();
+    const socket = (client as unknown as { socket: FakeSocket }).socket;
+    socket.emitError(new Error('Unexpected server response: 401'));
+    socket.emitClose();
+    await new Promise((r) => setTimeout(r, 5));
+    assert.equal(created, 1);
+    assert.equal(errors.length, 1);
+    assert.ok(statuses.includes('closed'));
+  });
+
+  it('sends the reply on the socket that received the event, even across a reconnect', async () => {
+    const sockets: FakeSocket[] = [];
+    let releaseFetch: () => void = () => {};
+    const slowFetch = (async () => {
+      await new Promise<void>((resolve) => {
+        releaseFetch = resolve;
+      });
+      return { status: 200, text: async () => 'ok', headers: new Headers() } as unknown as Response;
+    }) as typeof fetch;
+
+    const client = new ListenClient({
+      url: 'wss://x',
+      forwardTo: 'http://localhost/x',
+      reconnectDelayMs: 0,
+      fetchImpl: slowFetch,
+      createSocket: () => {
+        const s = new FakeSocket();
+        sockets.push(s);
+        return s;
+      },
+    });
+    client.start();
+    sockets[0].emitOpen();
+
+    const forwarding = sockets[0].emitMessage(eventMessage);
+    sockets[0].emitClose();
+    await new Promise((r) => setTimeout(r, 5));
+    assert.equal(sockets.length, 2);
+
+    releaseFetch();
+    await forwarding;
+
+    assert.equal(sockets[0].sent.length, 2);
+    assert.equal(sockets[1].sent.length, 0);
+  });
+
+  it('survives a send on a socket that closed mid-forward', async () => {
+    const socket = new FakeSocket();
+    socket.failSend = true;
+    const client = new ListenClient({
+      url: 'wss://x',
+      forwardTo: 'http://localhost/x',
+      createSocket: () => socket,
+      fetchImpl: okFetch,
+    });
+    client.start();
+    socket.emitOpen();
+    await socket.emitMessage(eventMessage);
+    assert.equal(socket.sent.length, 0);
+  });
+
+  it('does not reconnect after stop()', async () => {
+    let created = 0;
+    const statuses: string[] = [];
+    const client = new ListenClient({
+      url: 'wss://x',
+      forwardTo: 'http://localhost/x',
+      reconnectDelayMs: 0,
+      createSocket: () => {
+        created++;
+        return new FakeSocket();
+      },
+      onStatus: (s) => statuses.push(s),
+    });
+    client.start();
+    client.stop();
+    await new Promise((r) => setTimeout(r, 5));
+    assert.equal(created, 1);
+    assert.ok(statuses.includes('closed'));
+  });
+});
+
+describe('computeBackoff', () => {
+  it('grows exponentially and caps', () => {
+    assert.equal(computeBackoff(0, 1000, 30000), 1000);
+    assert.equal(computeBackoff(1, 1000, 30000), 2000);
+    assert.equal(computeBackoff(2, 1000, 30000), 4000);
+    assert.equal(computeBackoff(5, 1000, 30000), 30000);
+    assert.equal(computeBackoff(20, 1000, 30000), 30000);
+  });
+});

--- a/src/lib/listen-client.ts
+++ b/src/lib/listen-client.ts
@@ -1,0 +1,111 @@
+import { handleServerMessage, type ForwardResult } from './listen.js';
+import type { ListenEvent, ServerMessage } from './listen-protocol.js';
+
+// The minimal socket the client depends on. The real implementation wraps the
+// `ws` package (for header auth); tests inject a fake, so nothing here touches
+// the network or requires `ws`.
+export interface Socket {
+  send(data: string): void;
+  close(): void;
+  onOpen(handler: () => void): void;
+  onMessage(handler: (data: string) => void): void;
+  onClose(handler: () => void): void;
+  onError(handler: (error: unknown) => void): void;
+}
+
+export type SocketFactory = (url: string) => Socket;
+
+export type ListenStatus = 'connecting' | 'open' | 'reconnecting' | 'closed';
+
+/** Exponential backoff in ms, capped. */
+export function computeBackoff(attempt: number, baseMs: number, capMs: number): number {
+  return Math.min(baseMs * 2 ** attempt, capMs);
+}
+
+export interface ListenClientConfig {
+  url: string;
+  forwardTo: string;
+  createSocket: SocketFactory;
+  fetchImpl?: typeof fetch;
+  reconnectDelayMs?: number;
+  reconnectCapMs?: number;
+  onReady?: (sessionId: string, scope: string) => void;
+  onEvent?: (event: ListenEvent, response: ForwardResult['response']) => void;
+  onStatus?: (status: ListenStatus) => void;
+  onError?: (error: unknown) => void;
+}
+
+export class ListenClient {
+  private socket?: Socket;
+  private stopped = false;
+  private opened = false;
+  private reconnectAttempts = 0;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(private readonly config: ListenClientConfig) {}
+
+  start(): void {
+    this.stopped = false;
+    this.connect();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.socket?.close();
+    this.config.onStatus?.('closed');
+  }
+
+  private connect(): void {
+    this.config.onStatus?.('connecting');
+    const socket = this.config.createSocket(this.config.url);
+    this.socket = socket;
+    socket.onOpen(() => {
+      this.opened = true;
+      this.reconnectAttempts = 0;
+      this.config.onStatus?.('open');
+    });
+    socket.onMessage((data) => this.onMessage(socket, data));
+    socket.onError((error) => this.config.onError?.(error));
+    socket.onClose(() => this.onClose());
+  }
+
+  // `socket` is bound to the connection the message arrived on, so a reply for
+  // an event received before a reconnect isn't acked on the new session.
+  private async onMessage(socket: Socket, data: string): Promise<void> {
+    let message: ServerMessage;
+    try {
+      message = JSON.parse(data) as ServerMessage;
+    } catch {
+      return;
+    }
+    await handleServerMessage(message, {
+      forwardTo: this.config.forwardTo,
+      fetchImpl: this.config.fetchImpl,
+      send: (m) => {
+        try {
+          socket.send(JSON.stringify(m));
+        } catch {
+          // Socket closed mid-forward; best-effort, redelivers on reconnect.
+        }
+      },
+      onReady: this.config.onReady,
+      onEvent: this.config.onEvent,
+    });
+  }
+
+  private onClose(): void {
+    if (this.stopped) return;
+    // A failure before we ever opened is almost always config/auth (bad key,
+    // wrong base, 401) — already surfaced via `onError`; stop, don't loop.
+    if (!this.opened) {
+      this.stopped = true;
+      this.config.onStatus?.('closed');
+      return;
+    }
+    this.config.onStatus?.('reconnecting');
+    const delay = computeBackoff(this.reconnectAttempts, this.config.reconnectDelayMs ?? 1000, this.config.reconnectCapMs ?? 30000);
+    this.reconnectAttempts += 1;
+    this.reconnectTimer = setTimeout(() => this.connect(), delay);
+  }
+}

--- a/src/lib/listen-protocol.ts
+++ b/src/lib/listen-protocol.ts
@@ -1,0 +1,47 @@
+// The `one listen` WebSocket contract. The CLI and the server both speak these
+// messages; keep them in sync with the server-side definition.
+//
+// Modeled on the Stripe CLI's websocket protocol: the server pushes `event`
+// messages, the CLI forwards each to the local endpoint and replies with a
+// `response` (the local endpoint's answer) plus an `event_ack`.
+
+/** Which One stream an event came from. */
+export type ListenSource = 'relay' | 'subscription';
+
+/** A single event pushed to the CLI to forward locally. */
+export interface ListenEvent {
+  /** Whether this is an inbound relay (platform) event or a One subscription event. */
+  source: ListenSource;
+  /** Stable event id — used for the ack and for local deduplication. */
+  id: string;
+  /** Dotted event type (e.g. `customer.created`, `connection.created`); null when unknown. */
+  eventType: string | null;
+  /** Source platform for relay events (e.g. `stripe`); absent for subscription events. */
+  platform?: string;
+  /** RFC 3339 timestamp of when One received/emitted the event. */
+  timestamp: string;
+  /**
+   * The exact raw request body One received/signed, as a string. Replayed to
+   * the local endpoint byte-for-byte — never re-serialized — so a signature
+   * over the raw body (Stripe et al.) still verifies locally.
+   */
+  body: string;
+  /** Headers to replay to the local endpoint, including any signature header. */
+  headers: Record<string, string>;
+}
+
+/** Messages the server pushes to the CLI. */
+export type ServerMessage =
+  | { type: 'ready'; sessionId: string; scope: string }
+  | { type: 'event'; conversationId: string; event: ListenEvent };
+
+/** Messages the CLI sends back to the server. */
+export type ClientMessage =
+  | { type: 'event_ack'; conversationId: string; eventId: string }
+  | {
+      type: 'response';
+      conversationId: string;
+      status: number;
+      body: string;
+      headers: Record<string, string>;
+    };

--- a/src/lib/listen-socket.test.ts
+++ b/src/lib/listen-socket.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { AddressInfo } from 'node:net';
+import { WebSocketServer, type WebSocket as WsSocket } from 'ws';
+import { ListenClient } from './listen-client.js';
+import { createOneSocketFactory } from './listen-socket.js';
+
+describe('createOneSocketFactory (integration)', () => {
+  it('connects with the secret header, forwards an event, and replies over the real socket', async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve) => wss.once('listening', () => resolve()));
+    const { port } = wss.address() as AddressInfo;
+
+    let authHeader: string | undefined;
+    const serverReceived: Array<{ type: string }> = [];
+    const gotReplies = new Promise<void>((resolve) => {
+      wss.on('connection', (socket: WsSocket, req) => {
+        authHeader = req.headers['x-one-secret'] as string | undefined;
+        socket.on('message', (data) => {
+          serverReceived.push(JSON.parse(data.toString()));
+          if (serverReceived.length === 2) resolve();
+        });
+        socket.send(
+          JSON.stringify({
+            type: 'event',
+            conversationId: 'c1',
+            event: {
+              source: 'relay',
+              id: 'evt_1',
+              eventType: 'customer.created',
+              platform: 'stripe',
+              timestamp: '2026-07-05T00:00:00Z',
+              body: '{"a":1}',
+              headers: {},
+            },
+          }),
+        );
+      });
+    });
+
+    const forwarded: Array<{ init: any }> = [];
+    const fakeFetch = (async (_url: string, init: any) => {
+      forwarded.push({ init });
+      return { status: 200, text: async () => 'ok', headers: new Headers() } as unknown as Response;
+    }) as typeof fetch;
+
+    const client = new ListenClient({
+      url: `ws://127.0.0.1:${port}`,
+      forwardTo: 'http://localhost:9/hook',
+      createSocket: createOneSocketFactory('sk_test_123'),
+      fetchImpl: fakeFetch,
+    });
+    client.start();
+
+    await gotReplies;
+    client.stop();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+
+    assert.equal(authHeader, 'sk_test_123');
+    assert.equal(forwarded.length, 1);
+    assert.equal(forwarded[0].init.body, '{"a":1}');
+    assert.deepEqual(
+      serverReceived.map((m) => m.type).sort(),
+      ['event_ack', 'response'],
+    );
+  });
+});

--- a/src/lib/listen-socket.ts
+++ b/src/lib/listen-socket.ts
@@ -1,0 +1,21 @@
+import WebSocket, { type RawData } from 'ws';
+import type { Socket, SocketFactory } from './listen-client.js';
+
+// Production socket factory: opens an authenticated `ws` connection — the One
+// secret key rides in the `X-One-Secret` header, matching the rest of the API —
+// and adapts it to the minimal `Socket` interface the client depends on. This
+// is the only place the `ws` package is imported; the client and its tests stay
+// dependency-free.
+export function createOneSocketFactory(apiKey: string): SocketFactory {
+  return (url: string): Socket => {
+    const ws = new WebSocket(url, { headers: { 'X-One-Secret': apiKey } });
+    return {
+      send: (data) => ws.send(data),
+      close: () => ws.close(),
+      onOpen: (handler) => ws.on('open', handler),
+      onMessage: (handler) => ws.on('message', (data: RawData) => handler(data.toString())),
+      onClose: (handler) => ws.on('close', handler),
+      onError: (handler) => ws.on('error', handler),
+    };
+  };
+}

--- a/src/lib/listen.test.ts
+++ b/src/lib/listen.test.ts
@@ -1,0 +1,209 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildListenUrl, forwardEvent, handleServerMessage, resolveListenTarget } from './listen.js';
+import type { ClientMessage, ListenEvent } from './listen-protocol.js';
+
+const okFetch = (async () =>
+  ({ status: 200, text: async () => 'ok', headers: new Headers() }) as unknown as Response) as typeof fetch;
+
+const sampleEvent: ListenEvent = {
+  source: 'relay',
+  id: 'evt_1',
+  eventType: 'customer.created',
+  platform: 'stripe',
+  timestamp: '2026-07-05T00:00:00Z',
+  body: '{"hello":"world"}',
+  headers: { 'stripe-signature': 't=1,v1=abc' },
+};
+
+describe('forwardEvent', () => {
+  it('POSTs the payload + replayed headers and returns an ack and the local response', async () => {
+    const calls: Array<{ url: string; init: any }> = [];
+    const fakeFetch = async (url: string, init: any) => {
+      calls.push({ url, init });
+      return {
+        status: 202,
+        text: async () => 'accepted',
+        headers: new Headers({ 'x-app': 'yes' }),
+      } as unknown as Response;
+    };
+
+    const result = await forwardEvent(sampleEvent, 'conv_1', 'http://localhost:4242/hook', fakeFetch as typeof fetch);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'http://localhost:4242/hook');
+    assert.equal(calls[0].init.method, 'POST');
+    assert.equal(calls[0].init.body, '{"hello":"world"}');
+    assert.equal(calls[0].init.headers['stripe-signature'], 't=1,v1=abc');
+    assert.equal(calls[0].init.headers['content-type'], 'application/json');
+
+    assert.deepEqual(result.ack, { type: 'event_ack', conversationId: 'conv_1', eventId: 'evt_1' });
+    assert.equal(result.response.type, 'response');
+    assert.equal(result.response.status, 202);
+    assert.equal(result.response.body, 'accepted');
+    assert.equal(result.response.conversationId, 'conv_1');
+  });
+
+  it('replays the original content-type without duplicating it (any casing)', async () => {
+    const calls: Array<{ init: any }> = [];
+    const fakeFetch = async (_url: string, init: any) => {
+      calls.push({ init });
+      return { status: 200, text: async () => '', headers: new Headers() } as unknown as Response;
+    };
+    const event = {
+      ...sampleEvent,
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'stripe-signature': 'x' },
+    };
+    await forwardEvent(event, 'c', 'http://localhost/x', fakeFetch as typeof fetch);
+    const ctKeys = Object.keys(calls[0].init.headers).filter((k) => k.toLowerCase() === 'content-type');
+    assert.equal(ctKeys.length, 1);
+    assert.equal(calls[0].init.headers[ctKeys[0]], 'application/x-www-form-urlencoded');
+  });
+
+  it('defaults content-type to application/json only when the event has none', async () => {
+    const calls: Array<{ init: any }> = [];
+    const fakeFetch = async (_url: string, init: any) => {
+      calls.push({ init });
+      return { status: 200, text: async () => '', headers: new Headers() } as unknown as Response;
+    };
+    await forwardEvent(
+      { ...sampleEvent, headers: { 'stripe-signature': 'x' } },
+      'c',
+      'http://localhost/x',
+      fakeFetch as typeof fetch,
+    );
+    assert.equal(calls[0].init.headers['content-type'], 'application/json');
+  });
+
+  it('strips hop-by-hop transport headers before replaying, keeping the signature', async () => {
+    const calls: Array<{ init: any }> = [];
+    const fakeFetch = async (_url: string, init: any) => {
+      calls.push({ init });
+      return { status: 200, text: async () => '', headers: new Headers() } as unknown as Response;
+    };
+    const event = {
+      ...sampleEvent,
+      headers: {
+        Host: 'evil.internal',
+        'Content-Length': '999',
+        Connection: 'keep-alive',
+        'Transfer-Encoding': 'chunked',
+        'stripe-signature': 'sig',
+      },
+    };
+    await forwardEvent(event, 'c', 'http://localhost/x', fakeFetch as typeof fetch);
+    const keys = Object.keys(calls[0].init.headers as Record<string, string>).map((k) => k.toLowerCase());
+    assert.ok(!keys.includes('host'), 'host must be stripped');
+    assert.ok(!keys.includes('content-length'), 'content-length must be stripped');
+    assert.ok(!keys.includes('connection'), 'connection must be stripped');
+    assert.ok(!keys.includes('transfer-encoding'), 'transfer-encoding must be stripped');
+    assert.equal((calls[0].init.headers as Record<string, string>)['stripe-signature'], 'sig');
+  });
+
+  it('replays the raw body byte-for-byte so a signature over it still verifies', async () => {
+    const calls: Array<{ init: any }> = [];
+    const fakeFetch = async (_url: string, init: any) => {
+      calls.push({ init });
+      return { status: 200, text: async () => '', headers: new Headers() } as unknown as Response;
+    };
+    const raw = '{ "b": 2, "a": 1 }';
+    await forwardEvent({ ...sampleEvent, body: raw }, 'c', 'http://localhost/x', fakeFetch as typeof fetch);
+    assert.equal(calls[0].init.body, raw);
+  });
+
+  it('still acks when the local endpoint is unreachable, reporting a 0 status', async () => {
+    const failingFetch = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    const result = await forwardEvent(sampleEvent, 'conv_2', 'http://localhost:4242/hook', failingFetch as typeof fetch);
+    assert.deepEqual(result.ack, { type: 'event_ack', conversationId: 'conv_2', eventId: 'evt_1' });
+    assert.equal(result.response.status, 0);
+  });
+});
+
+describe('handleServerMessage', () => {
+  it('forwards an event message then sends response and ack', async () => {
+    const sent: ClientMessage[] = [];
+    let seen: ListenEvent | undefined;
+    await handleServerMessage(
+      { type: 'event', conversationId: 'c1', event: sampleEvent },
+      {
+        forwardTo: 'http://localhost/x',
+        fetchImpl: okFetch,
+        send: (m) => sent.push(m),
+        onEvent: (e) => {
+          seen = e;
+        },
+      },
+    );
+    assert.equal(sent.length, 2);
+    assert.equal(sent[0].type, 'response');
+    assert.equal(sent[1].type, 'event_ack');
+    assert.equal(seen?.id, 'evt_1');
+  });
+
+  it('reports the session on a ready message without forwarding', async () => {
+    const sent: ClientMessage[] = [];
+    let ready: { sessionId: string; scope: string } | undefined;
+    await handleServerMessage(
+      { type: 'ready', sessionId: 's1', scope: 'org:123' },
+      {
+        forwardTo: 'http://localhost/x',
+        send: (m) => sent.push(m),
+        onReady: (sessionId, scope) => {
+          ready = { sessionId, scope };
+        },
+      },
+    );
+    assert.equal(sent.length, 0);
+    assert.deepEqual(ready, { sessionId: 's1', scope: 'org:123' });
+  });
+});
+
+describe('buildListenUrl', () => {
+  it('upgrades https to wss and appends the listen path to the versioned base', () => {
+    assert.equal(
+      buildListenUrl('https://api.withone.ai/v1', 'both'),
+      'wss://api.withone.ai/v1/webhooks/listen?source=both',
+    );
+  });
+
+  it('upgrades http to ws for local dev and includes an events filter', () => {
+    assert.equal(
+      buildListenUrl('http://localhost:3000/v1', 'relay', 'customer.created,invoice.paid'),
+      'ws://localhost:3000/v1/webhooks/listen?source=relay&events=customer.created%2Cinvoice.paid',
+    );
+  });
+});
+
+describe('resolveListenTarget', () => {
+  const config = { apiKey: 'sk_test', apiBase: 'https://api.withone.ai/v1' };
+
+  it('errors when not configured', () => {
+    const r = resolveListenTarget({ forwardTo: 'http://localhost/x' }, { apiKey: null, apiBase: config.apiBase });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /Not configured/);
+  });
+
+  it('errors when --forward-to is missing', () => {
+    const r = resolveListenTarget({}, config);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /--forward-to/);
+  });
+
+  it('errors on an invalid --source', () => {
+    const r = resolveListenTarget({ forwardTo: 'http://localhost/x', source: 'bogus' }, config);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /Invalid --source/);
+  });
+
+  it('resolves a valid target with the ws url and the default source', () => {
+    const r = resolveListenTarget({ forwardTo: 'http://localhost:4242/hook' }, config);
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.target.forwardTo, 'http://localhost:4242/hook');
+      assert.equal(r.target.source, 'both');
+      assert.equal(r.target.url, 'wss://api.withone.ai/v1/webhooks/listen?source=both');
+    }
+  });
+});

--- a/src/lib/listen.ts
+++ b/src/lib/listen.ts
@@ -1,0 +1,144 @@
+import type { ClientMessage, ListenEvent, ServerMessage } from './listen-protocol.js';
+
+export interface ForwardResult {
+  ack: Extract<ClientMessage, { type: 'event_ack' }>;
+  response: Extract<ClientMessage, { type: 'response' }>;
+}
+
+export const LISTEN_SOURCES = ['relay', 'subscriptions', 'both'] as const;
+export type ListenSourceOption = (typeof LISTEN_SOURCES)[number];
+
+export interface ListenTarget {
+  url: string;
+  forwardTo: string;
+  source: ListenSourceOption;
+}
+
+export type ResolveListenResult = { ok: true; target: ListenTarget } | { ok: false; error: string };
+
+// Validates options + config into a listen target or a user-facing error. Pure.
+export function resolveListenTarget(
+  options: { forwardTo?: string; source?: string; events?: string },
+  config: { apiKey: string | null; apiBase: string },
+): ResolveListenResult {
+  if (!config.apiKey) {
+    return { ok: false, error: 'Not configured. Run `one init` first.' };
+  }
+  if (!options.forwardTo) {
+    return { ok: false, error: '--forward-to <url> is required (e.g. --forward-to http://localhost:4242/webhook).' };
+  }
+  const source = (options.source ?? 'both').toLowerCase();
+  if (!LISTEN_SOURCES.includes(source as ListenSourceOption)) {
+    return { ok: false, error: `Invalid --source "${source}". Use one of: ${LISTEN_SOURCES.join(', ')}.` };
+  }
+  return {
+    ok: true,
+    target: {
+      url: buildListenUrl(config.apiBase, source, options.events),
+      forwardTo: options.forwardTo,
+      source: source as ListenSourceOption,
+    },
+  };
+}
+
+// API base → listen WebSocket URL (https→wss) with source + optional filter.
+export function buildListenUrl(apiBase: string, source: string, events?: string): string {
+  const url = new URL(apiBase);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/webhooks/listen`;
+  url.search = '';
+  url.searchParams.set('source', source);
+  if (events) url.searchParams.set('events', events);
+  return url.toString();
+}
+
+// Transport headers describing the original connection — replaying a stale
+// `content-length`/`host` corrupts the local request; `fetch` sets its own.
+const STRIPPED_HEADERS = new Set([
+  'host',
+  'content-length',
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'upgrade',
+  'te',
+  'trailer',
+  'proxy-connection',
+  'proxy-authorization',
+]);
+
+// Replays the event's headers minus transport ones, defaulting content-type
+// only when absent (case-insensitive) so signatures + non-JSON bodies survive.
+function buildForwardHeaders(eventHeaders: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = {};
+  let hasContentType = false;
+  for (const [name, value] of Object.entries(eventHeaders)) {
+    const lower = name.toLowerCase();
+    if (STRIPPED_HEADERS.has(lower)) continue;
+    if (lower === 'content-type') hasContentType = true;
+    headers[name] = value;
+  }
+  if (!hasContentType) headers['content-type'] = 'application/json';
+  return headers;
+}
+
+export interface HandlerContext {
+  forwardTo: string;
+  send: (message: ClientMessage) => void;
+  fetchImpl?: typeof fetch;
+  onReady?: (sessionId: string, scope: string) => void;
+  onEvent?: (event: ListenEvent, response: ForwardResult['response']) => void;
+}
+
+// `ready` announces the session; `event` is forwarded, then its response + ack
+// are sent back. Only calls `send`, so it's testable without a live socket.
+export async function handleServerMessage(message: ServerMessage, ctx: HandlerContext): Promise<void> {
+  if (message.type === 'ready') {
+    ctx.onReady?.(message.sessionId, message.scope);
+    return;
+  }
+
+  const { ack, response } = await forwardEvent(message.event, message.conversationId, ctx.forwardTo, ctx.fetchImpl);
+  ctx.send(response);
+  ctx.send(ack);
+  ctx.onEvent?.(message.event, response);
+}
+
+// POSTs the event locally and returns the response + ack to send back. A dead
+// endpoint still acks (status 0) so the stream keeps flowing.
+export async function forwardEvent(
+  event: ListenEvent,
+  conversationId: string,
+  forwardTo: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ForwardResult> {
+  const ack = { type: 'event_ack' as const, conversationId, eventId: event.id };
+
+  try {
+    const res = await fetchImpl(forwardTo, {
+      method: 'POST',
+      headers: buildForwardHeaders(event.headers),
+      body: event.body,
+    });
+    const text = await res.text();
+    const headers: Record<string, string> = {};
+    res.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    return {
+      ack,
+      response: { type: 'response', conversationId, status: res.status, body: text, headers },
+    };
+  } catch (error) {
+    return {
+      ack,
+      response: {
+        type: 'response',
+        conversationId,
+        status: 0,
+        body: error instanceof Error ? error.message : String(error),
+        headers: {},
+      },
+    };
+  }
+}


### PR DESCRIPTION
Adds `one listen` — streams relay + subscription webhooks to a local URL over a WebSocket, like `stripe listen`. No public URL or tunnel.

- Replays each event's raw body + headers (signature intact), so local verification works as in prod.
- Best-effort with auto-reconnect + backoff — a dev tool, not a durable consumer.

Client only; the server WS endpoint is a follow-up. 23 tests.

⚠️ Run a full `npm install` before `npm test`/`build` — the branch was built with optional deps skipped.