### PR TITLE
fix(mem): five memory-subsystem fixes — keys, active-scoped uniqueness, searchable_text, concurrency (v1.49.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,17 @@ One ships a local memory store (a real Postgres process bootstrapped on demand v
 ```bash
 # User memories — works immediately on a new install
 one mem add note '{"content":"Design review is Thursday"}' --tags work --weight 7
+one mem update <id> '{"status":"done"}'              # merges into data; refreshes searchable_text
 one mem search "design review"                       # hybrid FTS + semantic (if key set)
 one mem list note --limit 20
+
+# Identity keys are a first-class column (unique across ACTIVE records; archiving
+# frees them). Manage them after creation with `mem key` — NOT via `mem update`.
+one mem key <id> --add email:x@y.com                 # also --remove / --set <csv>
+
+# Backfill searchable_text for rows that landed NULL or with UUID-noise-heavy text
+# (drops ids/timestamps, leads with name/title/email). No embedding provider needed.
+one mem reindex --searchable --type attio/attioPeople
 
 # Listing synced platform rows — type is positional and namespaced as <platform>/<model>;
 # there is NO --platform flag and NO platform column in the schema.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.48.0",
+      "version": "1.49.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -170,9 +170,18 @@ Underneath, the store has no `platform` column — `type` is the only platform-s
 ```bash
 # User memories
 one --agent mem add note '{"content":"..."}' --tags work --weight 7
+one --agent mem update <id> '{"status":"done"}'         # merges into data; refreshes searchable_text
 one --agent mem search "deadline"                       # hybrid if key set, else FTS
 one --agent mem list note --limit 20
 one --agent mem link <from-id> <to-id> relates_to --bi
+
+# Identity keys (first-class column, NOT data). Unique across ACTIVE records;
+# archiving a record frees its keys. `mem update '{"keys":[...]}'` is rejected.
+one --agent mem key <id> --add email:x@y.com            # add/--remove/--set
+one --agent mem find-by-source email:x@y.com            # prefers the active owner
+
+# Backfill searchable_text (no embedding provider needed) — fixes NULL/noisy text
+one --agent mem reindex --searchable --type attio/attioPeople
 
 # Status + diagnostics
 one --agent mem status                                  # backend, provider, _upgrade hint

--- a/src/commands/mem.ts
+++ b/src/commands/mem.ts
@@ -16,6 +16,7 @@ import {
   memAddCommand,
   memGetCommand,
   memUpdateCommand,
+  memKeyCommand,
   memArchiveCommand,
   memWeightCommand,
   memFlushCommand,
@@ -97,12 +98,14 @@ export function registerMemoryCommands(program: Command): void {
     .action(memVacuumCommand);
 
   mem.command('reindex')
-    .description('Backfill embeddings: re-embed records missing an embedding or under a different model')
+    .description('Backfill embeddings (default) or searchable_text (--searchable)')
     .option('--type <type>', 'Restrict to one record type, e.g. attio/attioPeople')
     .option('--model <name>', 'Override the embedding model')
     .option('--force', 'Re-embed even rows that already have a matching embedding', false)
     .option('--batch <n>', 'OpenAI calls per batch (default 50)', '50')
     .option('--limit <n>', 'Safety cap on total records to scan (default 100000)')
+    .option('--searchable', 'Regenerate searchable_text (NULL or stale vs. data) instead of embeddings', false)
+    .option('--all', 'With --searchable: also rewrite rows whose text is stale, not just NULL', false)
     .action(memReindexCommand);
 
   mem.command('sql <query>')
@@ -125,8 +128,15 @@ export function registerMemoryCommands(program: Command): void {
     .action(memGetCommand);
 
   mem.command('update <id> <patch>')
-    .description('Update a record (patch is JSON merged into data)')
+    .description('Update a record (patch is JSON merged into data; regenerates searchable_text)')
     .action(memUpdateCommand);
+
+  mem.command('key <id>')
+    .description('Manage a record\'s identity keys (unique across active records)')
+    .option('--add <csv>', 'Keys to add (comma-separated, e.g. email:x@y.com)')
+    .option('--remove <csv>', 'Keys to remove (comma-separated)')
+    .option('--set <csv>', 'Replace all keys with this comma-separated list')
+    .action((id: string, flags: { add?: string; remove?: string; set?: string }) => memKeyCommand(id, flags));
 
   mem.command('archive <id>')
     .description('Archive a record')

--- a/src/commands/mem/admin.ts
+++ b/src/commands/mem/admin.ts
@@ -4,7 +4,7 @@
 
 import * as output from '../../lib/output.js';
 import { getBackend } from '../../lib/memory/runtime.js';
-import { embed } from '../../lib/memory/embedding.js';
+import { embed, defaultSearchableText } from '../../lib/memory/embedding.js';
 import { getMemoryConfigOrDefault } from '../../lib/memory/index.js';
 import { okJson, parsePositiveInt, requireMemoryInit } from './util.js';
 
@@ -32,6 +32,10 @@ interface ReindexFlags {
   batch?: string;
   /** Safety cap on total records to process. */
   limit?: string;
+  /** Regenerate searchable_text instead of embeddings. */
+  searchable?: boolean;
+  /** With --searchable: rewrite stale text too, not just NULL. */
+  all?: boolean;
 }
 
 /**
@@ -50,6 +54,11 @@ interface ReindexFlags {
  */
 export async function memReindexCommand(flags: ReindexFlags): Promise<void> {
   requireMemoryInit();
+  // --searchable is a different job: regenerate searchable_text from the
+  // record's own `data`. No embedding provider required.
+  if (flags.searchable) {
+    return memReindexSearchableCommand(flags);
+  }
   const backend = await getBackend();
   const cfg = getMemoryConfigOrDefault();
   if (cfg.embedding.provider !== 'openai') {
@@ -119,5 +128,78 @@ export async function memReindexCommand(flags: ReindexFlags): Promise<void> {
     reembedded,
     skipped,
     force: !!flags.force,
+  });
+}
+
+/**
+ * Backfill `searchable_text` from each record's own `data`. Fixes the
+ * NULL-searchable_text records (agent/SDK writes that never derived it) and
+ * the UUID-noise-leading text on synced records (the improved
+ * `defaultSearchableText` now filters ids/timestamps and leads with
+ * name/title/email fields). Regenerated text also clears the row's stale
+ * embedding so a follow-up `mem reindex` re-embeds against the clean text.
+ *
+ * By default only NULL/empty rows are touched. `--all` additionally
+ * rewrites rows whose stored text is stale vs. what `data` produces now.
+ */
+async function memReindexSearchableCommand(flags: ReindexFlags): Promise<void> {
+  const backend = await getBackend();
+  const onlyNull = !flags.all;
+  const totalCap = flags.limit ? parsePositiveInt(flags.limit, 1_000_000, 'limit') : 1_000_000;
+  const PAGE = 500;
+
+  let considered = 0;
+  let updated = 0;
+  let unchanged = 0;
+  let emptied = 0; // rows whose data yields no usable text — left as-is
+  // `offset` is the count of rows we've decided to LEAVE in place. Updated
+  // rows drop out of the (onlyNull) filter, so the rows we skip accumulate
+  // at the front of the ordered set; advancing offset past them avoids both
+  // the re-scan-forever loop and skipping unprocessed rows.
+  let offset = 0;
+
+  while (considered < totalCap) {
+    const pageSize = Math.min(PAGE, totalCap - considered);
+    const rows = await backend.listForSearchableBackfill({
+      type: flags.type,
+      onlyNull,
+      limit: pageSize,
+      offset,
+    });
+    if (rows.length === 0) break;
+    considered += rows.length;
+
+    let updatedThisPage = 0;
+    for (const r of rows) {
+      const next = defaultSearchableText(r.data);
+      if (!next) { emptied++; continue; }
+      if (next === (r.searchable_text ?? '')) { unchanged++; continue; }
+      await backend.updateSearchableText(r.id, next);
+      updated++;
+      updatedThisPage++;
+    }
+
+    // Advance past the rows that stayed in the result set. In onlyNull mode
+    // updated rows leave the filter (their text is no longer NULL), so only
+    // the skipped rows (emptied/unchanged) still count toward the offset. In
+    // --all mode nothing leaves the set, so advance by the full page.
+    offset += onlyNull ? rows.length - updatedThisPage : rows.length;
+
+    if (!output.isAgentMode()) {
+      process.stderr.write(`  searchable: updated ${updated} / considered ${considered}\r`);
+    }
+  }
+
+  if (!output.isAgentMode()) process.stderr.write('\n');
+
+  okJson({
+    status: 'ok',
+    mode: 'searchable',
+    type: flags.type ?? null,
+    scope: onlyNull ? 'null_only' : 'all',
+    considered,
+    updated,
+    unchanged,
+    emptied,
   });
 }

--- a/src/commands/mem/records.ts
+++ b/src/commands/mem/records.ts
@@ -5,7 +5,7 @@
  */
 
 import * as output from '../../lib/output.js';
-import { getBackend, addRecord } from '../../lib/memory/runtime.js';
+import { getBackend, addRecord, updateRecord } from '../../lib/memory/runtime.js';
 import { embed } from '../../lib/memory/embedding.js';
 import { getMemoryConfigOrDefault } from '../../lib/memory/index.js';
 import { okJson, parseCsv, parseJsonArg, parsePositiveInt, printList, printRecord, requireMemoryInit, semanticSearchUpgradeHint, semanticSearchUpgradeLine } from './util.js';
@@ -48,10 +48,66 @@ export async function memGetCommand(id: string, flags: GetFlags): Promise<void> 
 export async function memUpdateCommand(id: string, patchRaw: string): Promise<void> {
   requireMemoryInit();
   const patch = parseJsonArg(patchRaw, 'patch');
-  const backend = await getBackend();
-  const updated = await backend.update(id, { type: '', data: patch } as Parameters<typeof backend.update>[1]);
+  // The patch is merged into `data`. `keys` is a first-class column, not a
+  // data field — steer callers to `one mem key` instead of silently
+  // burying `{"keys":[...]}` under data.keys where it does nothing.
+  if (patch && typeof patch === 'object' && !Array.isArray(patch) && 'keys' in patch) {
+    output.error('`keys` is not a data field. Use `one mem key <id> --set <csv>` (or --add/--remove) to change a record\'s keys.');
+  }
+  // Route through updateRecord so searchable_text + content_hash are
+  // regenerated from the merged data (backend.update alone leaves them
+  // stale — see runtime.updateRecord).
+  const updated = await updateRecord(id, { data: patch } as Parameters<typeof updateRecord>[1]);
   if (!updated) output.error(`Record ${id} not found`);
   printRecord(updated as unknown as Record<string, unknown>);
+}
+
+interface KeyFlags {
+  add?: string;
+  remove?: string;
+  set?: string;
+}
+
+/**
+ * Manage the `keys` column on an existing record — the first-class,
+ * uniqueness-checked way to change identity keys after creation. Without
+ * this, keys could only be set at insert time (`mem add --keys`), and
+ * `mem update '{"keys":[...]}'` silently wrote them into `data` instead.
+ */
+export async function memKeyCommand(id: string, flags: KeyFlags): Promise<void> {
+  requireMemoryInit();
+  const backend = await getBackend();
+
+  const setList = parseCsv(flags.set);
+  const addList = parseCsv(flags.add) ?? [];
+  const removeList = parseCsv(flags.remove) ?? [];
+  if (!setList && addList.length === 0 && removeList.length === 0) {
+    output.error('Pass at least one of --add <csv>, --remove <csv>, or --set <csv>.');
+  }
+
+  const existing = (await backend.getById(id)) as { keys?: string[] } | null;
+  if (!existing) output.error(`Record ${id} not found`);
+
+  // --set replaces wholesale; otherwise start from current keys, add, remove.
+  let next: string[];
+  if (setList) {
+    next = setList;
+  } else {
+    const removeSet = new Set(removeList);
+    next = [...(existing!.keys ?? []), ...addList].filter(k => !removeSet.has(k));
+  }
+  // De-dupe, preserve order.
+  next = [...new Set(next)];
+
+  const outcome = await backend.updateKeys(id, next);
+  if (outcome.status === 'not_found') output.error(`Record ${id} not found`);
+  if (outcome.status === 'conflict') {
+    output.error(
+      `Key "${outcome.key}" is already owned by active record ${outcome.recordId} (type ${outcome.recordType}). ` +
+      `Keys must be unique across active records — archive or re-key that record first.`,
+    );
+  }
+  printRecord((outcome as { record: unknown }).record as Record<string, unknown>);
 }
 
 interface ArchiveFlags {

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -482,10 +482,19 @@ one --agent mem add note '{"content":"..."}' --tags work,urgent --weight 8 --key
 # Get (optionally with links)
 one --agent mem get <id> --links
 
-# Update (shallow merge into data)
+# Update (shallow merge into data; regenerates searchable_text from the merged data)
 one --agent mem update <id> '{"status":"done"}'
 
-# Archive / unarchive
+# Manage identity keys AFTER creation (keys are a first-class column, NOT data).
+# Unique across ACTIVE records — a clear error names the record that owns a taken key.
+one --agent mem key <id> --add email:new@x.com
+one --agent mem key <id> --remove email:old@x.com
+one --agent mem key <id> --set 'email:a@x.com,phone:+1555'   # replace all keys
+# NOTE: passing keys to 'mem update' is rejected — keys are not a data field.
+
+# Archive / unarchive. Archiving FREES a record's keys: an archived record no
+# longer blocks a new active record from reusing the same key (uniqueness is
+# scoped to active records).
 one --agent mem archive <id> --reason superseded
 
 # List by type — type is positional. Synced rows are namespaced as <platform>/<model>.
@@ -551,7 +560,11 @@ one --agent mem status          # backend, provider, _upgrade hint
 one --agent mem doctor          # 7-check health report
 one --agent mem vacuum          # backend maintenance (VACUUM ANALYZE)
 one --agent mem reindex         # re-embed records under current model
+one --agent mem reindex --searchable              # backfill searchable_text where NULL
+one --agent mem reindex --searchable --type attio/attioPeople --all   # also rewrite stale text
 \`\`\`
+
+\`mem reindex --searchable\` regenerates \`searchable_text\` from each record's own \`data\` (no embedding provider needed). It fixes rows that landed with NULL searchable_text and, thanks to the cleaned-up text builder, drops UUID/timestamp noise and leads with name/title/email fields so FTS ranks on what humans search. Regenerated rows are re-queued for embedding on the next \`mem reindex\`.
 
 ## Admin
 

--- a/src/lib/memory/backend.ts
+++ b/src/lib/memory/backend.ts
@@ -65,6 +65,17 @@ export interface UpsertResult {
   action: 'inserted' | 'updated';
 }
 
+/**
+ * Outcome of `backend.updateKeys`. `not_found` when the id doesn't exist;
+ * `conflict` when one of the requested keys is already owned by another
+ * ACTIVE record (reports which key and which record so the caller can
+ * surface an actionable error); `ok` with the updated record otherwise.
+ */
+export type KeyUpdateOutcome =
+  | { status: 'ok'; record: MemRecord }
+  | { status: 'not_found' }
+  | { status: 'conflict'; key: string; recordId: string; recordType: string };
+
 export interface UpsertOptions {
   /**
    * When true, the existing record's `data` is REPLACED by the incoming
@@ -90,6 +101,16 @@ export interface MemBackend {
   upsertByKeys(row: RecordInput, opts?: UpsertOptions): Promise<UpsertResult>;
   getById(id: string, opts?: { withLinks?: boolean }): Promise<MemRecord | MemRecordWithLinks | null>;
   update(id: string, patch: Partial<RecordInput>): Promise<MemRecord | null>;
+  /**
+   * Replace the `keys` array on an existing record, enforcing the same
+   * active-scoped uniqueness rule as insert. Runs the conflict check and
+   * the write atomically (single transaction) so two concurrent key edits
+   * can't both claim the same key. Returns a structured outcome — the
+   * caller (e.g. `one mem key`) turns a `conflict` into a clear error
+   * naming the key and the record that already owns it. `update()` can
+   * also set `keys`, but only this method reports *which* key collided.
+   */
+  updateKeys(id: string, keys: string[]): Promise<KeyUpdateOutcome>;
   remove(id: string): Promise<boolean>;
   archive(id: string, reason?: string): Promise<boolean>;
   unarchive(id: string): Promise<boolean>;
@@ -184,6 +205,34 @@ export interface MemBackend {
    * buffer that `update` requires.
    */
   updateEmbedding(id: string, vector: number[], model: string): Promise<void>;
+
+  /**
+   * Searchable-text backfill scan — returns id/type/data/searchable_text
+   * for records whose searchable_text needs regenerating. Unlike
+   * `listForReindex` this DOES pull `data` (regenerating the text requires
+   * it). When `onlyNull` is true, only rows with a NULL/empty
+   * searchable_text are returned (the common "fix the NULLs" case);
+   * otherwise every row is returned so the caller can detect text that's
+   * stale vs. the current `data`.
+   */
+  listForSearchableBackfill(opts?: {
+    type?: string;
+    onlyNull?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<Array<{
+    id: string;
+    type: string;
+    data: Record<string, unknown>;
+    searchable_text: string | null;
+  }>>;
+
+  /**
+   * Set ONLY the searchable_text column (and clear the now-stale
+   * embedding bookkeeping so a subsequent `mem reindex` re-embeds against
+   * the new text). Used by the `mem reindex --searchable` backfill.
+   */
+  updateSearchableText(id: string, text: string): Promise<void>;
 
   // Hot columns (profile-driven partial expression indexes)
   ensureHotColumn(type: string, jsonPath: string): Promise<void>;

--- a/src/lib/memory/embedding.test.ts
+++ b/src/lib/memory/embedding.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { defaultSearchableText } from './embedding.js';
+
+describe('defaultSearchableText', () => {
+  it('leads with name/title/email fields and drops UUID + timestamp noise', () => {
+    const text = defaultSearchableText({
+      name: 'Ada Lovelace',
+      email: 'ada@analytical.engine',
+      company: 'Analytical Engine Co',
+      job_title: 'Countess of Computing',
+      description: 'first programmer',
+      attio_record_id: '6b2f9658-542c-5e9e-b5f5-ffcb568776e4',
+      first_seen: '2025-06-30',
+      last_meeting: '2025-06-30T23:36:40.816000000Z',
+    });
+    // Priority fields come first.
+    assert.ok(text.startsWith('Ada Lovelace ada@analytical.engine'), text);
+    // No UUID, no timestamps.
+    assert.ok(!/6b2f9658/.test(text), 'UUID must be dropped');
+    assert.ok(!/2025-06-30/.test(text), 'timestamp/date must be dropped');
+    // Human fields survive.
+    assert.ok(text.includes('Countess of Computing'));
+    assert.ok(text.includes('first programmer'));
+  });
+
+  it('handles Attio nested value shape and skips structural noise', () => {
+    const text = defaultSearchableText({
+      id: {
+        workspace_id: '87d81246-d824-45f0-a205-047a0eaa67bc',
+        object_id: '7be572b1-939b-4930-8426-578f2c6ab576',
+        record_id: '6b2f9658-542c-5e9e-b5f5-ffcb568776e4',
+      },
+      created_at: '2025-06-30T23:36:40.816000000Z',
+      web_url: 'https://app.attio.com/x/person/6b2f9658',
+      values: {
+        name: [{
+          active_from: '2025-06-30T23:36:40.816000000Z',
+          created_by_actor: { type: 'workspace-member', id: 'cdcd471a-0d5e-4070-8c25-e7e0fa79b85d' },
+          full_name: 'Patrick O\'Keeffe',
+          first_name: 'Patrick',
+          last_name: 'O\'Keeffe',
+          attribute_type: 'personal-name',
+        }],
+        email_addresses: [{
+          email_address: 'patrick.okeeffe@circuit.ai',
+          attribute_type: 'email-address',
+        }],
+        job_title: [{ value: 'Head of Engineering', attribute_type: 'text' }],
+      },
+    });
+    // Name leads.
+    assert.ok(text.startsWith('Patrick O\'Keeffe'), text);
+    // Nested job_title[0].value is picked up (classified via parent key).
+    assert.ok(text.includes('Head of Engineering'), text);
+    // Email present.
+    assert.ok(text.includes('patrick.okeeffe@circuit.ai'));
+    // All the noise is gone.
+    assert.ok(!/87d81246|7be572b1|6b2f9658|cdcd471a/.test(text), 'UUIDs must be dropped');
+    assert.ok(!/workspace-member|personal-name|email-address/.test(text), 'enum noise must be dropped');
+    assert.ok(!/2025-06-30/.test(text), 'timestamps must be dropped');
+    assert.ok(!/app\.attio\.com/.test(text), 'url must be dropped');
+  });
+
+  it('de-duplicates repeated tokens', () => {
+    const text = defaultSearchableText({
+      name: 'Acme',
+      values: { a: 'Acme', b: 'Acme', c: 'Acme' },
+    });
+    assert.equal(text, 'Acme');
+  });
+
+  it('returns empty string when nothing usable remains', () => {
+    const text = defaultSearchableText({
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      created_at: '2025-01-01T00:00:00Z',
+    });
+    assert.equal(text, '');
+  });
+
+  it('truncates to maxLen', () => {
+    const text = defaultSearchableText({ description: 'x'.repeat(5000) }, 100);
+    assert.equal(text.length, 100);
+  });
+});

--- a/src/lib/memory/embedding.ts
+++ b/src/lib/memory/embedding.ts
@@ -164,33 +164,107 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+// A value that's just a UUID / opaque id contributes nothing to FTS but
+// dominates the leading tokens on Attio-shaped records (workspace / object
+// / record ids come first in the JSON). Drop them.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Pure timestamps / dates (ISO 8601, with or without time, and the
+// nanosecond form Attio emits: 2025-06-30T23:36:40.816000000Z).
+const TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+// Keys whose *values* are opaque ids / links / structural noise — skip the
+// whole leaf regardless of what it holds. Matches `id`, `record_id`,
+// `workspace_id`, `attio_url`, `avatar_url`, `*_ids`, bare `uuid`, etc.
+const NOISE_KEY_RE = /(^|_)(id|ids|uuid|guid|url|href|link|avatar|photo|icon|hash|token|slug)$/i;
+// Attio (and similar) structural wrappers — their values are enum-ish noise
+// ("workspace-member", "personal-name", "text", timestamps) that bury the
+// human fields. Drop the subtree.
+const NOISE_KEY_EXACT = new Set([
+  'attribute_type', 'actor_type', 'created_by_actor',
+  'active_from', 'active_until', 'created_at', 'updated_at', 'last_synced_at',
+]);
+// Container keys carry no meaning themselves — descend but keep the PARENT
+// key as context, so `values.job_title[0].value` is classified as
+// "job_title", not the generic "value".
+const CONTAINER_KEYS = new Set([
+  'values', 'value', 'data', 'attributes', 'properties', 'items',
+  'records', 'result', 'results', 'fields',
+]);
+// Human-meaningful fields that should lead the searchable text so FTS ranks
+// on names / titles / emails instead of trailing metadata. Handles Attio's
+// nested leaf keys (`full_name`, `email_address`, `job_title`) directly.
+const PRIORITY_KEY_RE = /(^|_)(name|full_name|first_name|last_name|display_name|title|job_title|role|position|email|email_address|company|organization|org|description|bio|summary|headline|label|subject|content|body|text_content)$/i;
+
 /**
  * Pull a reasonable searchable text out of arbitrary JSON when a profile
- * hasn't specified one. Used by `mem add` and as the default fallback in
- * sync when a profile has no `memory.searchable` block.
+ * hasn't specified one. Used by `mem add`, by `mem reindex --searchable`,
+ * and as the default fallback in sync when a profile has no
+ * `memory.searchable` block.
+ *
+ * The walk is key-aware so it can (a) drop UUID / timestamp / opaque-id
+ * noise that otherwise leads the text on synced records (Attio in
+ * particular starts every record with workspace/object/record UUIDs and
+ * timestamps), and (b) emit name / title / email-like fields FIRST so FTS
+ * ranks on the fields humans actually search. Nested container keys
+ * (`values`, `value`, …) pass their parent key down as context so Attio's
+ * `values.name[0].full_name` / `values.job_title[0].value` shapes classify
+ * correctly. Tokens are de-duplicated (order-preserving) — Attio repeats
+ * the same name/actor many times across a record.
  */
 export function defaultSearchableText(data: Record<string, unknown>, maxLen = 4000): string {
-  const parts: string[] = [];
-  const walk = (value: unknown, depth = 0): void => {
+  const priority: string[] = [];
+  const normal: string[] = [];
+
+  const push = (key: string | undefined, text: string): void => {
+    if (key && PRIORITY_KEY_RE.test(key)) priority.push(text);
+    else normal.push(text);
+  };
+
+  const walk = (value: unknown, key: string | undefined, depth: number): void => {
     if (value === null || value === undefined) return;
-    if (typeof value === 'string' && value.trim()) {
-      parts.push(value.trim());
+    if (typeof value === 'string') {
+      const t = value.trim();
+      if (!t) return;
+      if (UUID_RE.test(t) || TIMESTAMP_RE.test(t)) return;
+      if (key && NOISE_KEY_RE.test(key)) return;
+      push(key, t);
       return;
     }
     if (typeof value === 'number' || typeof value === 'boolean') {
-      parts.push(String(value));
+      if (key && NOISE_KEY_RE.test(key)) return;
+      push(key, String(value));
       return;
     }
-    if (depth > 4) return;
+    if (depth > 6) return;
     if (Array.isArray(value)) {
-      for (const v of value) walk(v, depth + 1);
+      // Array indices aren't meaningful keys — carry the parent key down.
+      for (const v of value) walk(v, key, depth + 1);
       return;
     }
     if (typeof value === 'object') {
-      for (const v of Object.values(value as Record<string, unknown>)) walk(v, depth + 1);
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        const lower = k.toLowerCase();
+        if (NOISE_KEY_EXACT.has(lower) || NOISE_KEY_RE.test(k)) continue;
+        // Container keys keep the parent context; real keys become context.
+        const nextKey = CONTAINER_KEYS.has(lower) ? key : k;
+        walk(v, nextKey, depth + 1);
+      }
     }
   };
-  walk(data);
-  const joined = parts.join(' ').replace(/\s+/g, ' ').trim();
+
+  walk(data, undefined, 0);
+
+  // Priority fields first, then everything else; de-dupe case-insensitively
+  // while preserving first-seen order.
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const t of [...priority, ...normal]) {
+    const norm = t.toLowerCase();
+    if (seen.has(norm)) continue;
+    seen.add(norm);
+    ordered.push(t);
+  }
+
+  const joined = ordered.join(' ').replace(/\s+/g, ' ').trim();
   return joined.length > maxLen ? joined.slice(0, maxLen) : joined;
 }

--- a/src/lib/memory/plugins/embedded-postgres/index.ts
+++ b/src/lib/memory/plugins/embedded-postgres/index.ts
@@ -349,6 +349,7 @@ class LazyEmbeddedPostgresBackend implements MemBackend {
   async upsertByKeys(...a: Parameters<MemBackend['upsertByKeys']>): ReturnType<MemBackend['upsertByKeys']> { return (await this.ensure()).upsertByKeys(...a); }
   async getById(...a: Parameters<MemBackend['getById']>): ReturnType<MemBackend['getById']> { return (await this.ensure()).getById(...a); }
   async update(...a: Parameters<MemBackend['update']>): ReturnType<MemBackend['update']> { return (await this.ensure()).update(...a); }
+  async updateKeys(...a: Parameters<MemBackend['updateKeys']>): ReturnType<MemBackend['updateKeys']> { return (await this.ensure()).updateKeys(...a); }
   async remove(...a: Parameters<MemBackend['remove']>): ReturnType<MemBackend['remove']> { return (await this.ensure()).remove(...a); }
   async archive(...a: Parameters<MemBackend['archive']>): ReturnType<MemBackend['archive']> { return (await this.ensure()).archive(...a); }
   async unarchive(...a: Parameters<MemBackend['unarchive']>): ReturnType<MemBackend['unarchive']> { return (await this.ensure()).unarchive(...a); }
@@ -356,7 +357,9 @@ class LazyEmbeddedPostgresBackend implements MemBackend {
   async count(...a: Parameters<MemBackend['count']>): ReturnType<MemBackend['count']> { return (await this.ensure()).count(...a); }
   async listForReindex(...a: Parameters<MemBackend['listForReindex']>): ReturnType<MemBackend['listForReindex']> { return (await this.ensure()).listForReindex(...a); }
   async listKeysByType(...a: Parameters<MemBackend['listKeysByType']>): ReturnType<MemBackend['listKeysByType']> { return (await this.ensure()).listKeysByType(...a); }
+  async listForSearchableBackfill(...a: Parameters<MemBackend['listForSearchableBackfill']>): ReturnType<MemBackend['listForSearchableBackfill']> { return (await this.ensure()).listForSearchableBackfill(...a); }
   async updateEmbedding(...a: Parameters<MemBackend['updateEmbedding']>): ReturnType<MemBackend['updateEmbedding']> { return (await this.ensure()).updateEmbedding(...a); }
+  async updateSearchableText(...a: Parameters<MemBackend['updateSearchableText']>): ReturnType<MemBackend['updateSearchableText']> { return (await this.ensure()).updateSearchableText(...a); }
   async raw(sql: string, params?: unknown[]): ReturnType<NonNullable<MemBackend['raw']>> {
     const b = await this.ensure();
     if (!b.raw) throw new Error('Backend does not support raw SQL');

--- a/src/lib/memory/plugins/pglite/index.ts
+++ b/src/lib/memory/plugins/pglite/index.ts
@@ -157,6 +157,7 @@ class LazyPgliteBackend implements MemBackend {
   async upsertByKeys(...a: Parameters<MemBackend['upsertByKeys']>): ReturnType<MemBackend['upsertByKeys']> { return (await this.ensure()).upsertByKeys(...a); }
   async getById(...a: Parameters<MemBackend['getById']>): ReturnType<MemBackend['getById']> { return (await this.ensure()).getById(...a); }
   async update(...a: Parameters<MemBackend['update']>): ReturnType<MemBackend['update']> { return (await this.ensure()).update(...a); }
+  async updateKeys(...a: Parameters<MemBackend['updateKeys']>): ReturnType<MemBackend['updateKeys']> { return (await this.ensure()).updateKeys(...a); }
   async remove(...a: Parameters<MemBackend['remove']>): ReturnType<MemBackend['remove']> { return (await this.ensure()).remove(...a); }
   async archive(...a: Parameters<MemBackend['archive']>): ReturnType<MemBackend['archive']> { return (await this.ensure()).archive(...a); }
   async unarchive(...a: Parameters<MemBackend['unarchive']>): ReturnType<MemBackend['unarchive']> { return (await this.ensure()).unarchive(...a); }
@@ -164,7 +165,9 @@ class LazyPgliteBackend implements MemBackend {
   async count(...a: Parameters<MemBackend['count']>): ReturnType<MemBackend['count']> { return (await this.ensure()).count(...a); }
   async listForReindex(...a: Parameters<MemBackend['listForReindex']>): ReturnType<MemBackend['listForReindex']> { return (await this.ensure()).listForReindex(...a); }
   async listKeysByType(...a: Parameters<MemBackend['listKeysByType']>): ReturnType<MemBackend['listKeysByType']> { return (await this.ensure()).listKeysByType(...a); }
+  async listForSearchableBackfill(...a: Parameters<MemBackend['listForSearchableBackfill']>): ReturnType<MemBackend['listForSearchableBackfill']> { return (await this.ensure()).listForSearchableBackfill(...a); }
   async updateEmbedding(...a: Parameters<MemBackend['updateEmbedding']>): ReturnType<MemBackend['updateEmbedding']> { return (await this.ensure()).updateEmbedding(...a); }
+  async updateSearchableText(...a: Parameters<MemBackend['updateSearchableText']>): ReturnType<MemBackend['updateSearchableText']> { return (await this.ensure()).updateSearchableText(...a); }
   async raw(sql: string, params?: unknown[]): ReturnType<NonNullable<MemBackend['raw']>> {
     const b = await this.ensure();
     if (!b.raw) throw new Error('Backend does not support raw SQL');

--- a/src/lib/memory/plugins/pglite/pglite.test.ts
+++ b/src/lib/memory/plugins/pglite/pglite.test.ts
@@ -33,7 +33,7 @@ describe('PGlite plugin — live integration', () => {
 
   it('reports the schema version after ensureSchema', async () => {
     const v = await backend.getSchemaVersion();
-    assert.equal(v, '2.1.0');
+    assert.equal(v, '2.2.0');
   });
 
   it('advertises capabilities the CoreBackend relies on', () => {

--- a/src/lib/memory/plugins/pglite/pglite.test.ts
+++ b/src/lib/memory/plugins/pglite/pglite.test.ts
@@ -231,6 +231,75 @@ describe('PGlite plugin — live integration', () => {
     assert.equal(healed?.archived_reason, null, 'archived_reason must clear on resurrection');
   });
 
+  it('updateKeys replaces the keys column and enforces active uniqueness', async () => {
+    const a = await backend.insert({ type: 'person', data: { name: 'A' }, keys: ['email:a@x.com'] });
+    const b = await backend.insert({ type: 'person', data: { name: 'B' }, keys: ['email:b@x.com'] });
+
+    // Happy path: add a second key to A.
+    const ok = await backend.updateKeys(a.id, ['email:a@x.com', 'phone:+1555']);
+    assert.equal(ok.status, 'ok');
+    assert.deepEqual(
+      new Set((ok as { record: { keys: string[] } }).record.keys),
+      new Set(['email:a@x.com', 'phone:+1555']),
+    );
+
+    // Conflict: try to give A one of B's keys — reports the key + owner.
+    const conflict = await backend.updateKeys(a.id, ['email:b@x.com']);
+    assert.equal(conflict.status, 'conflict');
+    assert.equal((conflict as { key: string }).key, 'email:b@x.com');
+    assert.equal((conflict as { recordId: string }).recordId, b.id);
+
+    // not_found for an unknown id.
+    const missing = await backend.updateKeys('00000000-0000-0000-0000-000000000000', ['email:z@x.com']);
+    assert.equal(missing.status, 'not_found');
+  });
+
+  it('key uniqueness is scoped to active — an archived record frees its key', async () => {
+    const first = await backend.insert({
+      type: 'person', data: { name: 'Squatter' }, keys: ['email:reuse@x.com'],
+    });
+    // While active, a second active record can't claim the key.
+    await assert.rejects(
+      backend.insert({ type: 'person', data: { name: 'Dup' }, keys: ['email:reuse@x.com'] }),
+      /already exist/i,
+    );
+    // Archive the first — its key is now reclaimable.
+    await backend.archive(first.id, 'superseded');
+    const second = await backend.insert({
+      type: 'person', data: { name: 'Reclaimer' }, keys: ['email:reuse@x.com'],
+    });
+    assert.ok(second.id);
+
+    // find-by-source prefers the ACTIVE owner over the archived one.
+    const found = await backend.findBySource('email:reuse@x.com');
+    assert.equal(found?.id, second.id);
+    assert.equal(found?.status, 'active');
+  });
+
+  it('listForSearchableBackfill + updateSearchableText fills NULL rows', async () => {
+    // Insert with an explicit NULL searchable_text (as an SDK/raw write might).
+    const rec = await backend.insert({
+      type: 'backfill-me',
+      data: { name: 'Grace Hopper', title: 'Rear Admiral' },
+      keys: ['email:grace@navy.mil'],
+      searchable_text: null,
+    });
+    const before = await backend.getById(rec.id);
+    assert.equal(before?.searchable_text, null);
+
+    const rows = await backend.listForSearchableBackfill({ type: 'backfill-me', onlyNull: true });
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, rec.id);
+
+    await backend.updateSearchableText(rec.id, 'Grace Hopper Rear Admiral');
+    const after = await backend.getById(rec.id);
+    assert.equal(after?.searchable_text, 'Grace Hopper Rear Admiral');
+
+    // Row is no longer returned by the NULL-only scan.
+    const again = await backend.listForSearchableBackfill({ type: 'backfill-me', onlyNull: true });
+    assert.equal(again.length, 0);
+  });
+
   it('sync state round-trips', async () => {
     await backend.setSyncState({
       platform: 'attio',

--- a/src/lib/memory/plugins/pglite/pglite.test.ts
+++ b/src/lib/memory/plugins/pglite/pglite.test.ts
@@ -300,6 +300,48 @@ describe('PGlite plugin — live integration', () => {
     assert.equal(again.length, 0);
   });
 
+  it('unarchive surfaces an actionable error when the key was reclaimed', async () => {
+    const a = await backend.insert({
+      type: 'person', data: { name: 'Original' }, keys: ['email:reclaim@x.com'],
+    });
+    await backend.archive(a.id, 'superseded');
+    const b = await backend.insert({
+      type: 'person', data: { name: 'Reclaimer' }, keys: ['email:reclaim@x.com'],
+    });
+
+    // Flipping A back to active would collide with B on the shared key —
+    // must throw a message naming B, not a raw 23505.
+    await assert.rejects(
+      backend.unarchive(a.id),
+      (err: unknown) =>
+        err instanceof Error &&
+        /reclaimed by active record/.test(err.message) &&
+        err.message.includes(b.id),
+    );
+    // A stays archived; B stays active.
+    assert.equal((await backend.getById(a.id))?.status, 'archived');
+    assert.equal((await backend.getById(b.id))?.status, 'active');
+  });
+
+  it('update clears the stale embedding when searchable_text changes', async () => {
+    const rec = await backend.insert({
+      type: 'note', data: { content: 'original' }, searchable_text: 'original',
+    });
+    const vec = new Array(1536).fill(0.01);
+    await backend.updateEmbedding(rec.id, vec, 'openai:test');
+    assert.ok((await backend.getById(rec.id))?.embedded_at, 'precondition: embedded');
+
+    // Text changes → embedding is invalidated so the next reindex re-embeds.
+    const changed = await backend.update(rec.id, { data: { content: 'changed' }, searchable_text: 'changed' });
+    assert.equal(changed?.embedded_at, null, 'embedding must clear when text changes');
+    assert.equal(changed?.embedding_model, null);
+
+    // Metadata-only edit (no text change) → embedding preserved.
+    await backend.updateEmbedding(rec.id, vec, 'openai:test');
+    const weighted = await backend.update(rec.id, { weight: 8 });
+    assert.ok(weighted?.embedded_at, 'embedding preserved when text unchanged');
+  });
+
   it('sync state round-trips', async () => {
     await backend.setSyncState({
       platform: 'attio',

--- a/src/lib/memory/plugins/postgres-core/backend.ts
+++ b/src/lib/memory/plugins/postgres-core/backend.ts
@@ -127,6 +127,21 @@ export class CoreBackend implements MemBackend {
 
   async ensureSchema(): Promise<void> {
     const caps = this.caps;
+    // Fast path: if the store already reports the current schema version,
+    // every DDL statement below would be an idempotent no-op — so skip the
+    // whole block (no advisory lock, no CREATE OR REPLACE churn). This is
+    // the hot path taken by essentially every CLI invocation, and it's what
+    // makes concurrent `one mem` processes cheap: with no DDL and no lock
+    // there's nothing left to serialize or deadlock on (the 40P01 the lock
+    // below guards against only arises while DDL actually runs). A version
+    // mismatch (fresh DB, or an upgrade that bumped SCHEMA_VERSION) falls
+    // through to the locked setup exactly once, then this check short-
+    // circuits forever after.
+    try {
+      if ((await this.getSchemaVersion()) === SCHEMA_VERSION) return;
+    } catch {
+      // mem_meta doesn't exist yet (fresh DB) — fall through to full setup.
+    }
     // Apply in logical blocks so a backend without pgvector skips the
     // vector-specific DDL cleanly. The core blocks (tables, indexes,
     // functions) never reference the vector type — the embedding column

--- a/src/lib/memory/plugins/postgres-core/backend.ts
+++ b/src/lib/memory/plugins/postgres-core/backend.ts
@@ -84,6 +84,17 @@ interface RecordRow {
   updated_at: string;
 }
 
+// Postgres unique_violation (23505). The key-uniqueness trigger raises it
+// with ERRCODE = 'unique_violation'; node-pg surfaces `.code`, and PGlite
+// carries either `.code` or the SQLSTATE/message. Match defensively.
+function isUniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { code?: unknown; message?: unknown };
+  if (e.code === '23505') return true;
+  const msg = typeof e.message === 'string' ? e.message : '';
+  return /23505|unique_violation|Key conflict/i.test(msg);
+}
+
 function toRecord(row: RecordRow): MemRecord {
   return {
     id: row.id,
@@ -294,6 +305,19 @@ export class CoreBackend implements MemBackend {
     const hash = patch.content_hash ?? existing.content_hash ?? null;
     const weight = patch.weight ?? existing.weight;
 
+    // Changing searchable_text invalidates any existing embedding — it was
+    // computed from the OLD text. Plain `mem reindex` only re-embeds rows
+    // missing an embedding or under a wrong model, so without clearing the
+    // bookkeeping here an edited row would serve its pre-edit vector
+    // forever (only `--force` would catch it). Null the embedding columns
+    // in the same UPDATE so the row is re-embedded on the next reindex.
+    // Mirrors updateSearchableText, which does this for the backfill path.
+    const textChanged = searchable !== (existing.searchable_text ?? null);
+    const clearEmbedding = textChanged && this.caps.vectorSearch;
+    const embeddingReset = clearEmbedding
+      ? `, embedding = NULL, embedded_at = NULL, embedding_model = NULL`
+      : '';
+
     const res = await this.client.query<RecordRow>(
       `UPDATE mem_records
          SET data = $2::jsonb,
@@ -302,7 +326,7 @@ export class CoreBackend implements MemBackend {
              sources = $5::jsonb,
              searchable_text = $6,
              content_hash = $7,
-             weight = $8
+             weight = $8${embeddingReset}
        WHERE id = $1
        RETURNING *`,
       [id, JSON.stringify(data), tags, keys, JSON.stringify(sources), searchable, hash, weight],
@@ -316,35 +340,46 @@ export class CoreBackend implements MemBackend {
     // key-uniqueness trigger is the ultimate backstop, but doing the
     // lookup here lets us report WHICH key collided and WHICH record owns
     // it — the trigger only knows the conflicting record id.
-    return this.client.transaction(async (tx) => {
-      const exists = await tx.query<{ id: string }>(
-        `SELECT id FROM mem_records WHERE id = $1`,
-        [id],
-      );
-      if (!exists.rows[0]) return { status: 'not_found' as const };
+    try {
+      return await this.client.transaction(async (tx) => {
+        const exists = await tx.query<{ id: string }>(
+          `SELECT id FROM mem_records WHERE id = $1`,
+          [id],
+        );
+        if (!exists.rows[0]) return { status: 'not_found' as const };
 
-      // Scoped to active records — matches mem_enforce_key_uniqueness.
-      // The correlated subquery surfaces the first requested key that
-      // overlaps another active record's keys, so the error can name it.
-      const conflict = await tx.query<{ id: string; type: string; key: string }>(
-        `SELECT r.id, r.type,
-                (SELECT k FROM unnest($2::text[]) AS k WHERE k = ANY(r.keys) LIMIT 1) AS key
-           FROM mem_records r
-          WHERE r.keys && $2::text[] AND r.id != $1 AND r.status = 'active'
-          LIMIT 1`,
-        [id, keys],
-      );
-      const c = conflict.rows[0];
-      if (c) {
-        return { status: 'conflict' as const, key: c.key, recordId: c.id, recordType: c.type };
+        // Scoped to active records — matches mem_enforce_key_uniqueness.
+        // The correlated subquery surfaces the first requested key that
+        // overlaps another active record's keys, so the error can name it.
+        const conflict = await tx.query<{ id: string; type: string; key: string }>(
+          `SELECT r.id, r.type,
+                  (SELECT k FROM unnest($2::text[]) AS k WHERE k = ANY(r.keys) LIMIT 1) AS key
+             FROM mem_records r
+            WHERE r.keys && $2::text[] AND r.id != $1 AND r.status = 'active'
+            LIMIT 1`,
+          [id, keys],
+        );
+        const c = conflict.rows[0];
+        if (c) {
+          return { status: 'conflict' as const, key: c.key, recordId: c.id, recordType: c.type };
+        }
+
+        const res = await tx.query<RecordRow>(
+          `UPDATE mem_records SET keys = $2::text[] WHERE id = $1 RETURNING *`,
+          [id, keys.length > 0 ? keys : null],
+        );
+        return { status: 'ok' as const, record: toRecord(res.rows[0]) };
+      });
+    } catch (err) {
+      // A concurrent edit could claim one of these keys between our SELECT
+      // and UPDATE; the trigger then throws 23505. Map it back to a
+      // structured conflict (we can't cheaply say which key raced, so
+      // report the first requested one) rather than leaking a raw error.
+      if (isUniqueViolation(err)) {
+        return { status: 'conflict', key: keys[0] ?? '', recordId: 'unknown', recordType: 'unknown' };
       }
-
-      const res = await tx.query<RecordRow>(
-        `UPDATE mem_records SET keys = $2::text[] WHERE id = $1 RETURNING *`,
-        [id, keys.length > 0 ? keys : null],
-      );
-      return { status: 'ok' as const, record: toRecord(res.rows[0]) };
-    });
+      throw err;
+    }
   }
 
   async remove(id: string): Promise<boolean> {
@@ -362,12 +397,38 @@ export class CoreBackend implements MemBackend {
   }
 
   async unarchive(id: string): Promise<boolean> {
-    const res = await this.client.query(
-      `UPDATE mem_records SET status = 'active', archived_reason = NULL
-       WHERE id = $1 AND status = 'archived'`,
-      [id],
-    );
-    return (res.rowCount ?? 0) > 0;
+    // Flipping status back to 'active' re-arms the key-uniqueness trigger.
+    // If this row's key was reclaimed by another active record while it was
+    // archived (the flip side of "archiving frees a key"), the trigger
+    // raises a raw 23505. Translate that into an actionable message naming
+    // the reclaiming record instead of leaking the internal trigger text.
+    try {
+      const res = await this.client.query(
+        `UPDATE mem_records SET status = 'active', archived_reason = NULL
+         WHERE id = $1 AND status = 'archived'`,
+        [id],
+      );
+      return (res.rowCount ?? 0) > 0;
+    } catch (err) {
+      if (!isUniqueViolation(err)) throw err;
+      // Find which key + active record now owns it, for a useful message.
+      const owner = await this.client.query<{ id: string; type: string; key: string }>(
+        `SELECT r.id, r.type,
+                (SELECT k FROM unnest(a.keys) AS k
+                  WHERE k = ANY(r.keys) LIMIT 1) AS key
+           FROM mem_records a
+           JOIN mem_records r
+             ON r.keys && a.keys AND r.id != a.id AND r.status = 'active'
+          WHERE a.id = $1
+          LIMIT 1`,
+        [id],
+      );
+      const o = owner.rows[0];
+      const detail = o
+        ? `key "${o.key}" was reclaimed by active record ${o.id} (type ${o.type}) — re-key it or archive that record first`
+        : `one of its keys was reclaimed by another active record`;
+      throw new Error(`Cannot unarchive ${id}: ${detail}`);
+    }
   }
 
   async list(type: string, opts: ListOptions = {}): Promise<MemRecord[]> {

--- a/src/lib/memory/plugins/postgres-core/backend.ts
+++ b/src/lib/memory/plugins/postgres-core/backend.ts
@@ -592,8 +592,14 @@ export class CoreBackend implements MemBackend {
 
   async findBySource(sourceKey: string): Promise<MemRecord | null> {
     // sourceKey lives in keys[] (indexed GIN), so this is a fast lookup.
+    // Prefer the ACTIVE owner: key uniqueness is scoped to active records
+    // (an archived dupe can legitimately still hold the same key for
+    // provenance), so when both exist the live record is the answer.
     const res = await this.client.query<RecordRow>(
-      `SELECT * FROM mem_records WHERE $1 = ANY(keys) LIMIT 1`,
+      `SELECT * FROM mem_records
+        WHERE $1 = ANY(keys)
+        ORDER BY (status = 'active') DESC, updated_at DESC
+        LIMIT 1`,
       [sourceKey],
     );
     return res.rows[0] ? toRecord(res.rows[0]) : null;

--- a/src/lib/memory/plugins/postgres-core/backend.ts
+++ b/src/lib/memory/plugins/postgres-core/backend.ts
@@ -16,6 +16,7 @@ import type {
   UpsertResult,
   UpsertOptions,
   RawSqlResult,
+  KeyUpdateOutcome,
 } from '../../backend.js';
 import { validateReadOnlySql } from './sql-guard.js';
 import type {
@@ -309,6 +310,43 @@ export class CoreBackend implements MemBackend {
     return res.rows[0] ? toRecord(res.rows[0]) : null;
   }
 
+  async updateKeys(id: string, keys: string[]): Promise<KeyUpdateOutcome> {
+    // Conflict-check + write in one transaction so two concurrent key
+    // edits can't both slip past the check and claim the same key. The
+    // key-uniqueness trigger is the ultimate backstop, but doing the
+    // lookup here lets us report WHICH key collided and WHICH record owns
+    // it — the trigger only knows the conflicting record id.
+    return this.client.transaction(async (tx) => {
+      const exists = await tx.query<{ id: string }>(
+        `SELECT id FROM mem_records WHERE id = $1`,
+        [id],
+      );
+      if (!exists.rows[0]) return { status: 'not_found' as const };
+
+      // Scoped to active records — matches mem_enforce_key_uniqueness.
+      // The correlated subquery surfaces the first requested key that
+      // overlaps another active record's keys, so the error can name it.
+      const conflict = await tx.query<{ id: string; type: string; key: string }>(
+        `SELECT r.id, r.type,
+                (SELECT k FROM unnest($2::text[]) AS k WHERE k = ANY(r.keys) LIMIT 1) AS key
+           FROM mem_records r
+          WHERE r.keys && $2::text[] AND r.id != $1 AND r.status = 'active'
+          LIMIT 1`,
+        [id, keys],
+      );
+      const c = conflict.rows[0];
+      if (c) {
+        return { status: 'conflict' as const, key: c.key, recordId: c.id, recordType: c.type };
+      }
+
+      const res = await tx.query<RecordRow>(
+        `UPDATE mem_records SET keys = $2::text[] WHERE id = $1 RETURNING *`,
+        [id, keys.length > 0 ? keys : null],
+      );
+      return { status: 'ok' as const, record: toRecord(res.rows[0]) };
+    });
+  }
+
   async remove(id: string): Promise<boolean> {
     const res = await this.client.query(`DELETE FROM mem_records WHERE id = $1`, [id]);
     return (res.rowCount ?? 0) > 0;
@@ -449,6 +487,76 @@ export class CoreBackend implements MemBackend {
               embedded_at = NOW()
         WHERE id = $1`,
       [id, literal, model],
+    );
+  }
+
+  async listForSearchableBackfill(opts: {
+    type?: string;
+    onlyNull?: boolean;
+    limit?: number;
+    offset?: number;
+  } = {}): Promise<Array<{
+    id: string;
+    type: string;
+    data: Record<string, unknown>;
+    searchable_text: string | null;
+  }>> {
+    const limit = opts.limit ?? 1000;
+    const offset = opts.offset ?? 0;
+    const params: unknown[] = [];
+    const clauses: string[] = [`status = 'active'`];
+
+    if (opts.type) {
+      params.push(opts.type);
+      clauses.push(`type = $${params.length}`);
+    }
+    if (opts.onlyNull) {
+      // NULL *or* empty — an empty string is just as useless to FTS and is
+      // exactly what a bad earlier write left behind.
+      clauses.push(`(searchable_text IS NULL OR searchable_text = '')`);
+    }
+
+    params.push(limit);
+    params.push(offset);
+    // Order by id so paginated runs are stable. Unlike the reindex scan
+    // (whose filter shrinks as it works), a stale-detection pass may leave
+    // rows in place, so the caller pages with a real offset.
+    const res = await this.client.query<{
+      id: string;
+      type: string;
+      data: Record<string, unknown>;
+      searchable_text: string | null;
+    }>(
+      `SELECT id, type, data, searchable_text
+         FROM mem_records
+        WHERE ${clauses.join(' AND ')}
+        ORDER BY id ASC
+        LIMIT $${params.length - 1} OFFSET $${params.length}`,
+      params,
+    );
+    return res.rows;
+  }
+
+  async updateSearchableText(id: string, text: string): Promise<void> {
+    // Clear the embedding bookkeeping too: the stored vector was built
+    // from the OLD searchable_text, so it's now stale. Nulling embedded_at
+    // makes the row eligible for the next `mem reindex` (embedding) pass.
+    // The embedding column only exists when vectorSearch is on.
+    if (this.caps.vectorSearch) {
+      await this.client.query(
+        `UPDATE mem_records
+            SET searchable_text = $2,
+                embedding = NULL,
+                embedded_at = NULL,
+                embedding_model = NULL
+          WHERE id = $1`,
+        [id, text],
+      );
+      return;
+    }
+    await this.client.query(
+      `UPDATE mem_records SET searchable_text = $2 WHERE id = $1`,
+      [id, text],
     );
   }
 

--- a/src/lib/memory/plugins/postgres/index.ts
+++ b/src/lib/memory/plugins/postgres/index.ts
@@ -127,6 +127,7 @@ class LazyPostgresBackend implements MemBackend {
   async upsertByKeys(...a: Parameters<MemBackend['upsertByKeys']>): ReturnType<MemBackend['upsertByKeys']> { return (await this.ensure()).upsertByKeys(...a); }
   async getById(...a: Parameters<MemBackend['getById']>): ReturnType<MemBackend['getById']> { return (await this.ensure()).getById(...a); }
   async update(...a: Parameters<MemBackend['update']>): ReturnType<MemBackend['update']> { return (await this.ensure()).update(...a); }
+  async updateKeys(...a: Parameters<MemBackend['updateKeys']>): ReturnType<MemBackend['updateKeys']> { return (await this.ensure()).updateKeys(...a); }
   async remove(...a: Parameters<MemBackend['remove']>): ReturnType<MemBackend['remove']> { return (await this.ensure()).remove(...a); }
   async archive(...a: Parameters<MemBackend['archive']>): ReturnType<MemBackend['archive']> { return (await this.ensure()).archive(...a); }
   async unarchive(...a: Parameters<MemBackend['unarchive']>): ReturnType<MemBackend['unarchive']> { return (await this.ensure()).unarchive(...a); }
@@ -134,7 +135,9 @@ class LazyPostgresBackend implements MemBackend {
   async count(...a: Parameters<MemBackend['count']>): ReturnType<MemBackend['count']> { return (await this.ensure()).count(...a); }
   async listForReindex(...a: Parameters<MemBackend['listForReindex']>): ReturnType<MemBackend['listForReindex']> { return (await this.ensure()).listForReindex(...a); }
   async listKeysByType(...a: Parameters<MemBackend['listKeysByType']>): ReturnType<MemBackend['listKeysByType']> { return (await this.ensure()).listKeysByType(...a); }
+  async listForSearchableBackfill(...a: Parameters<MemBackend['listForSearchableBackfill']>): ReturnType<MemBackend['listForSearchableBackfill']> { return (await this.ensure()).listForSearchableBackfill(...a); }
   async updateEmbedding(...a: Parameters<MemBackend['updateEmbedding']>): ReturnType<MemBackend['updateEmbedding']> { return (await this.ensure()).updateEmbedding(...a); }
+  async updateSearchableText(...a: Parameters<MemBackend['updateSearchableText']>): ReturnType<MemBackend['updateSearchableText']> { return (await this.ensure()).updateSearchableText(...a); }
   async raw(sql: string, params?: unknown[]): ReturnType<NonNullable<MemBackend['raw']>> {
     const b = await this.ensure();
     if (!b.raw) throw new Error('Backend does not support raw SQL');

--- a/src/lib/memory/runtime.ts
+++ b/src/lib/memory/runtime.ts
@@ -131,6 +131,44 @@ export async function addRecord(input: RecordInput, opts: AddOptions = {}): Prom
   return backend.insert(prepared);
 }
 
+/**
+ * Update a record's `data` (shallow-merged, matching backend semantics)
+ * and regenerate the derived `searchable_text` + `content_hash` from the
+ * MERGED data — unless the caller passes an explicit `searchable_text`.
+ *
+ * Fixes the stale-searchable_text bug: `backend.update` on its own keeps
+ * the old searchable_text, so `mem update` used to leave FTS pointing at
+ * pre-edit content (and agent-authored records that were progressively
+ * enriched via update never became findable on their new fields). Embedding
+ * refresh is intentionally left to `mem reindex` — this only touches the
+ * text + hash, which is cheap and needs no API call.
+ */
+export async function updateRecord(
+  id: string,
+  patch: Partial<RecordInput>,
+): Promise<MemRecord | null> {
+  const backend = await getBackend();
+  const existing = (await backend.getById(id)) as MemRecord | null;
+  if (!existing) return null;
+
+  const mergedData = patch.data ? { ...existing.data, ...patch.data } : existing.data;
+
+  // Only regenerate when data actually moves (or the caller supplied text).
+  // A metadata-only patch (weight, tags) leaves searchable_text/hash alone.
+  const dataChanged = patch.data !== undefined;
+  const searchable_text =
+    patch.searchable_text ?? (dataChanged ? defaultSearchableText(mergedData) : existing.searchable_text ?? undefined);
+  const content_hash =
+    patch.content_hash ?? (dataChanged ? contentHash(mergedData) : existing.content_hash ?? undefined);
+
+  return backend.update(id, {
+    ...patch,
+    data: mergedData,
+    searchable_text,
+    content_hash,
+  });
+}
+
 export async function upsertRecord(input: RecordInput, opts: AddOptions = {}): Promise<UpsertResult> {
   const backend = await getBackend();
   const { searchable_text, content_hash, embedding, embedding_model } = await prepareRecord(input, opts, 'sync');

--- a/src/lib/memory/runtime.ts
+++ b/src/lib/memory/runtime.ts
@@ -139,9 +139,15 @@ export async function addRecord(input: RecordInput, opts: AddOptions = {}): Prom
  * Fixes the stale-searchable_text bug: `backend.update` on its own keeps
  * the old searchable_text, so `mem update` used to leave FTS pointing at
  * pre-edit content (and agent-authored records that were progressively
- * enriched via update never became findable on their new fields). Embedding
- * refresh is intentionally left to `mem reindex` — this only touches the
- * text + hash, which is cheap and needs no API call.
+ * enriched via update never became findable on their new fields).
+ *
+ * Embedding refresh is left to `mem reindex`, but it self-heals: when the
+ * regenerated text differs, `backend.update` nulls the row's embedding
+ * bookkeeping so the next reindex re-embeds it (no expensive API call on
+ * the edit itself). Note this uses `defaultSearchableText` even for synced
+ * types whose profile declares a custom `memory.searchable` block — the
+ * next sync run rewrites it from the profile paths, so it self-heals there
+ * too; interactive edits to synced rows are rare anyway.
  */
 export async function updateRecord(
   id: string,

--- a/src/lib/memory/schema.ts
+++ b/src/lib/memory/schema.ts
@@ -12,7 +12,7 @@
  * See docs/plans/unified-memory.md §4 for design rationale.
  */
 
-export const SCHEMA_VERSION = '2.1.0';
+export const SCHEMA_VERSION = '2.2.0';
 
 // `pg_trgm` was in the original mem schema but nothing in the unified query
 // layer uses it; dropped to keep optional-extension backends happy. Can be
@@ -140,19 +140,31 @@ END $$;
 `;
 
 export const FUNCTIONS_SQL = `
--- Enforce global uniqueness of the "keys" array across records.
+-- Enforce uniqueness of the "keys" array across ACTIVE records only.
+--
+-- Scoping to active is deliberate: an archived record must not squat on a
+-- key forever. If it did, re-adding the same identity (e.g. a person who
+-- was archived and re-surfaced) would hard-fail with 23505 and the key
+-- could never be reclaimed. So:
+--   - Only ACTIVE incoming rows are checked (an archived NEW row can hold
+--     any keys, including ones a live record also holds — provenance).
+--   - Conflicts are only raised against other ACTIVE records.
+-- Array-overlap uniqueness can't be expressed as a partial UNIQUE index
+-- (btree can't index "arrays overlap"), so the invariant lives here in a
+-- trigger. find-by-source, key lookups, and mem_upsert_by_keys all
+-- prefer active rows to match this scoping (see below).
 CREATE OR REPLACE FUNCTION mem_enforce_key_uniqueness()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$
 DECLARE
     conflicting_id UUID;
 BEGIN
-    IF NEW.keys IS NULL THEN RETURN NEW; END IF;
+    IF NEW.keys IS NULL OR NEW.status <> 'active' THEN RETURN NEW; END IF;
     SELECT id INTO conflicting_id
     FROM mem_records
-    WHERE keys && NEW.keys AND id != NEW.id
+    WHERE keys && NEW.keys AND id != NEW.id AND status = 'active'
     LIMIT 1;
     IF conflicting_id IS NOT NULL THEN
-        RAISE EXCEPTION 'Key conflict: one or more keys in % already exist on record %',
+        RAISE EXCEPTION 'Key conflict: one or more keys in % already exist on active record %',
             NEW.keys, conflicting_id USING ERRCODE = 'unique_violation';
     END IF;
     RETURN NEW;
@@ -259,14 +271,15 @@ DECLARE
 BEGIN
     -- Deterministic pick when more than one row's keys[] overlap p_keys
     -- (e.g. the incoming row identity-merges with an old Attio-id row AND
-    -- a newer email-keyed row from a separate sync). Newest-updated wins;
-    -- ties broken by id. Without ORDER BY, PG returns whichever row the
-    -- planner happens to surface first, leaving the loser persisted with
-    -- overlapping keys and breaking the keys-are-unique invariant.
+    -- a newer email-keyed row from a separate sync). Active rows win over
+    -- archived (key uniqueness is scoped to active, so an archived dupe may
+    -- coexist — never merge into it when a live owner exists); then newest-
+    -- updated; ties broken by id. Without ORDER BY, PG returns whichever
+    -- row the planner surfaces first, breaking the keys-are-unique invariant.
     SELECT r.id INTO existing_id
     FROM mem_records r
     WHERE r.keys && p_keys
-    ORDER BY r.updated_at DESC NULLS LAST, r.id ASC
+    ORDER BY (r.status = 'active') DESC, r.updated_at DESC NULLS LAST, r.id ASC
     LIMIT 1;
 
     IF existing_id IS NOT NULL THEN
@@ -352,12 +365,12 @@ DECLARE
 BEGIN
     v_embedding := CASE WHEN p_embedding IS NOT NULL THEN p_embedding::vector ELSE NULL END;
 
-    -- See no-vector variant for ORDER BY rationale (deterministic pick
-    -- when multiple rows' keys overlap p_keys).
+    -- See no-vector variant for ORDER BY rationale (active-preferred,
+    -- deterministic pick when multiple rows' keys overlap p_keys).
     SELECT r.id INTO existing_id
     FROM mem_records r
     WHERE r.keys && p_keys
-    ORDER BY r.updated_at DESC NULLS LAST, r.id ASC
+    ORDER BY (r.status = 'active') DESC, r.updated_at DESC NULLS LAST, r.id ASC
     LIMIT 1;
 
     IF existing_id IS NOT NULL THEN


### PR DESCRIPTION
Fixes five verified issues in the `one mem` memory subsystem, all surfaced while building an external dedupe/app on top of the store. Verified against real CEO-workspace data (throwaway records only, archived after). Version bumped **1.48.0 → 1.49.0**, schema **2.1.0 → 2.2.0** (existing stores re-migrate once on next open, then fast-path).

## The five fixes

1. **Keys couldn't be modified after creation** — `mem update '{"keys":[...]}'` silently buried keys under `data.keys`. New first-class `one mem key <id> --add/--remove/--set <csv>`, backed by an atomic `backend.updateKeys` that enforces uniqueness and reports **which** key collided and **which active record** owns it. `mem update` now rejects a top-level `keys` and points at `mem key`.

2. **Key uniqueness included archived records** — an archived duplicate hard-failed new inserts with 23505 and permanently squatted on its key (blocked the external dedupe). `mem_enforce_key_uniqueness` is now scoped to active rows (array-overlap uniqueness can't be a partial UNIQUE index, so it stays a trigger); `find-by-source` and both `mem_upsert_by_keys` variants prefer active.

3. **`searchable_text` NULL/stale on canonical records** — `mem update` kept the old text (FTS pointed at pre-edit content); many agent/SDK-written records landed NULL entirely. Updates now regenerate `searchable_text`+`content_hash` from merged data via `runtime.updateRecord`; new `mem reindex --searchable [--all]` backfills NULL/stale rows from each record's own data (no embedding provider needed; regenerated rows re-queue for embedding).

4. **Searchable text led with UUID noise** — Attio records started their `searchable_text` with workspace/object/record UUIDs + timestamps, burying names/emails. `defaultSearchableText` rewritten: skips UUIDs/timestamps/opaque-id keys, descends Attio's nested `values.*` shape, emits name/title/email first, de-dupes. Applies on next sync **and** via the reindex backfill.

5. **Concurrent CLI invocations deadlocked (40P01)** — every process ran the full `ensureSchema` DDL transaction at startup. `ensureSchema` now fast-paths on a schema-version check (no advisory lock, no DDL) when already current; only a version mismatch does the locked one-time setup.

## Verification (real CLI runs in `/Users/moe/CEO`)
- **1**: `mem key --add/--set/--remove` work; claiming a live person's key errors naming the owner + type.
- **2**: archived record A frees its key → active B claims it; `find-by-source` resolves to active B.
- **3**: `mem update` refreshes text; `mem reindex --searchable` filled throwaway NULL rows.
- **4**: Attio sample `87d81246… 7be572b1… <ts>…` → `Patrick O'Keeffe … Head of Engineering patrick.okeeffe@circuit.ai`.
- **5**: 8 concurrent `mem get` all succeed, no 40P01.

## Tests & docs
- New `src/lib/memory/embedding.test.ts` (builder: UUID/timestamp skipping, Attio nesting, priority ordering, dedupe).
- New PGlite integration cases: `updateKeys` (ok/conflict/not_found), active-scoped uniqueness + `find-by-source` preference, `listForSearchableBackfill`+`updateSearchableText`.
- Docs updated: `one guide memory`, `skills/one/SKILL.md`, `README.md`.
- Typecheck + build clean; suite 272 pass / 6 fail (pre-existing `resolveConfig` failures, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RupfZ559iRfz6TYHf7eaF