### PR TITLE
fix(ci): publish on node 22 so releases stop failing at npm install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          # Node 22 (Active LTS). Node 20 is deprecated on GitHub Actions
+          # runners AND was dropped by npm@latest (12.x needs
+          # ^22.22.2 || ^24.15.0 || >=26), which broke the publish job.
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org/'
+      # Latest npm for OIDC trusted publishing (the id-token: write flow
+      # below). Compatible now that the job runs on node 22.
       - name: Install latest npm
         run: npm install -g npm@latest
       - name: Install dependencies


### PR DESCRIPTION
## Problem

The **v1.49.0 release published nothing to npm** — the "Publish Package to NPM" workflow failed at the `Install latest npm` step:

```
npm error code EBADENGINE
npm error notsup Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`publish.yml` pins node **20** and runs `npm install -g npm@latest`. Since v1.48.0 shipped, `npm@latest` moved to **12.x**, which dropped node 20. So **every** release since that bump fails — this is infra, not tied to any package change. GitHub Actions has also **deprecated node 20** on its runners.

## Fix

Bump the publish job to **node 22** (Active LTS) and keep `npm@latest` (needed for the OIDC trusted-publishing / `id-token: write` flow). No package or version change — 1.49.0 is not yet on npm and still needs to publish.

## After merge

The `v1.49.0` git tag/release currently points at the pre-fix commit, so its workflow file is the broken one. To actually ship 1.49.0, the release must be re-cut against the merged commit (delete + recreate the `v1.49.0` release targeting updated `main`), which re-fires the publish workflow with node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RupfZ559iRfz6TYHf7eaF