### PR TITLE
feat(list): report per-connection access level, mirroring the MCP list tool (v1.50.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Opens your browser, you authorize, done. The CLI polls until the connection is l
 
 ### `one list`
 
-List your active connections with their status and connection keys.
+List your active connections with their status, connection keys, and what your access config lets you run on each.
 
 ```bash
 one list
@@ -192,6 +192,37 @@ one list
 ```
 
 You need the connection key (rightmost column) when executing actions.
+
+**Access reporting.** Every connection carries an `access` field describing what the current [access control](#one-config) config permits — so an agent knows its reach up front instead of discovering it as a failure mid-workflow. Three policies:
+
+| Policy | Means | Shown when |
+|--------|-------|-----------|
+| `{"policy": "full"}` | Every action on the connection | Default (admin, no action allowlist) |
+| `{"policy": "methods", "methods": ["GET"]}` | Only actions with those HTTP methods | Permission level is `read` or `write` |
+| `{"policy": "actions", "actions": [{"actionId": "...", "title": "...", "method": "..."}]}` | Only these specific actions | An action allowlist is configured |
+
+An action allowlist wins over the permission level (and is then method-filtered by it). When the policy is `actions`, those actions are exactly what may run — no `actions search` needed.
+
+```jsonc
+// one --agent list
+{
+  "total": 2,
+  "showing": 2,
+  "connections": [
+    {
+      "platform": "gmail",
+      "state": "operational",
+      "key": "live::gmail::default::abc123",
+      "access": { "policy": "methods", "methods": ["GET"] }
+    }
+  ],
+  "accessHint": "Permission level \"read\": only GET actions will execute."
+}
+```
+
+`knowledgeOnly: true` appears when knowledge-only mode is on (execution disabled), and `unresolvedActionIds` lists any allowlisted action ids that could not be looked up. In human output, an `Access` column and a summary note appear only when access is actually scoped.
+
+This mirrors the `access` field on the One MCP server's `list_one_integrations` tool, so both surfaces report access the same way.
 
 ### `one connection delete <connection-key>`
 
@@ -575,6 +606,8 @@ one config
 | Knowledge-only mode | Enable/disable execution | Off |
 
 Settings propagate automatically to all installed agent configs.
+
+Run [`one list`](#one-list) to see the effect: each connection reports an `access` field describing exactly what these settings let you run on it.
 
 #### `one config skills status` / `one config skills sync`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.49.0",
+      "version": "1.50.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -45,7 +45,21 @@ Always follow this sequence when the user wants to do something on a connected p
 one --agent connection list
 ```
 
-Returns connected platforms with their connection keys (needed for execution) and platform names in kebab-case (needed for searching).
+Returns connected platforms with their connection keys (needed for execution), platform names in kebab-case (needed for searching), and an `access` field per connection telling you what you may run there.
+
+**Read `access` before you plan a workflow** — it saves you from discovering a restriction as a 403 halfway through:
+
+| `access` | What it means |
+|----------|---------------|
+| `{"policy": "full"}` | Every action on this connection is available |
+| `{"policy": "methods", "methods": ["GET"]}` | Only actions with these HTTP methods will execute — don't propose writes |
+| `{"policy": "actions", "actions": [...]}` | Only these exact actions may run. Each has `actionId`, `title`, `method` — **use them directly and skip `actions search`** |
+
+Two more fields appear only when relevant:
+- `"knowledgeOnly": true` — `actions execute` is disabled. Read knowledge and write integration code instead of executing.
+- `"unresolvedActionIds": [...]` — allowlisted ids that couldn't be looked up; treat them as unavailable and tell the user.
+
+An empty `actions` array means the allowlist grants nothing on that connection — say so rather than searching for alternatives.
 
 ### 1b. Delete a connection
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,7 +82,7 @@ program
     one whoami                            Show current user, organization, and project
 
   Workflow (use these in order):
-    1. one list                           List your connected platforms and connection keys
+    1. one list                           List connected platforms, keys, and your access on each
     2. one actions search <platform> <q>  Search for actions using natural language
     3. one actions knowledge <plat> <id>  Get full docs for an action (ALWAYS do this before execute)
     4. one actions execute <p> <id> <key> Execute the action
@@ -430,7 +430,7 @@ connection
 connection
   .command('list')
   .alias('ls')
-  .description('List your connections')
+  .description('List your connections and what your access config lets you run on each')
   .option('-s, --search <query>', 'Filter connections by platform name')
   .option('-l, --limit <n>', 'Max connections to return (agent mode default: 20)')
   .action(async (options) => {

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -1,12 +1,13 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { getApiKey, getApiBase, getAccessControlFromAllSources, ensureWhoAmI, getEnvFromApiKey } from '../lib/config.js';
-import { OneApi, TimeoutError } from '../lib/api.js';
+import { OneApi, TimeoutError, isMethodAllowed, PERMISSION_METHODS } from '../lib/api.js';
+import { resolveAllowedActions, computeConnectionAccess, formatAccess } from '../lib/access.js';
 import { openConnectionPage, getConnectionUrl, type ConnectionUrlParams } from '../lib/browser.js';
 import { findPlatform, findSimilarPlatforms } from '../lib/platforms.js';
 import { printTable } from '../lib/table.js';
 import * as output from '../lib/output.js';
-import type { Connection } from '../lib/types.js';
+import type { Connection, ConnectionAccess, PermissionLevel } from '../lib/types.js';
 
 export async function connectionAddCommand(platformArg?: string, options?: { tag?: string }): Promise<void> {
   if (output.isAgentMode()) {
@@ -177,10 +178,25 @@ export async function connectionListCommand(options?: { search?: string; limit?:
 
     // Filter by access control settings
     const ac = getAccessControlFromAllSources();
+    const permissions: PermissionLevel = ac.permissions || 'admin';
     const allowedKeys = ac.connectionKeys || ['*'];
+    const actionIds = ac.actionIds || ['*'];
+    const knowledgeOnly = ac.knowledgeAgent || false;
     const accessFiltered = allowedKeys.includes('*')
       ? allConnections
       : allConnections.filter(conn => allowedKeys.includes(conn.key));
+
+    // Resolve what the access config actually permits, so the listing answers
+    // "what can I run here" without a follow-up search. No network cost unless
+    // an action allowlist is configured.
+    const resolvedActions = await resolveAllowedActions(api, actionIds);
+    const unresolvedActionIds = actionIds.includes('*')
+      ? []
+      : actionIds.filter(id => !resolvedActions.some(a => a.actionId === id));
+    const grantedActions = resolvedActions.filter(a => isMethodAllowed(a.method, permissions));
+    const accessFor = (platform: string): ConnectionAccess =>
+      computeConnectionAccess(platform, permissions, actionIds, grantedActions);
+    const hintText = accessHint(permissions, actionIds, knowledgeOnly);
 
     // Filter by search query if provided
     const searchQuery = options?.search?.toLowerCase();
@@ -204,7 +220,11 @@ export async function connectionListCommand(options?: { search?: string; limit?:
           key: conn.key,
           ...(conn.name && { name: conn.name }),
           ...(conn.tags?.length && { tags: conn.tags }),
+          access: accessFor(conn.platform),
         })),
+        ...(knowledgeOnly && { knowledgeOnly: true }),
+        ...(unresolvedActionIds.length > 0 && { unresolvedActionIds }),
+        ...(hintText && { accessHint: hintText }),
         ...(limited.length < filtered.length && {
           hint: `Showing ${limited.length} of ${filtered.length} connections. Use --search <query> to filter by platform or --limit <n> to see more.`,
         }),
@@ -241,9 +261,13 @@ export async function connectionListCommand(options?: { search?: string; limit?:
       state: conn.state,
       key: conn.key,
       tags: conn.tags?.length ? conn.tags.join(', ') : '',
+      access: formatAccess(accessFor(conn.platform)),
     }));
 
     const hasTags = rows.some(r => r.tags);
+    // Only worth a column when access is actually scoped — an all-"full"
+    // column is noise.
+    const hasScopedAccess = rows.some(r => r.access !== 'full');
 
     printTable(
       [
@@ -252,11 +276,23 @@ export async function connectionListCommand(options?: { search?: string; limit?:
         { key: 'state', label: 'Status' },
         { key: 'key', label: 'Connection Key', color: pc.dim },
         ...(hasTags ? [{ key: 'tags', label: 'Tags', color: pc.dim }] : []),
+        ...(hasScopedAccess ? [{ key: 'access', label: 'Access', color: pc.yellow }] : []),
       ],
       rows
     );
 
     console.log();
+
+    if (hintText) {
+      const lines = [hintText];
+      if (unresolvedActionIds.length > 0) {
+        lines.push(
+          `Could not resolve ${unresolvedActionIds.length} allowlisted action id(s): ${unresolvedActionIds.join(', ')}`
+        );
+      }
+      p.note(`${wrapText(lines.join('\n'))}\n\nChange it with: ${pc.cyan('one config')}`, 'Access');
+    }
+
     if (displayed.length < filtered.length) {
       p.note(
         `Showing ${displayed.length} of ${filtered.length}. Increase --limit or run without it to see all.`,
@@ -350,6 +386,56 @@ export async function connectionDeleteCommand(
     deleteSpinner.stop('Failed to delete connection');
     output.error(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
+}
+
+/**
+ * One-line explanation of a restricted access config, told from the caller's
+ * point of view ("you can only..."). Returns null when nothing is restricted —
+ * an unrestricted config needs no explanation.
+ */
+function accessHint(
+  permissions: PermissionLevel,
+  actionIds: string[],
+  knowledgeOnly: boolean
+): string | null {
+  const parts: string[] = [];
+
+  if (!actionIds.includes('*')) {
+    parts.push(
+      "Action-scoped: each connection's `access.actions` are the only actions you may run — " +
+      'use them directly, no `actions search` needed.'
+    );
+  } else if (permissions !== 'admin') {
+    const methods = PERMISSION_METHODS[permissions]?.join(', ') ?? '';
+    parts.push(`Permission level "${permissions}": only ${methods} actions will execute.`);
+  }
+
+  if (knowledgeOnly) {
+    parts.push('Knowledge-only mode: `actions execute` is disabled — read knowledge and write code instead.');
+  }
+
+  return parts.length > 0 ? parts.join(' ') : null;
+}
+
+/** Hard-wrap prose so a long hint doesn't stretch the note box past the terminal. */
+function wrapText(text: string, width = 72): string {
+  return text
+    .split('\n')
+    .map(paragraph => {
+      const lines: string[] = [];
+      let line = '';
+      for (const word of paragraph.split(/\s+/)) {
+        if (line && line.length + 1 + word.length > width) {
+          lines.push(line);
+          line = word;
+        } else {
+          line = line ? `${line} ${word}` : word;
+        }
+      }
+      if (line) lines.push(line);
+      return lines.join('\n');
+    })
+    .join('\n');
 }
 
 function getStatusIndicator(state: Connection['state']): string {

--- a/src/lib/access.test.ts
+++ b/src/lib/access.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { computeConnectionAccess, formatAccess, resolveAllowedActions } from './access.js';
+import type { ActionDetails, ResolvedAllowedAction } from './types.js';
+
+const granted: ResolvedAllowedAction[] = [
+  { actionId: 'a1', title: 'Send Email', method: 'POST', platform: 'gmail' },
+  { actionId: 'a2', title: 'List Messages', method: 'GET', platform: 'gmail' },
+  { actionId: 'a3', title: 'Post Message', method: 'POST', platform: 'slack' },
+];
+
+describe('computeConnectionAccess', () => {
+  it('reports full access for admin with no action allowlist', () => {
+    assert.deepEqual(
+      computeConnectionAccess('gmail', 'admin', ['*'], []),
+      { policy: 'full' }
+    );
+  });
+
+  it('reports the method set for a non-admin permission level', () => {
+    assert.deepEqual(
+      computeConnectionAccess('gmail', 'read', ['*'], []),
+      { policy: 'methods', methods: ['GET'] }
+    );
+    assert.deepEqual(
+      computeConnectionAccess('gmail', 'write', ['*'], []),
+      { policy: 'methods', methods: ['GET', 'POST', 'PUT', 'PATCH'] }
+    );
+  });
+
+  it('lets an action allowlist win over the permission level, scoped to the platform', () => {
+    const access = computeConnectionAccess('gmail', 'admin', ['a1', 'a2', 'a3'], granted);
+    assert.equal(access.policy, 'actions');
+    assert.deepEqual(access.policy === 'actions' ? access.actions : null, [
+      { actionId: 'a1', title: 'Send Email', method: 'POST' },
+      { actionId: 'a2', title: 'List Messages', method: 'GET' },
+    ]);
+  });
+
+  it('reports an empty action list for a platform the allowlist does not cover', () => {
+    assert.deepEqual(
+      computeConnectionAccess('shopify', 'admin', ['a1'], granted),
+      { policy: 'actions', actions: [] }
+    );
+  });
+});
+
+describe('formatAccess', () => {
+  it('renders each policy for the table', () => {
+    assert.equal(formatAccess({ policy: 'full' }), 'full');
+    assert.equal(formatAccess({ policy: 'methods', methods: ['GET', 'POST'] }), 'GET, POST');
+    assert.equal(formatAccess({ policy: 'actions', actions: [] }), 'none');
+  });
+
+  it('truncates long action lists', () => {
+    const actions = granted.map(({ actionId, title, method }) => ({ actionId, title, method }));
+    assert.equal(
+      formatAccess({ policy: 'actions', actions }),
+      'Send Email (POST), List Messages (GET) +1 more'
+    );
+  });
+});
+
+// resolveAllowedActions goes through the on-disk knowledge cache, so sandbox
+// $HOME to a temp dir instead of touching the developer's real ~/.one/.
+describe('resolveAllowedActions', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-cli-access-test-'));
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function stubApi(byId: Record<string, Partial<ActionDetails> | Error>) {
+    const calls: string[] = [];
+    const api = {
+      async getActionDetailsWithMeta(actionId: string) {
+        calls.push(actionId);
+        const entry = byId[actionId];
+        if (!entry || entry instanceof Error) {
+          throw entry ?? new Error(`Action with ID ${actionId} not found`);
+        }
+        return { data: entry as ActionDetails, etag: null, status: 200 };
+      },
+    };
+    return { api, calls };
+  }
+
+  it('makes no API calls for an unrestricted allowlist', async () => {
+    const { api, calls } = stubApi({});
+    assert.deepEqual(await resolveAllowedActions(api, ['*']), []);
+    assert.deepEqual(calls, []);
+  });
+
+  it('resolves ids to title, method, and owning platform', async () => {
+    const { api } = stubApi({
+      a1: { _id: 'a1', title: 'Send Email', method: 'POST', path: '/send', connectionPlatform: 'gmail' },
+      a3: { _id: 'a3', title: 'Post Message', method: 'POST', path: '/post', connectionPlatform: 'slack' },
+    });
+
+    assert.deepEqual(await resolveAllowedActions(api, ['a1', 'a3']), [
+      { actionId: 'a1', title: 'Send Email', method: 'POST', platform: 'gmail' },
+      { actionId: 'a3', title: 'Post Message', method: 'POST', platform: 'slack' },
+    ]);
+  });
+
+  it('skips ids that fail to resolve or carry no platform, keeping the rest', async () => {
+    const { api } = stubApi({
+      a1: { _id: 'a1', title: 'Send Email', method: 'POST', path: '/send', connectionPlatform: 'gmail' },
+      a2: { _id: 'a2', title: 'Orphan', method: 'GET', path: '/x' }, // no connectionPlatform
+      a3: new Error('404'),
+    });
+
+    const resolved = await resolveAllowedActions(api, ['a1', 'a2', 'a3']);
+    assert.deepEqual(resolved.map(a => a.actionId), ['a1']);
+  });
+
+  it('serves repeat lookups from the knowledge cache', async () => {
+    const { api, calls } = stubApi({
+      a1: { _id: 'a1', title: 'Send Email', method: 'POST', path: '/send', connectionPlatform: 'gmail' },
+    });
+
+    await resolveAllowedActions(api, ['a1']);
+    await resolveAllowedActions(api, ['a1']);
+    assert.deepEqual(calls, ['a1'], 'second resolution should hit the cache, not the API');
+  });
+});

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -1,0 +1,108 @@
+/**
+ * Access resolution — turning the configured access control (permission level,
+ * connection scope, action allowlist) into a concrete answer to "what can I run
+ * on this connection?".
+ *
+ * `one list` reports this per connection so an agent knows its reach up front,
+ * instead of discovering it as a 403 halfway through a workflow. The shapes
+ * mirror the One MCP server's `list_one_integrations` `access` field, so an
+ * agent that has learned one surface already understands the other.
+ *
+ * Precedence (same as the MCP server and One core):
+ *   action allowlist  >  permission level  >  full access
+ */
+
+import type { OneApi } from './api.js';
+import { PERMISSION_METHODS } from './api.js';
+import { resolveActionDetails } from './action-details.js';
+import type {
+  ConnectionAccess,
+  PermissionLevel,
+  ResolvedAllowedAction,
+} from './types.js';
+
+/**
+ * Resolves an allowlist of action ids to their metadata (title, method, and
+ * owning platform), so each connection can report the exact actions it may run.
+ *
+ * `['*']` (unrestricted) resolves to an empty list — there is no allowlist to
+ * enumerate, and no network call is made. Ids that fail to resolve, or that
+ * carry no platform, are skipped rather than failing the whole listing; the
+ * caller reports them separately so nothing is dropped silently.
+ *
+ * Resolution goes through the knowledge cache, so a scoped config pays the
+ * lookup once and reads from disk afterwards.
+ */
+export async function resolveAllowedActions(
+  api: Pick<OneApi, 'getActionDetailsWithMeta'>,
+  actionIds: string[]
+): Promise<ResolvedAllowedAction[]> {
+  if (actionIds.includes('*')) return [];
+
+  const resolved = await Promise.all(
+    actionIds.map(async (actionId): Promise<ResolvedAllowedAction | null> => {
+      try {
+        // Silence the stale-cache warning: a listing shouldn't print a network
+        // notice per allowlisted action.
+        const { details } = await resolveActionDetails(api, actionId, { warn: () => {} });
+        if (!details.connectionPlatform) return null;
+        return {
+          actionId,
+          title: details.title,
+          method: details.method,
+          platform: details.connectionPlatform,
+        };
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return resolved.filter((a): a is ResolvedAllowedAction => a !== null);
+}
+
+/**
+ * What the current access config lets you run on a connection of `platform`.
+ *
+ * `grantedActions` is the allowlist already resolved by `resolveAllowedActions`
+ * and filtered by the permission level — pass `[]` when the allowlist is `['*']`.
+ */
+export function computeConnectionAccess(
+  platform: string,
+  permissions: PermissionLevel,
+  allowedActionIds: string[],
+  grantedActions: ResolvedAllowedAction[]
+): ConnectionAccess {
+  if (!allowedActionIds.includes('*')) {
+    const actions = grantedActions
+      .filter(a => a.platform === platform)
+      .map(({ actionId, title, method }) => ({ actionId, title, method }));
+    return { policy: 'actions', actions };
+  }
+
+  const methods = PERMISSION_METHODS[permissions];
+  if (methods !== null) {
+    return { policy: 'methods', methods };
+  }
+
+  return { policy: 'full' };
+}
+
+/**
+ * One-line rendering of a connection's access for the human-readable table.
+ * Action lists are truncated — the full list is in `--agent` output.
+ */
+export function formatAccess(access: ConnectionAccess, maxActions = 2): string {
+  switch (access.policy) {
+    case 'full':
+      return 'full';
+    case 'methods':
+      return access.methods.join(', ');
+    case 'actions': {
+      if (access.actions.length === 0) return 'none';
+      const shown = access.actions.slice(0, maxActions).map(a => `${a.title} (${a.method})`);
+      const rest = access.actions.length - shown.length;
+      return rest > 0 ? `${shown.join(', ')} +${rest} more` : shown.join(', ');
+    }
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -726,7 +726,8 @@ export function replacePathVariables(
 
 import type { PermissionLevel } from './types.js';
 
-const PERMISSION_METHODS: Record<PermissionLevel, string[] | null> = {
+/** `null` means "no method restriction" (admin). */
+export const PERMISSION_METHODS: Record<PermissionLevel, string[] | null> = {
   read: ['GET'],
   write: ['GET', 'POST', 'PUT', 'PATCH'],
   admin: null,

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -43,7 +43,7 @@ Search for actions, read their docs, and execute them. This is the core workflow
 
 **Quick start:**
 \`\`\`bash
-one --agent connection list                                    # See connected platforms
+one --agent connection list                                    # See connected platforms + your access on each
 one --agent connection delete <connection-key>                 # Remove a connection
 one --agent actions search <platform> "<query>" -t execute     # Find an action
 one --agent actions knowledge <platform> <actionId>            # Read docs (REQUIRED)
@@ -132,6 +132,7 @@ Request specific sections:
 - Always use the **exact action ID** from search results — don't guess
 - Always read **knowledge** before executing any action
 - Connection keys come from \`one connection list\` — don't hardcode them
+- \`connection list\` also reports an \`access\` field per connection (\`full\` / \`methods\` / \`actions\`) — read it before planning so you don't propose an action the access config will reject
 - Skills stay in lockstep with the CLI version automatically — every command checks a \`.one-cli-version\` marker in the canonical skill dir and refreshes the files if the CLI has been upgraded. Check manually with \`one config skills status\`; force a resync with \`one config skills sync\`
 `;
 
@@ -147,7 +148,17 @@ Always follow this sequence. Never skip the knowledge step.
 one --agent connection list
 \`\`\`
 
-Returns platforms, status, connection keys, and tags.
+Returns platforms, status, connection keys, tags, and an \`access\` field per connection describing what the current access config lets you run there:
+
+| \`access\` | Meaning |
+|----------|---------|
+| \`{"policy": "full"}\` | Every action on the connection |
+| \`{"policy": "methods", "methods": ["GET"]}\` | Only actions with these HTTP methods will execute |
+| \`{"policy": "actions", "actions": [{"actionId", "title", "method"}]}\` | Only these exact actions — use them directly, skip \`actions search\` |
+
+Also present when relevant: \`knowledgeOnly: true\` (execution disabled — read knowledge and write code instead), \`unresolvedActionIds\` (allowlisted ids that could not be looked up), and \`accessHint\` (a one-line summary of the restriction).
+
+Read \`access\` before planning — it prevents proposing an action the config will reject. Change it with \`one config\`.
 
 ### 1b. Delete a Connection
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,6 +60,37 @@ export interface AccessControlSettings {
   knowledgeAgent?: boolean;
 }
 
+/**
+ * A single action the current access config permits on a connection, resolved
+ * from an allowlisted action id. Same shape as the MCP server's `GrantedAction`.
+ */
+export interface GrantedAction {
+  actionId: string;
+  title: string;
+  method: string;
+}
+
+/**
+ * What the current access config lets you run on one connection, so
+ * `one list` answers "what can I do here" without a search. Same shape as the
+ * MCP server's `ConnectionAccess` (`policy` discriminant):
+ * - `full`: every action on the connection.
+ * - `methods`: only actions whose HTTP method is in the set.
+ * - `actions`: only these specific actions.
+ */
+export type ConnectionAccess =
+  | { policy: 'full' }
+  | { policy: 'methods'; methods: string[] }
+  | { policy: 'actions'; actions: GrantedAction[] };
+
+/**
+ * An allowlisted action id resolved to its metadata, including the platform it
+ * belongs to so it can be bucketed onto the matching connection.
+ */
+export interface ResolvedAllowedAction extends GrantedAction {
+  platform: string;
+}
+
 export interface WhoAmIUser { id: string; name: string; email: string }
 export interface WhoAmIOrg { id: string; name: string }
 export interface WhoAmIProject { id: string; name: string }
@@ -137,6 +168,8 @@ export interface ActionDetails {
   path: string;
   method: string;
   ioSchema?: IoSchema;
+  /** Platform the action belongs to — used to bucket allowlisted actions onto connections. */
+  connectionPlatform?: string;
 }
 
 export interface ActionKnowledgeResponse {


### PR DESCRIPTION
## What

`one list` now reports **what you're allowed to run on each connection**, using the same `access` shape the One MCP server's `list_one_integrations` tool returns. An agent learns its reach from the first call instead of discovering a restriction as a 403 halfway through a workflow.

```jsonc
// one --agent list
{
  "connections": [
    { "platform": "gmail", "key": "live::gmail::…", "access": { "policy": "methods", "methods": ["GET"] } },
    { "platform": "exa",   "key": "live::exa::…",   "access": { "policy": "actions", "actions": [
        { "actionId": "conn_mod_def::…", "title": "Search", "method": "POST" } ] } }
  ],
  "accessHint": "Permission level \"read\": only GET actions will execute."
}
```

Three policies, same precedence as the MCP server and One core — **action allowlist > permission level > full**:

| Policy | When |
|--------|------|
| `full` | admin, no action allowlist (the default) |
| `methods` | permission level is `read` / `write` |
| `actions` | an action allowlist is configured (then method-filtered by the permission level) |

When the policy is `actions`, those are exactly what may run — the agent can skip `actions search` entirely.

## How

- **`src/lib/access.ts`** (new) — `resolveAllowedActions` resolves allowlisted ids to `{actionId, title, method, platform}` through the existing knowledge cache (so a scoped config pays the lookup once, and there is **zero network cost** when the allowlist is `*`, i.e. the default); `computeConnectionAccess` applies the precedence; `formatAccess` renders the table cell.
- **`connection list`** — agent mode adds `access` per connection plus `knowledgeOnly`, `unresolvedActionIds` (allowlisted ids that couldn't be looked up, so nothing is dropped silently), and `accessHint`. Human mode gains an `Access` column and a summary note, **both only when access is actually scoped** — unrestricted output is byte-identical to before.
- `ActionDetails` gains the `connectionPlatform` field the API already returns (the cache was storing it untyped).
- `PERMISSION_METHODS` is exported from `api.ts` rather than duplicated.

## Verification

- New `src/lib/access.test.ts` — 10 tests covering all three policies, allowlist-beats-permissions precedence, platform bucketing, skipped/unresolvable ids, no-network on `*`, and cache reuse on repeat lookups. All pass.
- Exercised end-to-end against the live API for every path: default (`full`), `ONE_PERMISSIONS=read`/`write` (`methods`), `ONE_ACTION_IDS=…` incl. a deliberately bogus id (`actions` + `unresolvedActionIds`), and `ONE_KNOWLEDGE_AGENT=true`.
- `npm run typecheck` clean (only the pre-existing optional-dependency errors in `lib/memory/*`).
- `npm test`: 284/290 pass. The 6 failures are pre-existing `resolveConfig` cases that fail identically on a clean tree (macOS `/private/var` vs `/var` symlink), untouched by this PR.

## Docs

Updated per the documentation-first rule: `README.md`, `skills/one/SKILL.md`, `src/lib/guide-content.ts` (overview + actions guide), and `src/cli.ts` help text. Version bumped 1.49.0 → 1.50.0 with `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)