### PR TITLE
chore: update platform count in user-facing copy to 600+

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="https://withone.ai/knowledge"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.withone.ai%2Fopen%2Fcount%2Ftools" alt="tools"></a>
 </p>
 
-One gives your AI agent authenticated access to 400+ platforms - Gmail, Slack, Shopify, HubSpot, Stripe, Notion, and everything else - through a single interface. No API keys to juggle, no OAuth flows to build, no request formats to memorize. Connect a platform once, and your agent can search for actions, read the docs, and execute API calls in seconds.
+One gives your AI agent authenticated access to 600+ platforms - Gmail, Slack, Shopify, HubSpot, Stripe, Notion, and everything else - through a single interface. No API keys to juggle, no OAuth flows to build, no request formats to memorize. Connect a platform once, and your agent can search for actions, read the docs, and execute API calls in seconds.
 
 ## Install
 
@@ -241,7 +241,7 @@ Shows the connection details and asks for confirmation before deleting. Use `--f
 
 ### `one platforms`
 
-Browse all 200+ available platforms.
+Browse all 600+ available platforms.
 
 ```bash
 one platforms              # all platforms

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -20,7 +20,7 @@ description: |
 
 # One CLI
 
-You have access to the One CLI which lets you interact with 400+ third-party platforms through their APIs. Always include the `--agent` flag right after `one` for structured JSON output.
+You have access to the One CLI which lets you interact with 600+ third-party platforms through their APIs. Always include the `--agent` flag right after `one` for structured JSON output.
 
 If the user wants a separate API key / connections for a specific project (vs. their default), walk them through running `one init` from that project folder and picking the "project" scope — see `references/scoping.md`. For monorepo subprojects (where a parent already has `.git`/`package.json`), have them `mkdir .one` in the subproject first so the config is keyed to that dir, not the monorepo root.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ const program = new Command();
 program
   .name('one')
   .option('--agent', 'Machine-readable JSON output (no colors, spinners, or prompts)')
-  .description(`One CLI — Connect AI agents to 400+ platforms through one interface.
+  .description(`One CLI — Connect AI agents to 600+ platforms through one interface.
 
   Setup:
     one login                             Authenticate via browser (opens app.withone.ai)
@@ -142,7 +142,7 @@ program
         -d '{"to":"j@example.com","subject":"Hello","body":"Hi!","connectionKey":"live::gmail::default::abc123"}'
 
   Platform names are lowercase; multi-word names use dashes (e.g. hubspot, ship-station, google-calendar).
-  Run 'one platforms' to browse all 400+ available platforms.`)
+  Run 'one platforms' to browse all 600+ available platforms.`)
   .version(version);
 
 // Fire a non-blocking version check alongside every command

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -941,7 +941,7 @@ function printOnboardingPrompt(): void {
   console.log(pc.cyan('  ┌─────────────────────────────────────────────────────────────'));
   console.log(pc.cyan('  │'));
   console.log(pc.cyan('  │  The One CLI (`one`) is now installed on this machine. It'));
-  console.log(pc.cyan('  │  lets you interact with 400+ third-party platforms (Gmail,'));
+  console.log(pc.cyan('  │  lets you interact with 600+ third-party platforms (Gmail,'));
   console.log(pc.cyan('  │  Slack, Shopify, HubSpot, Stripe, GitHub, etc.) through'));
   console.log(pc.cyan('  │  their APIs. Whenever you need to interact with any'));
   console.log(pc.cyan('  │  third-party platform or external service, use the `one`'));
@@ -1294,7 +1294,7 @@ async function promptConnectIntegrations(apiKey: string, connParams?: Connection
         label: i.label,
         hint: i.hint,
       })),
-      { value: 'more', label: 'Browse all 200+ platforms' },
+      { value: 'more', label: 'Browse all 600+ platforms' },
       { value: 'skip', label: 'Skip for now', hint: 'you can always run one add later' },
     ];
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -277,7 +277,7 @@ export async function loginCommand(): Promise<void> {
   console.log(pc.cyan('  ┌─────────────────────────────────────────────────────────────'));
   console.log(pc.cyan('  │'));
   console.log(pc.cyan('  │  The One CLI (`one`) is now installed on this machine. It'));
-  console.log(pc.cyan('  │  lets you interact with 400+ third-party platforms (Gmail,'));
+  console.log(pc.cyan('  │  lets you interact with 600+ third-party platforms (Gmail,'));
   console.log(pc.cyan('  │  Slack, Shopify, HubSpot, Stripe, GitHub, etc.) through'));
   console.log(pc.cyan('  │  their APIs. Whenever you need to interact with any'));
   console.log(pc.cyan('  │  third-party platform or external service, use the `one`'));

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -51,7 +51,7 @@ function buildStep1(): { step: number; totalSteps: number; message: string; next
     nextCommand: 'one onboard --step 2',
     message: `# One CLI — Agent Onboarding
 
-You now have access to the One CLI. It connects you to 400+ platforms
+You now have access to the One CLI. It connects you to 600+ platforms
 (Gmail, Slack, Stripe, Notion, etc.) — you'll learn the details shortly.
 
 IMPORTANT: Your only task right now is to send the message below to the
@@ -61,7 +61,7 @@ Do not offer demos yet. Just send this message and wait for their reply:
 ---
 
 I just got access to the One CLI — it connects me to your platforms like
-Gmail, Slack, Stripe, and 400+ others so I can work with them directly.
+Gmail, Slack, Stripe, and 600+ others so I can work with them directly.
 I'll show you what I can do in a moment.
 
 First, one quick setup step: right now only this conversation knows about
@@ -96,7 +96,7 @@ If they declined, skip this section.
 ## One CLI — Platform Integrations
 
 The One CLI (\`one\`) is installed and configured on this machine. It is a
-command-line tool that gives AI agents the ability to interact with 400+
+command-line tool that gives AI agents the ability to interact with 600+
 third-party platforms (Gmail, Slack, Shopify, HubSpot, Stripe, GitHub,
 Notion, Salesforce, etc.) through a single, unified interface.
 
@@ -201,7 +201,7 @@ function buildStep3(connections: Connection[]): { step: number; totalSteps: numb
 The user can connect any of these popular platforms:
 Gmail, Google Calendar, Slack, Notion, Shopify, Stripe, HubSpot, GitHub,
 Salesforce, QuickBooks, Asana, Jira, Linear, Intercom, Zendesk, Twilio,
-and 400+ more. Run \`one platforms\` for the full list.`);
+and 600+ more. Run \`one platforms\` for the full list.`);
 
   sections.push('## Onboarding complete!\n\nYou\'re all set. Use `one --agent guide` any time you need the full reference.');
 
@@ -236,7 +236,7 @@ platform before you can start using actions. Suggest they run:
   one add slack
   one add <any-platform>
 
-Run \`one platforms\` to see all 400+ available platforms.`;
+Run \`one platforms\` to see all 600+ available platforms.`;
   }
 
   const header = `## Current State

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -38,7 +38,7 @@ Before using any feature, read its guide section first: \`one guide actions\`, \
 
 ## Features
 
-### 1. Actions — Execute API calls on 400+ platforms
+### 1. Actions — Execute API calls on 600+ platforms
 Search for actions, read their docs, and execute them. This is the core workflow.
 
 **Quick start:**


### PR DESCRIPTION
## What

The CLI tells users it connects to **400+ platforms**. The live count is **606** (`api.withone.ai/open/count/platforms`). Two spots were staler still, at 200+.

This updates 13 strings to `600+`. Copy only, no behavior change.

## Where it showed

| File | Surface |
|---|---|
| `src/cli.ts` | `one --help` description + platforms hint |
| `src/commands/init.ts` | post-install banner, platform picker label (was 200+) |
| `src/commands/login.ts` | post-login banner |
| `src/commands/onboard.ts` | onboarding copy and the CLAUDE.md block written into user projects |
| `src/lib/guide-content.ts` | `one guide` |
| `skills/one/SKILL.md` | skill shipped to user projects |
| `README.md` | intro, `one platforms` section (was 200+) |

The onboard and skill strings matter most: they get written into user projects, so the stale number propagates into agent context.

## Note on the 200+ instances

A grep for `400+` alone misses them. Worth grepping `[0-9]+\+ platforms` rather than a specific number next time this is refreshed.

## Verification

- `npm run build` and `npm run typecheck` clean
- Built binary checked: `one --help` prints 600+ on both lines
- `npm test` 385 pass / 6 fail, and the same 6 (`resolveConfig`) fail identically on a clean `origin/main` checkout, so they are pre-existing and unrelated
- Not published to npm, per the team's release flow

Left alone deliberately: `Connect 2+ platforms to unlock cross-platform workflows` in the guide, which is a real threshold and not a catalog count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)