### PR TITLE
fix(sync): never destroy a healthy database on a driver fault (v1.52.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.52.2",
+  "version": "1.52.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.52.2",
+      "version": "1.52.3",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.52.1",
+  "version": "1.52.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.52.1",
+      "version": "1.52.2",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.52.2",
+  "version": "1.52.3",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.52.1",
+  "version": "1.52.2",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -1007,7 +1007,7 @@ Every \`sync X\` command is also exposed as \`mem sync X\` — same handlers, sa
 | Command | What it does |
 |---------|-------------|
 | \`sync profiles [platform]\` | List built-in pre-validated profiles |
-| \`sync doctor\` | Verify sync engine health |
+| \`sync doctor\` | Verify sync engine health. **Exits non-zero when not ready**, so \`one sync doctor && one sync run <platform>\` is a safe gate — run it first from cron/launchd, where a bare PATH can select a Node the native driver wasn't built for |
 | \`sync models <platform>\` | Discover available models |
 | \`sync init <plat> <model>\` | Create/patch profile (seeds from built-in, auto-tests) |
 | \`sync test <plat>/<model>\` | Validate profile. \`--show-searchable\` previews embedded text across 5 samples with per-path hit rates |

--- a/src/lib/memory/sync/db-integrity.test.ts
+++ b/src/lib/memory/sync/db-integrity.test.ts
@@ -1,0 +1,128 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isDriverFault, passesIntegrityCheck, backupPathFor } from './db.js';
+import type { loadSqlite } from './sqlite-loader.js';
+
+// Regression cover for #178: a Node ABI mismatch made openDatabase() treat a
+// healthy database as corrupt, rename it to a fixed `<db>.bak` and write an
+// empty replacement — destroying a 747MB live sync database. These tests pin
+// the three guarantees that fix rests on, without needing the native module
+// installed (better-sqlite3 is an optionalDependency and is frequently absent).
+
+type Ctor = Awaited<ReturnType<typeof loadSqlite>>;
+
+/** Minimal better-sqlite3 stand-in that records how it was constructed. */
+function fakeCtor(behaviour: {
+  throwOnOpen?: unknown;
+  quickCheck?: unknown;
+  onClose?: () => void;
+}): { ctor: Ctor; calls: Array<{ path: string; opts: unknown }> } {
+  const calls: Array<{ path: string; opts: unknown }> = [];
+  const ctor = function (this: unknown, path: string, opts: unknown) {
+    calls.push({ path, opts });
+    if (behaviour.throwOnOpen) throw behaviour.throwOnOpen;
+    return {
+      pragma: (_stmt: string) => behaviour.quickCheck,
+      close: () => behaviour.onClose?.(),
+    };
+  } as unknown as Ctor;
+  return { ctor, calls };
+}
+
+describe('isDriverFault — environment faults must never be mistaken for corruption', () => {
+  it('flags ERR_DLOPEN_FAILED by error code', () => {
+    const err = Object.assign(new Error('dlopen failed'), { code: 'ERR_DLOPEN_FAILED' });
+    assert.equal(isDriverFault(err), true);
+  });
+
+  it('flags the exact ABI-mismatch message from the #178 report', () => {
+    const err = new Error(
+      'The module was compiled against a different Node.js version using ' +
+      'NODE_MODULE_VERSION 141. This version of Node.js requires NODE_MODULE_VERSION 127.',
+    );
+    assert.equal(isDriverFault(err), true);
+  });
+
+  it('flags a missing bindings file', () => {
+    assert.equal(isDriverFault(new Error('Could not locate the bindings file. Tried: ...')), true);
+  });
+
+  it('flags platform loader failures (linux / macos / windows)', () => {
+    assert.equal(isDriverFault(new Error('invalid ELF header')), true);
+    assert.equal(isDriverFault(new Error('symbol not found in flat namespace')), true);
+    assert.equal(isDriverFault(new Error('is not a valid Win32 application.')), true);
+  });
+
+  it('does NOT flag genuine file corruption', () => {
+    assert.equal(isDriverFault(new Error('database disk image is malformed')), false);
+    assert.equal(isDriverFault(new Error('file is not a database')), false);
+    assert.equal(
+      isDriverFault(Object.assign(new Error('unable to open database file'), { code: 'SQLITE_CANTOPEN' })),
+      false,
+    );
+  });
+
+  it('does not throw on non-Error inputs', () => {
+    assert.equal(isDriverFault(undefined), false);
+    assert.equal(isDriverFault(null), false);
+    assert.equal(isDriverFault('some string'), false);
+  });
+});
+
+describe('passesIntegrityCheck — only discard what SQLite calls damaged', () => {
+  it('probes read-only so the check cannot mutate the file', () => {
+    const { ctor, calls } = fakeCtor({ quickCheck: [{ quick_check: 'ok' }] });
+    passesIntegrityCheck(ctor, '/tmp/x.db');
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].opts, { readonly: true, fileMustExist: true });
+  });
+
+  it('returns true for a healthy database (row form)', () => {
+    const { ctor } = fakeCtor({ quickCheck: [{ quick_check: 'ok' }] });
+    assert.equal(passesIntegrityCheck(ctor, '/tmp/x.db'), true);
+  });
+
+  it('returns true for a healthy database (scalar form)', () => {
+    const { ctor } = fakeCtor({ quickCheck: 'ok' });
+    assert.equal(passesIntegrityCheck(ctor, '/tmp/x.db'), true);
+  });
+
+  it('returns false when SQLite reports damage', () => {
+    const { ctor } = fakeCtor({ quickCheck: [{ quick_check: '*** in database main ***\nPage 4 is never used' }] });
+    assert.equal(passesIntegrityCheck(ctor, '/tmp/x.db'), false);
+  });
+
+  it('returns false when the probe itself throws', () => {
+    const { ctor } = fakeCtor({ throwOnOpen: new Error('file is not a database') });
+    assert.equal(passesIntegrityCheck(ctor, '/tmp/x.db'), false);
+  });
+
+  it('closes the probe even when the verdict is not ok', () => {
+    let closed = false;
+    const { ctor } = fakeCtor({ quickCheck: [{ quick_check: 'malformed' }], onClose: () => { closed = true; } });
+    passesIntegrityCheck(ctor, '/tmp/x.db');
+    assert.equal(closed, true, 'probe handle must not leak');
+  });
+});
+
+describe('backupPathFor — a repeat failure must not destroy the previous backup', () => {
+  it('produces distinct paths for distinct times', () => {
+    const a = backupPathFor('/data/gmail.db', new Date('2026-08-10T09:15:00.000Z'));
+    const b = backupPathFor('/data/gmail.db', new Date('2026-08-10T09:16:00.000Z'));
+    assert.notEqual(a, b, 'the old fixed .bak name is what made #178 unrecoverable on the second run');
+  });
+
+  it('keeps the original path as a prefix', () => {
+    const p = backupPathFor('/data/gmail.db', new Date('2026-08-10T09:15:00.000Z'));
+    assert.ok(p.startsWith('/data/gmail.db.bak.'), `unexpected shape: ${p}`);
+  });
+
+  it('contains no characters Windows forbids in a filename', () => {
+    const p = backupPathFor('C:\\data\\gmail.db', new Date('2026-08-10T09:15:00.000Z'));
+    const filename = p.slice(p.lastIndexOf('\\') + 1);
+    for (const bad of ['<', '>', ':', '"', '|', '?', '*']) {
+      assert.equal(filename.includes(bad), false, `backup filename must not contain "${bad}": ${filename}`);
+    }
+  });
+});

--- a/src/lib/memory/sync/db.ts
+++ b/src/lib/memory/sync/db.ts
@@ -15,6 +15,58 @@ export function listSyncedPlatforms(): string[] {
     .map(f => f.replace(/\.db$/, ''));
 }
 
+/**
+ * Distinguish "the native driver cannot run in this process" from "the file on
+ * disk is bad".
+ *
+ * better-sqlite3 loads its addon lazily *inside* the Database constructor, so
+ * `await import('better-sqlite3')` succeeds under a mismatched Node and the ABI
+ * error only surfaces at open time — where it is otherwise indistinguishable
+ * from corruption. Rotating on one of these destroyed a healthy 747MB Gmail
+ * sync database (#178).
+ */
+export function isDriverFault(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'ERR_DLOPEN_FAILED') return true;
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  return /NODE_MODULE_VERSION|compiled against a different Node\.js version|Could not locate the bindings file|invalid ELF header|wrong ELF class|symbol not found|image not found|not a valid Win32 application/i.test(msg);
+}
+
+/**
+ * Ask SQLite whether the file is actually damaged, via a read-only probe so the
+ * check itself can never mutate it. Returns true only when the database opens
+ * *and* reports `ok` — a throw or any other verdict means "could not prove it
+ * healthy", which is the conservative answer for a caller deciding whether to
+ * discard user data.
+ */
+export function passesIntegrityCheck(
+  Ctor: Awaited<ReturnType<typeof loadSqlite>>,
+  dbPath: string,
+): boolean {
+  let probe: Database.Database | undefined;
+  try {
+    probe = new Ctor(dbPath, { readonly: true, fileMustExist: true });
+    const result = probe.pragma('quick_check') as unknown;
+    const first = Array.isArray(result) ? result[0] : result;
+    const verdict = typeof first === 'string' ? first : (first as { quick_check?: string })?.quick_check;
+    return verdict === 'ok';
+  } catch {
+    return false;
+  } finally {
+    try { probe?.close(); } catch { /* nothing to close */ }
+  }
+}
+
+/**
+ * Timestamped backup path. The old code rotated to a fixed `<db>.bak`, so a
+ * second bad run overwrote the only surviving copy of the data — the reason
+ * #178 was recoverable exactly once. Colons are illegal in Windows filenames,
+ * hence the `:`/`.` substitution.
+ */
+export function backupPathFor(dbPath: string, now: Date = new Date()): string {
+  return `${dbPath}.bak.${now.toISOString().replace(/[:.]/g, '-')}`;
+}
+
 export async function openDatabase(
   platform: string,
   opts: { readonly?: boolean } = {},
@@ -35,13 +87,47 @@ export async function openDatabase(
   let db: Database.Database;
   try {
     db = new Database(dbPath);
-  } catch {
-    // Corrupted database — back up and start fresh
-    const backupPath = dbPath + '.bak';
-    if (fs.existsSync(dbPath)) {
-      fs.renameSync(dbPath, backupPath);
-      process.stderr.write(`Database corrupted, starting fresh. Backup saved at ${backupPath}\n`);
+  } catch (err) {
+    // An environment fault is not a corrupt file. Never rotate on one. (#178)
+    if (isDriverFault(err)) {
+      const detail = err instanceof Error ? err.message.split('\n')[0] : String(err);
+      throw new Error(
+        `The local sync engine (better-sqlite3) could not load in this Node process.\n` +
+        `Your database was NOT modified.\n\n` +
+        `This usually means the CLI is running under a different Node than the one\n` +
+        `better-sqlite3 was built for — currently node ${process.version} ` +
+        `(NODE_MODULE_VERSION ${process.versions.modules}). ` +
+        `\`one\` is a #!/usr/bin/env node shim, so a minimal PATH under cron, launchd,\n` +
+        `or an agent runner can select a different interpreter than your shell does.\n\n` +
+        `Rebuild it against this Node with:\n` +
+        `  one sync install\n\n` +
+        `Underlying error: ${detail}`
+      );
     }
+
+    // Nothing on disk to protect — the open failed for some other reason (bad
+    // path, permissions, full disk). Surface it instead of masking it.
+    if (!fs.existsSync(dbPath)) throw err;
+
+    // Only discard a file SQLite itself reports as damaged. A healthy database
+    // that merely failed to open (locked, read-only mount) must be left alone.
+    if (passesIntegrityCheck(Database, dbPath)) {
+      const detail = err instanceof Error ? err.message.split('\n')[0] : String(err);
+      throw new Error(
+        `Could not open ${dbPath}, but it passes SQLite's integrity check — ` +
+        `so it is not corrupt and has been left untouched.\n\n` +
+        `Underlying error: ${detail}`
+      );
+    }
+
+    // Genuine corruption. Timestamp the backup so a repeat run cannot destroy
+    // the previous one.
+    const backupPath = backupPathFor(dbPath);
+    fs.renameSync(dbPath, backupPath);
+    process.stderr.write(
+      `Database at ${dbPath} failed its integrity check. ` +
+      `Backup saved at ${backupPath}, starting fresh.\n`
+    );
     db = new Database(dbPath);
   }
 

--- a/src/lib/memory/sync/index.ts
+++ b/src/lib/memory/sync/index.ts
@@ -105,6 +105,11 @@ async function syncDoctorCommand(): Promise<void> {
 
   const allOk = checks.every(c => c.ok);
 
+  // Exit non-zero when sync isn't ready, so `one sync doctor && one sync run ...`
+  // actually gates. Set exitCode rather than process.exit() so the postAction
+  // hook still runs (backend close, telemetry flush). (#178)
+  if (!allOk) process.exitCode = 1;
+
   if (output.isAgentMode()) {
     output.json({ ok: allOk, checks });
     return;


### PR DESCRIPTION
Fixes #178 · INT-4393

## Problem

`openDatabase()` treated **any** `new Database(path)` failure as "the file is corrupt": it renamed the database to a fixed `<db>.bak` and wrote an empty replacement.

better-sqlite3 loads its native addon **lazily, inside the `Database` constructor**, so `await import('better-sqlite3')` succeeds under a mismatched Node and the ABI error only surfaces at open time — landing in a bare `catch {}` that discarded the reason. And because `renameSync` overwrites an existing `.bak`, the first bad run was recoverable and the second was not.

This destroyed a 747MB live Gmail sync database on 2026-08-10 (CLI 1.52.1). Recovered only because it was the first occurrence.

`one` is a `#!/usr/bin/env node` shim, so PATH picks the interpreter — which is what makes this easy to hit from cron, launchd, and agent runs with a minimal PATH, even when the CLI path itself is pinned.

## Changes

**1. Never rotate on a driver fault** — `isDriverFault()` classifies the caught error (`ERR_DLOPEN_FAILED`, `NODE_MODULE_VERSION`, "compiled against a different Node.js version", missing bindings, and the platform loader messages). Those rethrow with the current Node version, the module version, why PATH is the likely cause, and a `one sync install` hint. The file is left untouched.

**2. Verify before discarding** — `passesIntegrityCheck()` opens a **read-only** probe (so the check itself can never mutate the file) and requires `PRAGMA quick_check` to actually report damage. A healthy database that merely failed to open — locked, read-only mount — is now reported rather than rotated.

**3. Never overwrite a backup** — `backupPathFor()` produces `<db>.bak.<ISO>`, with `:`/`.` substituted so the name is legal on NTFS.

**4. `sync doctor` gates properly** — it detected this case correctly but still exited 0, so `one sync doctor && one sync run ...` passed straight through. Now sets `process.exitCode = 1` on `ok:false` (via `exitCode`, not `process.exit()`, so the `postAction` hook still closes the backend and flushes telemetry).

## Tests

15 new tests in `src/lib/memory/sync/db-integrity.test.ts` covering all three data-loss guarantees: driver-fault classification (including the exact message from the report) vs. genuine corruption, the read-only probe and its verdict handling, probe-handle cleanup, and non-clobbering/Windows-legal backup names.

They use an injected constructor rather than the real driver, so they run everywhere — `better-sqlite3` is an `optionalDependency` and is frequently absent (it would not install on this machine under Node 24, which is the same precondition that triggers the bug).

## Verification notes

- `npx tsc --noEmit` passes.
- The new suite passes 15/15.
- I did **not** run the full `npm test` suite: on Windows it reads and writes the developer's real `~/.one` (every test sandboxes `process.env.HOME`, which `os.homedir()` ignores on win32). Filed separately — it is unrelated to this change.
- Version bumped 1.52.1 → 1.52.2. `package-lock.json` version fields were hand-edited rather than regenerated, because `npm install` on Node 24 drops the `pg` optional dependency from the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)