### PR TITLE
fix(deps): bump better-sqlite3 to v12 for Node 24 support (v1.54.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,19 @@ Do NOT run `npm publish` directly. The release is automated via GitHub.
 5. Once merged to `main`, create a **release tag** in GitHub for that version
 6. The GitHub release triggers the automated deploy to npm
 
+### Editing package-lock.json
+
+`npm install` on this project prunes `node_modules/pg` out of the lockfile on
+any machine where that optional dependency can't be installed — which would
+ship a broken postgres backend to everyone else. Two rules:
+
+1. For a **version-only bump**, don't run `npm install` at all. Hand-edit the
+   two `"version"` fields (root and `packages[""]`).
+2. For a **real dependency change**, run `npm install --package-lock-only`,
+   then check `git diff package-lock.json` for dropped `node_modules/*` entries
+   and restore any that npm pruned. Verify with `npm ci` before pushing —
+   a malformed lockfile breaks every CI job at once.
+
 ### Version bump checklist
 
 Every feature PR must include a version bump before shipping:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ one login              # Opens browser for authentication (global or per-directo
 one logout             # Clear credentials (with scope picker and confirmation)
 ```
 
-Requires Node.js 18+.
+Requires Node.js 18+. `one sync` additionally needs Node 20+, because its
+local SQLite engine (`better-sqlite3`, an optional dependency) ships prebuilt
+binaries only for Node 20 and above. On Node 18 every other command works
+normally; `one sync` reports that the engine isn't installed.
 
 ## Quick start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.54.0",
+      "version": "1.54.1",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",
@@ -31,7 +31,7 @@
       },
       "optionalDependencies": {
         "@electric-sql/pglite": "^0.2.17",
-        "better-sqlite3": "^11.7.0",
+        "better-sqlite3": "^12.11.1",
         "pg": "^8.20.0"
       }
     },
@@ -1199,15 +1199,18 @@
       "optional": true
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {
@@ -1492,6 +1495,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2011,6 +2015,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2186,6 +2191,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2636,6 +2642,7 @@
       "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -3152,6 +3159,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "description": "CLI for managing One",
   "type": "module",
   "files": [
@@ -36,7 +36,7 @@
   },
   "optionalDependencies": {
     "@electric-sql/pglite": "^0.2.17",
-    "better-sqlite3": "^11.7.0",
+    "better-sqlite3": "^12.11.1",
     "pg": "^8.20.0"
   },
   "devDependencies": {


### PR DESCRIPTION
INT-4407

## Problem

`one sync` is silently broken for anyone on Node 24 without a C++ toolchain — which is the default experience for a new user, since Node 24 is what you get installing Node today.

`better-sqlite3@11` publishes prebuilt binaries only up to `NODE_MODULE_VERSION 131` (Node 23):

```
v11.10.0 win32-x64:  node-v108  node-v115  node-v127  node-v131          ← no v137
v12.11.1 win32-x64:  node-v127  node-v137  node-v141  node-v147          ← Node 24 covered
```

Node 24 is 137, so `prebuild-install` falls back to `node-gyp rebuild` — compiling from source, which needs Visual Studio Build Tools on Windows. And because it's an `optionalDependency`, **npm doesn't error, it silently skips it**. The install succeeds, the CLI works, and `one sync` is dead with no warning.

## Blast radius

Narrower than it sounds, but it hits the marquee feature. SQLite is only opened when a profile declares `enrich` (`runner.ts:172`, `needsSqlite = !!profile.enrich`) — 2 of the 9 built-in profiles:

- **Broken:** gmail, fathom — i.e. exactly the profiles the cross-platform identity-key work is built around. Plus `sync delete`, `sync remove`, and `mem migrate` (which is the tool for getting people *off* SQLite).
- **Unaffected:** attio ×2, google-calendar, hacker-news, notion, stripe ×2 — these never touch SQLite.

## Verification

On this machine (Windows, Node 24.14.0):

- `npm ci` installs 12.11.1 clean — no compilation.
- `pragma()` and FTS5 both work; `tsc --noEmit` passes against the existing `@types/better-sqlite3@^7`.
- **Full suite: 13 skipped → 0 skipped, 443/443 passing.**

That last point matters beyond this PR. `enrich-preserve.test.ts` skips itself when the driver is missing, so it had been quietly not running here — which is exactly how the `--no-memory` regression in #180 reached CI instead of my machine. This restores local coverage of the enrich path.

## Cost

v12 requires Node 20+, so `one sync` no longer works on Node 18. In practice it already didn't — v11 can't build there on a current toolchain either — but the README now states it explicitly rather than implying "Node 18+" covers everything. Every other command is unaffected on 18.

## Worth knowing for review

**CI cannot catch this class of bug.** GitHub runners ship with compilers, so they build from source successfully and go green regardless of whether a prebuild exists. Adding Node 24 to the matrix would not have found this, and won't protect against the next occurrence — the protection is keeping the dependency current.

**Lockfile.** This needed a real regeneration, not a version-field edit. `npm install --package-lock-only` dropped `node_modules/pg` (an optional dep that can't install here), so I restored that entry by hand and validated the result with a clean `npm ci`. Documented the trap in CLAUDE.md so the next person doesn't ship a lockfile with `pg` missing.

**Not bumped:** `@types/better-sqlite3` stays at `^7.6.13` (latest is 9.6.0). It typechecks clean against v12 and bumping it is unrelated risk — happy to split that out if you'd rather they moved together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)