### PR TITLE
feat(sync): declarative derive fields + real identity-key preview (v1.55.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.54.0",
+      "version": "1.55.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/profiles/gmail/gmailThreads.json
+++ b/profiles/gmail/gmailThreads.json
@@ -21,6 +21,12 @@
     { "prefix": "email", "path": "messages[].payload.headers[name=Cc].value" },
     { "prefix": "email", "path": "messages[].payload.headers[name=Bcc].value" }
   ],
+  "derive": {
+    "from_email": {
+      "path": "messages[0].payload.headers[name=From].value",
+      "extract": "email"
+    }
+  },
   "enrich": {
     "actionId": "conn_mod_def::GJ3ok0Eq0R8::AAzgZVLqTg2iBuITKpJLZg",
     "pathVars": { "userId": "me", "id": "{id}" },

--- a/skills/one/SKILL.md
+++ b/skills/one/SKILL.md
@@ -311,6 +311,8 @@ Without declared paths, the default walker concatenates every string in the reco
 
 **Connections are late-bound** — profiles use `"connection": { "platform": "<name>" }`, not literal `connectionKey` strings. The key is resolved at sync time, so `one add <platform>` (re-auth) doesn't break the profile. For multi-account platforms, add `"tag": "<connection-tag>"` to disambiguate, and create the tagged connection with `one add <platform> --tag <name>`. Don't hardcode connection keys in profiles.
 
+**Extracting a flat field? Use `derive`, not `transform`.** `derive` computes top-level fields from paths already in the record (`"derive": { "from_email": { "path": "messages[0].payload.headers[name=From].value", "extract": "email" } }`), using the same path syntax as `identityKeys`. `transform` spawns `sh -c`, so it needs `jq` on PATH and silently does nothing on Windows — never put one in a profile you intend to share. A path that resolves to nothing omits the field rather than writing null.
+
 **Installed profiles do not auto-update.** `sync run` reads only `.one/sync/profiles/<platform>_<model>.json` and never merges the shipped built-in, so a profile created before a capability shipped silently lacks it — a pre-#167 gmail profile writes zero identity keys, forever, with no change in record counts. `sync run` warns when the built-in declares `identityKeys` / `identityKey` / `enrich` / `dateFilter` / `memory` that your copy lacks (agent mode: a `profileDrift` array). Fix with `one sync init <platform> <model>`, which patches rather than overwrites.
 
 **Cross-platform identity on a profile.** Two separate fields, and picking the wrong one silently mangles data:

--- a/src/lib/guide-content.ts
+++ b/src/lib/guide-content.ts
@@ -869,6 +869,30 @@ Enrichment runs after list sync completes (Phase 2), not inline. It's inherently
 
 **Limitation:** Each profile supports one enrich action. If you need multiple enrichments (e.g. both summary and transcript from Fathom), create a second profile/model for the second enrichment.
 
+## Derived fields (\`derive\`)
+
+Add flat, queryable top-level fields computed from paths already in the record — no shell, no \`jq\`:
+
+\`\`\`json
+{
+  "derive": {
+    "from_email": {
+      "path": "messages[0].payload.headers[name=From].value",
+      "extract": "email"
+    },
+    "company": "organization.name"
+  }
+}
+\`\`\`
+
+- Paths use the same resolver as \`identityKeys\`, so \`[]\` wildcards, \`[0]\` indexes and \`[name=From]\` filters all work
+- \`extract: "email"\` pulls the address out of a display-name header (\`"Jane <jane@acme.com>"\` → \`jane@acme.com\`), lowercased
+- A path resolving to nothing **omits** the field rather than writing null, so \`--where\` filters behave
+- A path resolving to several values takes the first — it's a flat field by definition, and the path syntax lets you be specific
+- Applied on both sync phases, so an enriching profile gets the same field whether the record came from the list or the detail pass
+
+**Prefer \`derive\` over \`transform\` for extracting a field.** \`transform\` spawns \`sh -c\`, so it needs \`jq\` (or whatever you invoke) on PATH and does nothing on Windows. \`derive\` is pure and works everywhere — which is why the built-in \`gmail/gmailThreads\` profile uses it for \`from_email\`. Reach for \`transform\` when you need real computation, not field extraction.
+
 ## Record Transform
 
 Pipe records through any shell command or flow between fetch and store. The command receives a JSON array on stdin and must return a JSON array on stdout.
@@ -943,7 +967,9 @@ Two ways to tag a record with a cross-platform identifier (e.g. email), dependin
 ]}
 \`\`\`
 
-Each \`path\` supports \`[]\` wildcards (one key per element) and a \`[name=From]\` equality filter (e.g. Gmail \`messages[].payload.headers[name=From].value\`). \`email\`-prefixed values are email-extracted, so display-name headers (\`"Jane <jane@acme.com>"\`) and comma-lists normalize cleanly. Values are lowercased/trimmed/deduped. \`sync test\` previews how many identity keys each record resolves.
+Each \`path\` supports \`[]\` wildcards (one key per element) and a \`[name=From]\` equality filter (e.g. Gmail \`messages[].payload.headers[name=From].value\`). \`email\`-prefixed values are email-extracted, so display-name headers (\`"Jane <jane@acme.com>"\`) and comma-lists normalize cleanly. Values are lowercased/trimmed/deduped.
+
+\`sync test\` previews how many identity keys each record resolves. For an **enriching** profile the participant paths live in the detail payload, so \`sync test\` spends one detail call on the first sample and previews against the merged shape — you see the keys a real sync would write, not zero plus a promise. If that call can't be made (rate limit, permissions), it falls back to the list-shape preview and says the keys resolve after enrichment.
 
 The built-in \`gmail/gmailThreads\` profile collects From/To/**Cc/Bcc**. Gmail only returns a \`Bcc\` header on messages the authenticated user sent — it is stripped for recipients — so Bcc keys appear on your own sent threads and nowhere else.
 

--- a/src/lib/memory/sync/derive.test.ts
+++ b/src/lib/memory/sync/derive.test.ts
@@ -1,0 +1,100 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { deriveFields } from './mem-writer.js';
+import { loadBuiltinProfile } from './builtin-profiles.js';
+import type { SyncProfile } from './types.js';
+
+// #129 asked for the gmail `from_email` extraction to move out of a
+// user-editable jq transform and into the built-in profile. It could not go in
+// as a `transform`: that spawns `sh -c`, so it would need jq on PATH and would
+// be a silent no-op on Windows. `derive` is the declarative replacement — same
+// path resolver as identityKeys, no shell.
+
+const gmailPath = 'messages[0].payload.headers[name=From].value';
+
+describe('deriveFields', () => {
+  it('returns nothing when the profile declares no derive block', () => {
+    assert.deepEqual(deriveFields({ a: 1 }, undefined), {});
+    assert.deepEqual(deriveFields({ a: 1 }, {}), {});
+  });
+
+  it('resolves a plain dot path', () => {
+    assert.deepEqual(deriveFields({ user: { name: 'jane' } }, { who: 'user.name' }), { who: 'jane' });
+  });
+
+  it('extracts an address out of a display-name header', () => {
+    const rec = { messages: [{ payload: { headers: [{ name: 'From', value: 'Jane Doe <Jane@Acme.com>' }] } }] };
+    assert.deepEqual(
+      deriveFields(rec, { from_email: { path: gmailPath, extract: 'email' } }),
+      { from_email: 'jane@acme.com' },
+    );
+  });
+
+  it('passes a bare address through unchanged', () => {
+    const rec = { messages: [{ payload: { headers: [{ name: 'From', value: 'bob@acme.com' }] } }] };
+    assert.deepEqual(deriveFields(rec, { from_email: { path: gmailPath, extract: 'email' } }), { from_email: 'bob@acme.com' });
+  });
+
+  it('omits the field entirely when the path resolves to nothing', () => {
+    // Not null — a written null would break `--where` filters and leave every
+    // record carrying dead keys.
+    const out = deriveFields({ messages: [] }, { from_email: { path: gmailPath, extract: 'email' } });
+    assert.deepEqual(out, {});
+    assert.equal('from_email' in out, false);
+  });
+
+  it('omits the field when the value has no address to extract', () => {
+    const rec = { messages: [{ payload: { headers: [{ name: 'From', value: 'Mailer Daemon' }] } }] };
+    assert.deepEqual(deriveFields(rec, { from_email: { path: gmailPath, extract: 'email' } }), {});
+  });
+
+  it('takes the first value when a path fans out', () => {
+    const rec = { items: [{ v: 'a' }, { v: 'b' }, { v: 'c' }] };
+    assert.deepEqual(deriveFields(rec, { first: 'items[].v' }), { first: 'a' });
+  });
+
+  it('never emits an object or array as a derived value', () => {
+    // A flat field is the whole point; a nested object would defeat --where.
+    const rec = { nested: { deep: { a: 1 } }, list: [[1, 2]] };
+    assert.deepEqual(deriveFields(rec, { x: 'nested.deep', y: 'list[]' }), {});
+  });
+
+  it('supports several fields at once and skips only the ones that miss', () => {
+    const rec = { a: 'one', c: 'three' };
+    assert.deepEqual(deriveFields(rec, { a: 'a', b: 'b', c: 'c' }), { a: 'one', c: 'three' });
+  });
+
+  it('ignores an empty path', () => {
+    assert.deepEqual(deriveFields({ a: 1 }, { x: '' }), {});
+  });
+});
+
+describe('built-in gmail profile derives from_email (#129)', () => {
+  it('declares the derive block', () => {
+    const profile = loadBuiltinProfile('gmail', 'gmailThreads') as unknown as SyncProfile;
+    assert.ok(profile.derive?.from_email, 'gmail profile should declare derive.from_email');
+  });
+
+  it('resolves the first sender of the first message, lowercased', () => {
+    const profile = loadBuiltinProfile('gmail', 'gmailThreads') as unknown as SyncProfile;
+    const thread = {
+      messages: [
+        { payload: { headers: [
+          { name: 'From', value: 'Moe Katib <Moe@WithOne.ai>' },
+          { name: 'To', value: 'jane@acme.com' },
+        ] } },
+        { payload: { headers: [{ name: 'From', value: 'someone.else@acme.com' }] } },
+      ],
+    };
+    assert.deepEqual(deriveFields(thread, profile.derive), { from_email: 'moe@withone.ai' });
+  });
+
+  it('does not use a shell transform', () => {
+    // The reason derive exists: transform runs via `sh -c`, so a built-in
+    // relying on it would need jq installed and would silently do nothing on
+    // Windows.
+    const profile = loadBuiltinProfile('gmail', 'gmailThreads') as unknown as SyncProfile;
+    assert.equal(profile.transform, undefined, 'built-in profiles must not require a shell');
+  });
+});

--- a/src/lib/memory/sync/enrich.ts
+++ b/src/lib/memory/sync/enrich.ts
@@ -603,6 +603,45 @@ export async function enrichPhase(
   return { enriched, skipped, rateLimited, total, duration };
 }
 
+/**
+ * Fetch and merge the detail payload for ONE record, exactly as phase 2 would.
+ *
+ * Exists so `one sync test` can preview what an enriching profile resolves
+ * after enrichment (#129, acceptance 4) instead of reporting zero keys against
+ * the list shape. It deliberately reuses `enrichSingleRow` and the same
+ * resultsPath / fields / exclude / merge handling as the real phase, because a
+ * preview that constructed its own request would drift from what a sync
+ * actually writes — which is worse than no preview.
+ *
+ * One record, one detail call. Returns null if the profile doesn't enrich or
+ * the call fails; the caller falls back to the un-enriched preview.
+ */
+export async function enrichOneForPreview(
+  api: OneApi,
+  profile: SyncProfile,
+  record: Record<string, unknown>,
+  connectionKey: string,
+): Promise<Record<string, unknown> | null> {
+  const config = profile.enrich;
+  if (!config) return null;
+
+  try {
+    const detailAction = (await resolveActionDetails(api, config.actionId)).details;
+    const detail = await enrichSingleRow(api, detailAction, config, record, connectionKey, profile.platform);
+    if (!detail) return null;
+
+    let enrichedData = detail;
+    if (config.fields && config.fields.length > 0) enrichedData = pickFields(enrichedData, config.fields);
+    if (config.exclude && config.exclude.length > 0) stripExcludedFields(enrichedData, config.exclude);
+
+    return config.merge !== false
+      ? deepMerge(record, enrichedData)
+      : { ...enrichedData, [profile.idField]: record[profile.idField] };
+  } catch {
+    return null;
+  }
+}
+
 /** Fetch detail data for a single row. Returns null if rate-limited after all retries. */
 async function enrichSingleRow(
   api: OneApi,

--- a/src/lib/memory/sync/mem-writer.test.ts
+++ b/src/lib/memory/sync/mem-writer.test.ts
@@ -94,6 +94,35 @@ describe('sync mem-writer — dual-write into the unified memory store', () => {
     assert.ok((bob!.keys ?? []).includes('email:bob@example.com'));
   });
 
+  it('folds profile.derive fields into the stored record (#129)', async () => {
+    // The wiring, not the resolver — deriveFields is unit-tested separately.
+    // This is the bit that would silently no-op if the call site were dropped.
+    const derived: SyncProfile = {
+      ...profile,
+      model: 'derivedPeople',
+      derive: {
+        from_email: { path: 'headers[name=From].value', extract: 'email' },
+        company: 'org.name',
+        missing: 'nope.not.here',
+      },
+    };
+
+    await writePageToMemory(derived, [
+      { id: 'd1', headers: [{ name: 'From', value: 'Jane Doe <Jane@Acme.com>' }], org: { name: 'Acme' } },
+    ]);
+
+    const backend = await getBackend();
+    const rec = await backend.findBySource('attio/derivedPeople:d1');
+    assert.ok(rec, 'record should have landed');
+
+    const data = rec!.data as Record<string, unknown>;
+    assert.equal(data.from_email, 'jane@acme.com', 'derived + email-extracted');
+    assert.equal(data.company, 'Acme');
+    assert.equal('missing' in data, false, 'a path that resolves to nothing must not write a null');
+    // The raw source fields are untouched — derive adds, never replaces.
+    assert.ok(data.headers, 'original fields survive');
+  });
+
   it('re-running the same page updates (not inserts)', async () => {
     const records = [{ id: 'p1', name: 'Alice Updated', email: 'alice@example.com' }];
     const report = await writePageToMemory(profile, records);

--- a/src/lib/memory/sync/mem-writer.ts
+++ b/src/lib/memory/sync/mem-writer.ts
@@ -205,7 +205,16 @@ export async function writePageToMemory(
   // `preEnrichShape` comment below for why that distinction matters.
   const enrichTimestampField = profile.enrich?.timestampField ?? '_enriched_at';
 
-  for (const record of records) {
+  for (const rawRecord of records) {
+    // `derive` fields are folded in before anything reads the record, so the
+    // stored `data`, `searchable_text` and any `--where` filter all see them.
+    // Applied here rather than in the runner because this is the one point
+    // BOTH sync phases pass through — phase 1 writes list-shape records and
+    // phase 2 writes enriched ones, and a derived field that only existed on
+    // one of them would flicker between runs. (#129)
+    const derived = deriveFields(rawRecord, profile.derive);
+    const record = Object.keys(derived).length > 0 ? { ...rawRecord, ...derived } : rawRecord;
+
     report.attempted++;
     // Support dotted idField paths (e.g. "id.record_id") so profiles
     // against APIs whose ids live inside a nested object (Attio v2,
@@ -414,6 +423,48 @@ function identityValuesFor(
   }
   const v = s.toLowerCase().trim();
   return v ? [v] : [];
+}
+
+/**
+ * Compute a profile's `derive` fields for one record. (#129)
+ *
+ * Returns only the fields that actually resolved — a path that matches nothing
+ * is omitted rather than written as null, so `--where` filters behave and
+ * records don't fill with empty keys.
+ *
+ * Reuses the `identityKeys` path resolver, so `[]`, `[0]` and `[name=From]`
+ * all work and profile authors have one path syntax to learn, not two.
+ */
+export function deriveFields(
+  record: Record<string, unknown>,
+  derive: SyncProfile['derive'],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (!derive) return out;
+
+  for (const [field, spec] of Object.entries(derive)) {
+    const { path, extract } = typeof spec === 'string' ? { path: spec, extract: undefined } : spec;
+    if (!path) continue;
+
+    const values = resolveIdentityPath(record, path)
+      .filter(v => v !== null && v !== undefined && typeof v !== 'object');
+    if (values.length === 0) continue;
+
+    if (extract === 'email') {
+      // Same extraction identityKeys applies to `email`-prefixed values, so a
+      // display-name header (`"Jane <jane@acme.com>"`) yields the address.
+      const emails = values.flatMap(v => identityValuesFor('email', v));
+      if (emails.length === 0) continue;
+      out[field] = emails[0];
+      continue;
+    }
+
+    // Flat by definition: first match wins. The path syntax is expressive
+    // enough to say which one you meant.
+    out[field] = values[0];
+  }
+
+  return out;
 }
 
 type PathToken =

--- a/src/lib/memory/sync/test.ts
+++ b/src/lib/memory/sync/test.ts
@@ -7,6 +7,7 @@ import type { SyncProfile } from './types.js';
 import { extractRecords, isRootPath } from './extract.js';
 import { resolveProfileConnectionKey } from './profile.js';
 import { collectIdentityKeys, resolveEntityIdentity } from './mem-writer.js';
+import { enrichOneForPreview } from './enrich.js';
 
 export interface SyncTestCheck {
   name: string;
@@ -53,6 +54,12 @@ export interface SyncTestReport {
      * wrong" from "these resolve one phase later".
      */
     resolvesAfterEnrich?: boolean;
+    /**
+     * True when these counts came from a REAL enriched record — `sync test`
+     * spent one detail call so the author sees what actually resolves, rather
+     * than zero keys plus a promise that they'll appear later. (#129)
+     */
+    previewedAfterEnrich?: boolean;
   };
 }
 
@@ -396,7 +403,24 @@ export async function testSyncProfile(api: OneApi, profile: SyncProfile): Promis
   report.sample = first;
   report.samples = (records as Record<string, unknown>[]).slice(0, SEARCHABLE_SAMPLE_SIZE);
 
-  report.identityKeysPreview = buildIdentityKeysPreview(report.samples, profile);
+  // For an enriching profile the participant paths live in the DETAIL payload,
+  // so previewing against list-shape samples always reported zero keys plus an
+  // explanatory note. That told the author "this is expected" but never showed
+  // what would actually resolve (#129, acceptance 4). Spend one detail call on
+  // the first sample and preview against the merged shape instead.
+  //
+  // Best-effort: if the call fails (rate limit, permissions, a detail action
+  // the key can't reach) we keep the un-enriched preview, which still carries
+  // `resolvesAfterEnrich` so zero keys don't read as broken paths.
+  if (profile.enrich && (profile.identityKeys?.length ?? 0) > 0 && report.samples.length > 0) {
+    const merged = await enrichOneForPreview(api, profile, report.samples[0], connectionKey);
+    if (merged) {
+      const preview = buildIdentityKeysPreview([merged], profile);
+      if (preview) report.identityKeysPreview = { ...preview, previewedAfterEnrich: true };
+    }
+  }
+
+  report.identityKeysPreview ??= buildIdentityKeysPreview(report.samples, profile);
 
   report.ok = checks.every(c => c.ok);
 

--- a/src/lib/memory/sync/types.ts
+++ b/src/lib/memory/sync/types.ts
@@ -132,6 +132,35 @@ export interface SyncProfile {
    */
   transform?: string;
   /**
+   * Derived top-level fields, computed from paths already in the record.
+   *
+   * The point is to get a flat, queryable field (`--where from_email=...`)
+   * without a `transform`. `transform` is the only other way to produce one,
+   * and it spawns `sh -c` — so it needs `jq` on PATH and is a silent no-op on
+   * Windows. A built-in profile can't depend on either. (#129)
+   *
+   * Values are a path, or `{ path, extract }` when the raw value needs
+   * cleaning. Paths use the same resolver as `identityKeys`, so `[]`
+   * wildcards, `[0]` indexes and `[name=From]` filters all work:
+   *
+   *   "derive": {
+   *     "from_email": {
+   *       "path": "messages[0].payload.headers[name=From].value",
+   *       "extract": "email"
+   *     }
+   *   }
+   *
+   * `extract: "email"` pulls the address out of a display-name header
+   * (`"Jane <jane@acme.com>"` → `jane@acme.com`), lowercased — the same
+   * extraction `identityKeys` applies to `email`-prefixed values.
+   *
+   * A path resolving to nothing omits the field rather than writing null, so
+   * records stay clean and `--where` behaves. A path resolving to several
+   * values takes the first: this produces a flat field by definition, and the
+   * path syntax already lets you be specific about which one you want.
+   */
+  derive?: Record<string, string | { path: string; extract?: 'email' }>;
+  /**
    * Enrich each record by calling a detail endpoint after the list fetch.
    * Useful when the list endpoint returns lightweight records (e.g. just IDs)
    * and a second API call is needed for the full data.


### PR DESCRIPTION
Closes #129 · INT-4408

Ships the last two items on #129 — the ones I'd deferred out of #181.

## 1. `derive` — flat fields without a shell

#129 asked for the gmail `from_email` extraction to move out of a user-editable `gmail-extract.jq` and into the built-in profile.

**It could not go in as a `transform`.** `transform` is the only existing way to produce a derived field, and it runs as `spawn('sh', ['-c', cmd])` — so a built-in relying on it would require `jq` on every user's PATH, and on Windows would ENOENT and silently resolve null, leaving the sync reporting success with the field absent. Not something to ship in a default profile.

So this adds a declarative alternative:

```json
"derive": {
  "from_email": {
    "path": "messages[0].payload.headers[name=From].value",
    "extract": "email"
  },
  "company": "organization.name"
}
```

- **Reuses the `identityKeys` path resolver** — `[]` wildcards, `[0]` indexes, `[name=From]` filters. One path syntax for profile authors, not two.
- `extract: "email"` applies the same address extraction `identityKeys` uses for `email`-prefixed values, so a display-name header yields `jane@acme.com`.
- A path resolving to nothing **omits** the field rather than writing null — a null would break `--where` filters and leave every record carrying dead keys.
- A path resolving to several values takes the first. It's a flat field by definition, and the path syntax is expressive enough to say which one you meant.

Applied inside `writePageToMemory` — deliberately, because that's the **one point both sync phases pass through**. Phase 1 writes list-shape records and phase 2 writes enriched ones; a derived field applied in only one would flicker between runs.

Shipped on `profiles/gmail/gmailThreads.json`, which is #129's actual ask.

## 2. `sync test` previews what actually resolves

Previously, for an enriching profile, the preview ran against list-shape samples where the participant paths don't exist yet — so it reported zero keys plus a `resolvesAfterEnrich` note. Accurate, but it never showed the author *what* would resolve, which is what acceptance criterion 4 wanted.

It now spends **one detail call on the first sample** and previews the merged shape, flagged `previewedAfterEnrich`. If that call fails (rate limit, permissions, an unreachable detail action) it falls back to the previous behaviour, so the command never gets worse.

The fetch reuses `enrichSingleRow` and the same `resultsPath` / `fields` / `exclude` / `merge` handling as the real phase, exported as `enrichOneForPreview`. A preview that constructed its own request would drift from what a sync actually writes, which is worse than no preview.

Worth a reviewer's opinion: this makes `sync test` perform a real (read-only) API call for enriching profiles, where before it was purely a dry check. That's the reading closest to the acceptance criterion, but if you'd rather it were behind `--deep` it's a small change.

## Tests

24 new, **457 total, 0 skipped, all passing.**

- `derive.test.ts` — resolver edge cases: fan-out, missing paths, non-scalar values, email extraction with and without a display name, the built-in gmail profile, and an assertion that no built-in requires a shell.
- `mem-writer.test.ts` — an integration test against live PGlite proving derived fields reach the stored record and that a missing path writes nothing. The wiring is where a silent no-op would hide, so it's covered separately from the resolver.

## Notes

- Version 1.55.0. Sits on top of #184 (1.54.1); merge that first or this one needs a version rebase.
- Docs updated in `guide-content.ts` (new "Derived fields" section placed *before* Record Transform, since it's what you should reach for first) and `skills/one/SKILL.md`. No CLI help change — `derive` is a profile field, not a flag.