### PR TITLE
fix(flow): allow resuming flows with bash steps (v1.55.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,12 @@ Resume a paused or failed workflow run from where it left off.
 
 ```bash
 one flow resume abc123
+one flow resume abc123 --allow-bash    # required if the flow has bash steps
 ```
+
+`--allow-bash` is gated the same way as on `flow execute` — resuming doesn't
+inherit the permission from the original run, so pass it again. `one flow list`
+shows which flows need it.
 
 ### `one flow runs [flowKey]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withone/cli",
-  "version": "1.55.0",
+  "version": "1.55.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withone/cli",
-      "version": "1.55.0",
+      "version": "1.55.1",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withone/cli",
-  "version": "1.55.0",
+  "version": "1.55.1",
   "description": "CLI for managing One",
   "type": "module",
   "files": [

--- a/skills/one/references/flows.md
+++ b/skills/one/references/flows.md
@@ -686,7 +686,13 @@ one --agent flow execute <key> --allow-bash -i key=value
 one --agent flow runs [flowKey]
 one --agent flow inspect <runId>          # per-step outputs of a past run (add --full for untruncated)
 one --agent flow resume <runId>
+one --agent flow resume <runId> --allow-bash   # required if the flow has bash steps
 ```
+
+`flow resume` gates bash exactly like `flow execute` — the permission is not
+inherited from the original run. Resuming a bash flow without the flag fails
+fast with `{"error": "...", "requiresBash": true, "flowKey": "...", "runId": "..."}`,
+so re-invoke with `--allow-bash` rather than treating it as a broken run.
 
 ## Debugging a flow
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -571,8 +571,9 @@ flow
 flow
   .command('resume <runId>')
   .description('Resume a paused or failed workflow run')
-  .action(async (runId: string) => {
-    await flowResumeCommand(runId);
+  .option('--allow-bash', 'Allow bash step execution (disabled by default for security) — required to resume any flow containing bash steps')
+  .action(async (runId: string, options: { allowBash?: boolean }) => {
+    await flowResumeCommand(runId, options);
   });
 
 flow

--- a/src/commands/flow-resume-allow-bash.test.ts
+++ b/src/commands/flow-resume-allow-bash.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Command } from 'commander';
+
+import { program } from '../cli.js';
+
+// Regression cover for INT-4409: `flow resume` was registered with ZERO
+// options, and flowResumeCommand never passed `allowBash` to runner.resume.
+// FlowRunner.resume accepts it — it was simply never populated, and no flag
+// existed to populate it from. So resuming any flow with a bash step threw
+// "Bash steps require --allow-bash flag for security" with no way to satisfy
+// it, making a paused or failed bash flow permanently unrecoverable.
+
+function sub(parent: Command, name: string): Command {
+  const found = parent.commands.find(c => c.name() === name);
+  assert.ok(found, `expected a "${name}" command`);
+  return found;
+}
+
+const flow = sub(program, 'flow');
+
+describe('flow resume --allow-bash (INT-4409)', () => {
+  it('registers the flag', () => {
+    const resume = sub(flow, 'resume');
+    const opt = resume.options.find(o => o.long === '--allow-bash');
+    assert.ok(opt, 'flow resume must accept --allow-bash, or bash flows cannot be resumed at all');
+  });
+
+  it('maps the flag to the `allowBash` property the handler reads', () => {
+    // The half-fix this guards against: registering the flag but reading a
+    // differently-named property, which commander would leave undefined —
+    // the gate would still reject and nothing would look wrong.
+    const resume = sub(flow, 'resume');
+    const opt = resume.options.find(o => o.long === '--allow-bash')!;
+    assert.equal(opt.attributeName(), 'allowBash');
+  });
+
+  it('is a boolean flag, not one taking a value', () => {
+    const resume = sub(flow, 'resume');
+    const opt = resume.options.find(o => o.long === '--allow-bash')!;
+    assert.equal(opt.required, false, '--allow-bash must not require an argument');
+    assert.equal(opt.optional, false);
+  });
+
+  it('matches how `flow execute` declares the same flag', () => {
+    // The two commands gate the same engine behaviour; a mismatch in shape is
+    // how they drifted apart in the first place.
+    const execOpt = sub(flow, 'execute').options.find(o => o.long === '--allow-bash');
+    const resumeOpt = sub(flow, 'resume').options.find(o => o.long === '--allow-bash');
+    assert.ok(execOpt && resumeOpt);
+    assert.equal(resumeOpt!.attributeName(), execOpt!.attributeName());
+    assert.equal(resumeOpt!.required, execOpt!.required);
+  });
+});

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -564,7 +564,10 @@ export async function flowValidateCommand(keyOrPath: string): Promise<void> {
   output.note(`Workflow "${(flowData as Flow).key}" passed all validation checks`, 'Valid');
 }
 
-export async function flowResumeCommand(runId: string): Promise<void> {
+export async function flowResumeCommand(
+  runId: string,
+  options: { allowBash?: boolean } = {},
+): Promise<void> {
   output.intro(pc.bgCyan(pc.black(' One Workflow ')));
 
   const state = FlowRunner.loadRunState(runId);
@@ -590,6 +593,18 @@ export async function flowResumeCommand(runId: string): Promise<void> {
     return;
   }
 
+  // Same pre-flight `flow execute` runs: fail fast with the machine-readable
+  // shape rather than partway through, so a caller knows to re-invoke with the
+  // flag instead of parsing a mid-run engine error.
+  if (!options.allowBash && flowRequiresBash(flow)) {
+    const msg = `Workflow "${flow.key}" contains bash steps. Re-run with --allow-bash to permit shell execution.`;
+    if (output.isAgentMode()) {
+      output.json({ error: msg, requiresBash: true, flowKey: flow.key, runId });
+      process.exit(1);
+    }
+    output.error(msg);
+  }
+
   const runner = FlowRunner.fromRunState(state!);
 
   const onEvent = (event: FlowEvent): void => {
@@ -602,7 +617,11 @@ export async function flowResumeCommand(runId: string): Promise<void> {
   spinner.start(`Resuming run ${runId} (${state!.completedSteps.length} steps already completed)...`);
 
   try {
-    const context = await runner.resume(flow, api, permissions, actionIds, { onEvent, rootDir });
+    const context = await runner.resume(flow, api, permissions, actionIds, {
+      onEvent,
+      rootDir,
+      allowBash: options.allowBash,
+    });
     spinner.stop('Workflow completed');
 
     if (output.isAgentMode()) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,13 +1,12 @@
 import { homeDir } from '../lib/home.js';
-import { createRequire } from 'module';
 import { spawn } from 'node:child_process';
 import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as output from '../lib/output.js';
+import { cliVersion } from '../lib/version.js';
 
-const require = createRequire(import.meta.url);
-const { version: currentVersion } = require('../package.json');
+const currentVersion = cliVersion();
 
 // Lazy: binding these at module load captures the home directory from the env
 // as it was at import time, which defeats ONE_HOME (and every test that sets

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -20,6 +20,7 @@ import {
   writeUsageState,
 } from './config.js';
 import { isAgentMode } from './output.js';
+import { cliVersion } from './version.js';
 
 /**
  * CLI usage analytics for the One CLI (identified — keyed to the One user).
@@ -92,13 +93,10 @@ function posthogKey(): string {
   return process.env.ONE_POSTHOG_KEY || DEFAULT_POSTHOG_KEY;
 }
 
-function cliVersion(): string {
-  try {
-    return (require('../package.json') as { version: string }).version;
-  } catch {
-    return 'unknown';
-  }
-}
+// cliVersion() now lives in lib/version.ts — the old `require('../package.json')`
+// here resolved to `src/package.json`, which does not exist, so every telemetry
+// event in a source checkout reported version "unknown". Correct only in the
+// bundled dist/ layout.
 
 function envName(): 'live' | 'test' {
   const key = getApiKey();

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { cliVersion } from './version.js';
+
+// The old code did `require('../package.json')` from two levels down, which
+// only resolves in the bundled dist/ layout. From source it threw
+// MODULE_NOT_FOUND in update.ts (so importing the command tree died outright)
+// and was silently swallowed in analytics.ts (so every dev telemetry event
+// reported version "unknown").
+
+describe('cliVersion', () => {
+  it('resolves the real version from a source checkout', () => {
+    const pkgPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'package.json',
+    );
+    const expected = (JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version: string }).version;
+
+    assert.equal(cliVersion(), expected);
+  });
+
+  it('never returns the "unknown" fallback here', () => {
+    // The fallback exists for exotic layouts. Hitting it in this repo means
+    // the walk broke, which is exactly the silent failure analytics had.
+    assert.notEqual(cliVersion(), 'unknown');
+  });
+
+  it('looks like a semver', () => {
+    assert.match(cliVersion(), /^\d+\.\d+\.\d+/);
+  });
+
+  it('is stable across calls', () => {
+    assert.equal(cliVersion(), cliVersion());
+  });
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,46 @@
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+
+let cached: string | null = null;
+
+/**
+ * The CLI's own version, read from package.json.
+ *
+ * Walks upward to find it rather than hardcoding a relative depth. The depth
+ * differs between layouts: tsup bundles everything into `dist/index.js`, one
+ * level below the package root, while the sources it was built from sit two
+ * or three levels down (`src/lib/`, `src/commands/`). A fixed `'../package.json'`
+ * is therefore correct in `dist/` and wrong in `src/` — which made
+ * `src/commands/update.ts` throw MODULE_NOT_FOUND at import time, so anything
+ * importing the command tree from source (including a test) died before it ran.
+ * `src/lib/analytics.ts` had the same bug but swallowed it, silently reporting
+ * every telemetry event as version `unknown` in dev.
+ *
+ * Mirrors the directory walk `builtin-profiles.ts` already uses to locate
+ * `profiles/`.
+ */
+export function cliVersion(): string {
+  if (cached !== null) return cached;
+
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 1; i <= 4; i++) {
+    const candidate = path.resolve(dir, ...Array(i).fill('..'), 'package.json');
+    if (!existsSync(candidate)) continue;
+    try {
+      const version = (require(candidate) as { version?: string }).version;
+      if (version) {
+        cached = version;
+        return cached;
+      }
+    } catch {
+      // Unreadable or malformed — keep walking.
+    }
+  }
+
+  cached = 'unknown';
+  return cached;
+}


### PR DESCRIPTION
INT-4409 · found while triaging #186

## Problem

`one flow resume <runId>` was registered with **zero options** (`cli.ts:572`), and `flowResumeCommand` called `runner.resume(flow, api, permissions, actionIds, { onEvent, rootDir })` — no `allowBash` (`flow.ts:605`).

`FlowRunner.resume` already takes `FlowExecuteOptions`, which supports the field. It was simply never populated, and no flag existed to populate it from. So resuming any flow with a bash step threw:

```
Bash steps require --allow-bash flag for security
```

with no way to satisfy it. Resume is the recovery path for a paused or failed run, so **a bash flow that failed was permanently unrecoverable.**

Found while triaging #186 (Clockwork), where 76 of 110 flows use bash steps and run on a scheduler — exactly the case where a failed run needs resuming. (The four defects in #186 itself are all Clockwork's; nothing there needs a CLI change.)

## Changes

- Registers `--allow-bash` on `flow resume` and threads it through to `runner.resume`.
- Adds the same fail-fast pre-flight `flow execute` runs, so a caller gets `{error, requiresBash, flowKey, runId}` up front rather than a mid-run engine error partway through a partially-completed resume.

The permission is deliberately **not** inherited from the original run — resuming re-grants shell execution, so it should be re-stated. Documented in README and `flows.md`.

## Second fix — required to test the first

`src/commands/update.ts` resolved `require('../package.json')` from two levels down. That path only exists in the bundled `dist/` layout; from source it resolves to `src/package.json`, which doesn't exist. It threw `MODULE_NOT_FOUND` **at import time**, so importing the command tree — and therefore any test of the commander registration — died before running. This is why the command layer has almost no tests.

`src/lib/analytics.ts` had the identical bug but swallowed it in a `try/catch`, silently reporting every telemetry event from a source checkout as version `"unknown"`.

Both now use `lib/version.ts`, which walks upward for `package.json` the same way `builtin-profiles.ts` already locates `profiles/`. It's a genuine (small) scope addition, and I'd rather flag it than bury it — but the alternative was shipping the fix with no test of the thing that was broken.

Verified in **both** layouts, since that was the regression risk:
- the suite now imports the command tree from source
- `node bin/cli.js --version` on the rebuilt bundle still reports `1.55.1`
- `node bin/cli.js flow resume --help` lists `--allow-bash`

## Tests

8 new; **465 total, 0 skipped, all passing.**

The registration tests assert `attributeName()` maps to `allowBash` and matches how `flow execute` declares the same flag — registering a flag but reading a differently-named property would leave it `undefined`, the gate would still reject, and nothing would look wrong. That's the failure mode worth pinning, not merely "an option exists".